### PR TITLE
Remove BlockSizeError

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -238,10 +238,13 @@ async def _run_coros_in_chunks(
             asyncio.Task(asyncio.wait_for(c, timeout=timeout))
             for c in coros[start : start + batch_size]
         ]
-        [
-            t.add_done_callback(lambda: callback.call("relative_update", 1))
-            for t in chunk
-        ]
+        if callback is not _DEFAULT_CALLBACK:
+            [
+                t.add_done_callback(
+                    lambda *_, **__: callback.call("relative_update", 1)
+                )
+                for t in chunk
+            ]
         results.extend(
             await asyncio.gather(*chunk, return_exceptions=return_exceptions),
         )


### PR DESCRIPTION
So that we can still stream from the start of a file without error
(will cancel transfer once enough bytes are received). Does *not*
allow random access from not the start of the download.

Fixes https://github.com/dask/dask/issues/8402