### PR TITLE
BF: do not hardcode /tmp -- use tempfile.gettempdir()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ ENV/
 
 # docker artifacts
 .docker
+
+build/

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 from ftplib import FTP, Error, error_perm
 from typing import Any
@@ -266,7 +265,7 @@ class FTPFile(AbstractBufferedFile):
         )
         if not autocommit:
             self.target = self.path
-            self.path = os.path.join(kwargs["tempdir"], str(uuid.uuid4()))
+            self.path = "/".join([kwargs["tempdir"], str(uuid.uuid4())])
 
     def commit(self):
         self.fs.mv(self.path, self.target)

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -1,3 +1,4 @@
+import tempfile
 import uuid
 from ftplib import FTP, Error, error_perm
 from typing import Any
@@ -21,7 +22,7 @@ class FTPFileSystem(AbstractFileSystem):
         password=None,
         acct=None,
         block_size=None,
-        tempdir="/tmp",
+        tempdir=tempfile.gettempdir(),
         timeout=30,
         **kwargs,
     ):

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 import uuid
 from ftplib import FTP, Error, error_perm
 from typing import Any
@@ -23,7 +22,7 @@ class FTPFileSystem(AbstractFileSystem):
         password=None,
         acct=None,
         block_size=None,
-        tempdir=str(tempfile.gettempdir()),
+        tempdir=None,
         timeout=30,
         **kwargs,
     ):
@@ -56,7 +55,7 @@ class FTPFileSystem(AbstractFileSystem):
         super(FTPFileSystem, self).__init__(**kwargs)
         self.host = host
         self.port = port
-        self.tempdir = tempdir
+        self.tempdir = tempdir or "/tmp"
         self.cred = username, password, acct
         self.timeout = timeout
         if block_size is not None:

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import uuid
 from ftplib import FTP, Error, error_perm
@@ -266,7 +267,7 @@ class FTPFile(AbstractBufferedFile):
         )
         if not autocommit:
             self.target = self.path
-            self.path = "/".join([kwargs["tempdir"], str(uuid.uuid4())])
+            self.path = os.path.join(kwargs["tempdir"], str(uuid.uuid4()))
 
     def commit(self):
         self.fs.mv(self.path, self.target)

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -23,7 +23,7 @@ class FTPFileSystem(AbstractFileSystem):
         password=None,
         acct=None,
         block_size=None,
-        tempdir=tempfile.gettempdir(),
+        tempdir=str(tempfile.gettempdir()),
         timeout=30,
         **kwargs,
     ):

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -43,7 +43,7 @@ class SFTPFileSystem(AbstractFileSystem):
         if self._cached:
             return
         super(SFTPFileSystem, self).__init__(**ssh_kwargs)
-        self.temppath = ssh_kwargs.pop("temppath", tempfile.gettempdir())
+        self.temppath = ssh_kwargs.pop("temppath", str(tempfile.gettempdir()))
         self.host = host
         self.ssh_kwargs = ssh_kwargs
         self._connect()

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import tempfile
 import types
 import uuid
@@ -137,7 +138,7 @@ class SFTPFileSystem(AbstractFileSystem):
         logger.debug("Opening file %s" % path)
         if kwargs.get("autocommit", True) is False:
             # writes to temporary file, move on commit
-            path2 = "{}/{}".format(self.temppath, uuid.uuid4())
+            path2 = os.path.join(self.temppath, uuid.uuid4())
             f = self.ftp.open(path2, mode, bufsize=block_size if block_size else -1)
             f.temppath = path2
             f.targetpath = path

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -1,7 +1,5 @@
 import datetime
 import logging
-import os
-import tempfile
 import types
 import uuid
 from stat import S_ISDIR, S_ISLNK
@@ -43,7 +41,7 @@ class SFTPFileSystem(AbstractFileSystem):
         if self._cached:
             return
         super(SFTPFileSystem, self).__init__(**ssh_kwargs)
-        self.temppath = ssh_kwargs.pop("temppath", str(tempfile.gettempdir()))
+        self.temppath = ssh_kwargs.pop("temppath", "/tmp")  # remote temp directory
         self.host = host
         self.ssh_kwargs = ssh_kwargs
         self._connect()
@@ -138,7 +136,7 @@ class SFTPFileSystem(AbstractFileSystem):
         logger.debug("Opening file %s" % path)
         if kwargs.get("autocommit", True) is False:
             # writes to temporary file, move on commit
-            path2 = os.path.join(self.temppath, uuid.uuid4())
+            path2 = "/".join([self.temppath, str(uuid.uuid4())])
             f = self.ftp.open(path2, mode, bufsize=block_size if block_size else -1)
             f.temppath = path2
             f.targetpath = path

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import tempfile
 import types
 import uuid
 from stat import S_ISDIR, S_ISLNK
@@ -41,7 +42,7 @@ class SFTPFileSystem(AbstractFileSystem):
         if self._cached:
             return
         super(SFTPFileSystem, self).__init__(**ssh_kwargs)
-        self.temppath = ssh_kwargs.pop("temppath", "/tmp")
+        self.temppath = ssh_kwargs.pop("temppath", tempfile.gettempdir())
         self.host = host
         self.ssh_kwargs = ssh_kwargs
         self._connect()

--- a/fsspec/implementations/tests/test_ftp.py
+++ b/fsspec/implementations/tests/test_ftp.py
@@ -103,9 +103,9 @@ def test_write_big(ftp_writable, cache_type):
     assert fs.cat(fn) == b"o" * 1700
 
 
-def test_transaction(ftp_writable):
+def test_transaction(ftp_writable, tmpdir):
     host, port, user, pw = ftp_writable
-    fs = FTPFileSystem(host, port, user, pw)
+    fs = FTPFileSystem(host, port, user, pw, tempdir=str(tmpdir))
     fs.mkdir("/tmp")
     fn = "/tr"
     with fs.transaction:
@@ -119,9 +119,9 @@ def test_transaction(ftp_writable):
     assert not fs.exists(fn)
 
 
-def test_transaction_with_cache(ftp_writable):
+def test_transaction_with_cache(ftp_writable, tmpdir):
     host, port, user, pw = ftp_writable
-    fs = FTPFileSystem(host, port, user, pw)
+    fs = FTPFileSystem(host, port, user, pw, tempdir=str(tmpdir))
     fs.mkdir("/tmp")
     fs.mkdir("/tmp/dir")
     assert "dir" in fs.ls("/tmp", detail=False)

--- a/fsspec/implementations/tests/test_ftp.py
+++ b/fsspec/implementations/tests/test_ftp.py
@@ -103,9 +103,9 @@ def test_write_big(ftp_writable, cache_type):
     assert fs.cat(fn) == b"o" * 1700
 
 
-def test_transaction(ftp_writable, tmpdir):
+def test_transaction(ftp_writable):
     host, port, user, pw = ftp_writable
-    fs = FTPFileSystem(host, port, user, pw, tempdir=str(tmpdir))
+    fs = FTPFileSystem(host, port, user, pw)
     fs.mkdir("/tmp")
     fn = "/tr"
     with fs.transaction:
@@ -121,7 +121,7 @@ def test_transaction(ftp_writable, tmpdir):
 
 def test_transaction_with_cache(ftp_writable, tmpdir):
     host, port, user, pw = ftp_writable
-    fs = FTPFileSystem(host, port, user, pw, tempdir=str(tmpdir))
+    fs = FTPFileSystem(host, port, user, pw)
     fs.mkdir("/tmp")
     fs.mkdir("/tmp/dir")
     assert "dir" in fs.ls("/tmp", detail=False)

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -3,6 +3,7 @@
 import logging
 import secrets
 import shutil
+import os
 import tempfile
 import uuid
 from contextlib import suppress
@@ -378,7 +379,7 @@ class WebHDFile(AbstractBufferedFile):
         tempdir = kwargs.pop("tempdir")
         if kwargs.pop("autocommit", False) is False:
             self.target = self.path
-            self.path = "/".join([tempdir, str(uuid.uuid4())])
+            self.path = os.path.join(tempdir, str(uuid.uuid4()))
 
     def _upload_chunk(self, final=False):
         """Write one part of a multi-block file upload

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -3,6 +3,7 @@
 import logging
 import secrets
 import shutil
+import tempfile
 import uuid
 from contextlib import suppress
 from urllib.parse import quote
@@ -35,7 +36,7 @@ class WebHDFS(AbstractFileSystem):
 
     """
 
-    tempdir = "/tmp"
+    tempdir = tempfile.gettempdir()
     protocol = "webhdfs", "webHDFS"
 
     def __init__(

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -1,9 +1,9 @@
 # https://hadoop.apache.org/docs/r1.0.4/webhdfs.html
 
 import logging
+import os
 import secrets
 import shutil
-import os
 import tempfile
 import uuid
 from contextlib import suppress
@@ -37,7 +37,7 @@ class WebHDFS(AbstractFileSystem):
 
     """
 
-    tempdir = tempfile.gettempdir()
+    tempdir = str(tempfile.gettempdir())
     protocol = "webhdfs", "webHDFS"
 
     def __init__(

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ conda_deps=
 deps=
     {[core]deps}
 commands =
-    pytest --cov=fsspec -v -r s {posargs}
+    pytest -v -r s {posargs}
 passenv = CIRUN
 
 [testenv:s3fs]

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ conda_deps=
     pytest-cov
     pytest-vcr
     fusepy
+    tomli < 2
     msgpack-python
     python-libarchive-c
     numpy
@@ -48,7 +49,7 @@ conda_deps=
 deps=
     {[core]deps}
 commands =
-    pytest -v -r s {posargs}
+    pytest --cov=fsspec -v -r s {posargs}
 passenv = CIRUN
 
 [testenv:s3fs]


### PR DESCRIPTION
In this version it is incomplete since other locations needing change exist, e.g.:

	fsspec/implementations/ftp.py:        tempdir="/tmp",
	fsspec/implementations/sftp.py:        self.temppath = ssh_kwargs.pop("temppath", "/tmp")

so it would be nice to centralize.  Where should such "constant" be defined?