### PR TITLE
Add mypy to the test suite

### DIFF
--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -2,9 +2,9 @@ try:
     from importlib.metadata import entry_points
 except ImportError:  # python < 3.8
     try:
-        from importlib_metadata import entry_points
+        from importlib_metadata import entry_points  # type: ignore
     except ImportError:
-        entry_points = None
+        entry_points = None  # type: ignore
 
 
 from . import _version, caching

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -161,7 +161,7 @@ def fsspec_loop():
 try:
     import resource
 except ImportError:
-    resource = None
+    resource = None  # type: ignore
     ResourceError = OSError
 else:
     ResourceEror = resource.error

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -1,8 +1,9 @@
 import configparser
 import json
 import os
+from typing import Dict
 
-conf = {}
+conf: Dict[str, Dict] = {}
 default_conf_dir = os.path.join(os.path.expanduser("~"), ".config/fsspec")
 conf_dir = os.environ.get("FSSPEC_CONFIG_DIR", default_conf_dir)
 

--- a/fsspec/gui.py
+++ b/fsspec/gui.py
@@ -3,6 +3,7 @@ import contextlib
 import logging
 import os
 import re
+from typing import ClassVar, List
 
 import panel as pn
 
@@ -25,9 +26,9 @@ class SigSlot(object):
     By default, all signals emit a DEBUG logging statement.
     """
 
-    signals = []  # names of signals that this class may emit
+    signals: ClassVar[List[str]] = []  # names of signals that this class may emit
     # each of which must be set by _register for any new instance
-    slots = []  # names of actions that this class may respond to
+    slots: ClassVar[List[str]] = []  # names of actions that this class may respond to
 
     # each of which must be a method name
 

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -6,6 +6,7 @@ import pickle
 import tempfile
 import time
 from shutil import move, rmtree
+from typing import Tuple, Union
 
 from fsspec import AbstractFileSystem, filesystem
 from fsspec.callbacks import _DEFAULT_CALLBACK
@@ -36,7 +37,7 @@ class CachingFileSystem(AbstractFileSystem):
       allowed, for testing
     """
 
-    protocol = ("blockcache", "cached")
+    protocol: Union[str, Tuple[str, str]] = ("blockcache", "cached")
 
     def __init__(
         self,

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 from errno import ENOTEMPTY
 from io import BytesIO
+from typing import ClassVar, Dict
 
 from fsspec import AbstractFileSystem
 
@@ -17,7 +18,7 @@ class MemoryFileSystem(AbstractFileSystem):
     in memory filesystem.
     """
 
-    store = {}  # global
+    store: Dict[str, bytes] = {}  # global
     pseudo_dirs = [""]
     protocol = "memory"
     root_marker = "/"

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -18,7 +18,7 @@ class MemoryFileSystem(AbstractFileSystem):
     in memory filesystem.
     """
 
-    store: Dict[str, bytes] = {}  # global
+    store: ClassVar[Dict[str, bytes]] = {}  # global
     pseudo_dirs = [""]
     protocol = "memory"
     root_marker = "/"

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -6,16 +6,17 @@ from functools import lru_cache
 
 import fsspec.core
 
-try:
-    import ujson as json
-except ImportError:
-    import json
-
 from ..asyn import AsyncFileSystem, sync
 from ..callbacks import _DEFAULT_CALLBACK
 from ..core import filesystem, open
 from ..mapping import get_mapper
 from ..spec import AbstractFileSystem
+
+try:
+    import ujson as json
+except ImportError:
+    import json  # type: ignore
+
 
 logger = logging.getLogger("fsspec.reference")
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -8,6 +8,7 @@ from distutils.version import LooseVersion
 from errno import ESPIPE
 from glob import has_magic
 from hashlib import sha256
+from typing import Sequence, Tuple, Union
 
 from .callbacks import _DEFAULT_CALLBACK
 from .config import apply_config, conf
@@ -101,7 +102,7 @@ else:  # pragma: no cover
     up = object
 
 
-class AbstractFileSystem(up, metaclass=_Cached):
+class AbstractFileSystem(up, metaclass=_Cached):  # type: ignore
     """
     An abstract super-class for pythonic file-systems
 
@@ -113,7 +114,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
     _cached = False
     blocksize = 2 ** 22
     sep = "/"
-    protocol = "abstract"
+    protocol: Union[str, Tuple[str, str]] = "abstract"
     async_impl = False
     root_marker = ""  # For some FSs, may require leading '/' or other character
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -8,7 +8,7 @@ from distutils.version import LooseVersion
 from errno import ESPIPE
 from glob import has_magic
 from hashlib import sha256
-from typing import Sequence, Tuple, Union
+from typing import Tuple, Union
 
 from .callbacks import _DEFAULT_CALLBACK
 from .config import apply_config, conf

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -7,6 +7,7 @@ import sys
 from contextlib import contextmanager
 from functools import partial
 from hashlib import md5
+from typing import Any, Dict
 from urllib.parse import urlsplit
 
 DEFAULT_BLOCK_SIZE = 5 * 2 ** 20
@@ -110,7 +111,7 @@ def update_storage_options(options, inherited=None):
 
 
 # Compression extensions registered via fsspec.compression.register_compression
-compressions = {}
+compressions: Dict[str, Any] = {}
 
 
 def infer_compression(filename):

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,19 @@ skip=
     docs/source/conf.py
     versioneer.py
     fsspec/_version
+
+[mypy]
+# TODO: turn on when enough things are checked
+check_untyped_defs = False
+ignore_missing_imports = True
+show_error_codes = True
+warn_unused_configs = True
+warn_unused_ignores = True
+
+# Ignore errors from tests and from versioneer
+[mypy-fsspec.tests.*]
+ignore_errors = True
+[mypy-fsspec.implementations.tests.*]
+ignore_errors = True
+[mypy-fsspec._version]
+ignore_errors = True

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ conda_deps=
     pytest-benchmark
     pytest-cov
     pytest-vcr
+    mypy
     fusepy
     msgpack-python
     python-libarchive-c
@@ -49,6 +50,9 @@ deps=
     {[core]deps}
 commands =
     pytest --cov=fsspec -v -r s {posargs}
+    mypy --install-types
+    mypy fsspec
+
 passenv = CIRUN
 
 [testenv:s3fs]

--- a/tox.ini
+++ b/tox.ini
@@ -49,9 +49,8 @@ conda_deps=
 deps=
     {[core]deps}
 commands =
+    mypy --install-types --non-interactive fsspec
     pytest --cov=fsspec -v -r s {posargs}
-    mypy --install-types
-    mypy fsspec
 
 passenv = CIRUN
 


### PR DESCRIPTION
This is the first step towards https://github.com/fsspec/filesystem_spec/issues/834, where we add `mypy` to the tox config. For now, we do the minimal thing and only add some typehints to a couple global variables. I intend to send some follow-up PRs gradually adding typehints (and hopefully setting `check_untyped_def=True` at some point).