### PR TITLE
Add top-level `copy`/`cp` function

### DIFF
--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -10,7 +10,7 @@ except ImportError:  # python < 3.8
 from . import caching
 from ._version import get_versions
 from .callbacks import Callback
-from .core import get_fs_token_paths, open, open_files, open_local, copy, cp
+from .core import copy, cp, get_fs_token_paths, open, open_files, open_local
 from .exceptions import FSTimeoutError
 from .mapping import FSMap, get_mapper
 from .registry import (

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -10,7 +10,7 @@ except ImportError:  # python < 3.8
 from . import caching
 from ._version import get_versions
 from .callbacks import Callback
-from .core import get_fs_token_paths, open, open_files, open_local
+from .core import get_fs_token_paths, open, open_files, open_local, copy, cp
 from .exceptions import FSTimeoutError
 from .mapping import FSMap, get_mapper
 from .registry import (
@@ -37,6 +37,8 @@ __all__ = [
     "open",
     "open_files",
     "open_local",
+    "copy",
+    "cp",
     "registry",
     "caching",
     "Callback",

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -468,6 +468,35 @@ def open_local(url, mode="rb", **storage_options):
     return paths
 
 
+def cp(filea, fileb: OpenFile, callback=None, **open_kwargs):
+    """Copy ``filea`` to ``fileb``.
+
+    Parameters
+    ----------
+    filea: str
+        The path to a local or remote file.
+    fileb: OpenFile
+        The target to write to. Must be in write mode.
+    callback:
+
+    open_kwargs: dict
+        Additional arguments passed to ``fsspec.open``
+        when opening ``filea``.
+    """
+    with open(filea, **open_kwargs) as a:
+        with fileb as b:
+            while True:
+                data = a.read(a.fs.blocksize)
+                if not data:
+                    break
+                b.write(data)
+
+
+def copy():
+    """Alias for `cp`"""
+    pass
+
+
 def get_compression(urlpath, compression):
     if compression == "infer":
         compression = infer_compression(urlpath)

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -187,6 +187,21 @@ def test_chained_fs():
     assert os.listdir(d2) == ["f1"]
 
 
+def test_cp():
+    d = tempfile.mkdtemp()
+    f1 = os.path.join(d, "f1")
+    f2 = os.path.join(d, "f2")
+    with open(f1, "wb") as f:
+        f.write(b"test")
+
+    target = fsspec.open(f2, mode="wb")
+    fsspec.cp(f1, target)
+    target.close()
+
+    with fsspec.open(f2) as f:
+        assert f.read() == b"test"
+
+
 @pytest.mark.xfail(reason="see issue #334", strict=True)
 def test_multilevel_chained_fs():
     """This test reproduces intake/filesystem_spec#334"""


### PR DESCRIPTION
First draft for the feature proposed by @martindurant in https://github.com/pangeo-forge/pangeo-forge-recipes/pull/179#issuecomment-896039997. The included test passes, as do the CI tests for https://github.com/pangeo-forge/pangeo-forge-recipes/pull/179 (with fsspec installed from here).

Remaining TODO:

- [ ] Add callbacks

Martin, my understanding is that within `fsspec.cp`, this should look like:
```python
while True:
    data = a.read(a.fs.blocksize, callback=callback)
```
Except that [`AbstractBufferedFile.read`](https://github.com/intake/filesystem_spec/blob/3cdfd6cf8386857815535a32f747cd2033b30da7/fsspec/spec.py#L1463) does not implement callbacks. (And neither does and [`HTTPFile.read`](https://github.com/intake/filesystem_spec/blob/3cdfd6cf8386857815535a32f747cd2033b30da7/fsspec/implementations/http.py#L477), as one backend example.) Do I understand correctly that this is because callbacks are new and sporadically implemented, and therefore the next step is to add callbacks to `AbstractBufferedFile.read` following this example:


https://github.com/intake/filesystem_spec/blob/5c58feb616a1e39c234fe85394d990ae36737203/fsspec/spec.py#L730-L743

?

- [ ] Special-casing for FTP servers that don't allow random access reads

This is a second step after completing the callbacks implementation, but my impression is it should be something like:

```python
# fsspec.cp
while True:
    data = a.read(a.fs.blocksize, callback=callback)
    if not data:
        break
    if not isinstance(a.fs, FTPFileSystem):
        b.write(data)
```

...and above that, we'll need to make sure `b.write(data)` is included in the callback if `a.fs` is an FTPFileSystem.

Two questions about this:
1. Do we want to force writing within the callback for __*all*__ FTPFileSystems? Or just the subset that don't allow random access?
2. For those that do require writing within the callback, might a good way to implement that be to pass the callback to a new `FTPFileSystem._fetch_all` method (following the naming pattern of `HTTPFileSystem._fetch_all`), which does something like:
```python
def _fetch_all(self, rpath, callback):    
    with self.ftp.transfercmd("RETR %s" % rpath) as conn:
        data = conn.recv(self.blocksize)
        callback.relative_update(data)  # assumes that a write function is one of the callback hooks
```
?