### PR TITLE
Fix range-index bug in open_parquet_file

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -471,10 +471,10 @@ class KnownPartsOfAFile(BaseCache):
             self.data = data
 
     def _fetch(self, start, stop):
+        out = b""
         for (loc0, loc1), data in self.data.items():
             # If self.strict=False, use zero-padded data
             # for reads beyond the end of a "known" buffer
-            out = b""
             if loc0 <= start < loc1:
                 off = start - loc0
                 out = data[off : off + stop - start]

--- a/fsspec/parquet.py
+++ b/fsspec/parquet.py
@@ -513,11 +513,15 @@ class PyarrowEngine:
                 schema.metadata is not None and b"pandas" in schema.metadata
             )
             if has_pandas_metadata:
-                column_set |= set(
-                    json.loads(schema.metadata[b"pandas"].decode("utf8")).get(
-                        "index_columns", []
-                    )
-                )
+                md_index = [
+                    ind
+                    for ind in json.loads(
+                        schema.metadata[b"pandas"].decode("utf8")
+                    ).get("index_columns", [])
+                    # Ignore RangeIndex information
+                    if not isinstance(ind, dict)
+                ]
+                column_set |= set(md_index)
 
         # Loop through column chunks to add required byte ranges
         for r in range(md.num_row_groups):

--- a/fsspec/tests/test_parquet.py
+++ b/fsspec/tests/test_parquet.py
@@ -38,8 +38,9 @@ def engine(request):
 @pytest.mark.parametrize("max_gap", [0, 64])
 @pytest.mark.parametrize("max_block", [64, 256_000_000])
 @pytest.mark.parametrize("footer_sample_size", [64, 1_000])
+@pytest.mark.parametrize("range_index", [True, False])
 def test_open_parquet_file(
-    tmpdir, engine, columns, max_gap, max_block, footer_sample_size
+    tmpdir, engine, columns, max_gap, max_block, footer_sample_size, range_index
 ):
 
     # Pandas required for this test
@@ -56,6 +57,9 @@ def test_open_parquet_file(
         },
         index=pd.Index([10 * i for i in range(nrows)], name="myindex"),
     )
+    if range_index:
+        df = df.reset_index(drop=True)
+        df.index.name = "myindex"
     df.to_parquet(path)
 
     # "Traditional read" (without `open_parquet_file`)


### PR DESCRIPTION
Simple bug fix in `fsspec.parquet.read_parquet_file` for parquet files with range-index information in the pandas metadata. Note that the bug is only for the "pyarrow" engine.