### PR TITLE
Update smb.py

### DIFF
--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -119,7 +119,7 @@ class SMBFileSystem(AbstractFileSystem):
             self.host,
             username=self.username,
             password=self.password,
-            port=self.port,
+            port=445 if self.port is None else self.port,
             encrypt=self.encrypt,
             connection_timeout=self.timeout,
         )


### PR DESCRIPTION
Default port to smbclient is 445 not None. Example will now work without explicitly specifying port as int.