### PR TITLE
Fix a bug in `CachingFileSystem.pop_from_cache()`

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -235,9 +235,10 @@ class CachingFileSystem(AbstractFileSystem):
         raises PermissionError
         """
         path = self._strip_protocol(path)
-        _, fn = self._check_file(path)
-        if fn is None:
+        details = self._check_file(path)
+        if not details:
             return
+        _, fn = details
         if fn.startswith(self.storage[-1]):
             # is in in writable cache
             os.remove(fn)

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -180,6 +180,7 @@ def test_pop():
     with pytest.raises(PermissionError):
         fs.pop_from_cache(f1)
     fs.pop_from_cache(f2)
+    fs.pop_from_cache(os.path.join(origin, "uncached-file"))
     assert len(os.listdir(cache2)) == 1
     assert not fs._check_file(f2)
     assert fs._check_file(f1)


### PR DESCRIPTION
`pop_from_cache()` would crash if asked to pop a path that wasn't in the cache.  This PR fixes that.