### PR TITLE
Change the type of listings_expiry_time in the document.

### DIFF
--- a/fsspec/dircache.py
+++ b/fsspec/dircache.py
@@ -38,7 +38,7 @@ class DirCache(MutableMapping):
         use_listings_cache: bool
             If False, this cache never returns items, but always reports KeyError,
             and setting items has no effect
-        listings_expiry_time: int (optional)
+        listings_expiry_time: int or float (optional)
             Time in seconds that a listing is considered valid. If None,
             listings do not expire.
         max_paths: int (optional)


### PR DESCRIPTION
Already use float value
https://github.com/fsspec/filesystem_spec/blob/6233f315548b512ec379323f762b70764efeb92c/fsspec/implementations/tests/test_http.py#L198
From implementation, seems works with float value
https://github.com/fsspec/filesystem_spec/blob/6233f315548b512ec379323f762b70764efeb92c/fsspec/dircache.py#L58