### PR TITLE
Define a BlocksizeMismatchError exception class

### DIFF
--- a/fsspec/exceptions.py
+++ b/fsspec/exceptions.py
@@ -4,6 +4,15 @@ fsspec user-defined exception classes
 import asyncio
 
 
+class BlocksizeMismatchError(ValueError):
+    """
+    Raised when a cached file is opened with a different blocksize than it was
+    written with
+    """
+
+    ...
+
+
 class FSTimeoutError(asyncio.TimeoutError):
     """
     Raised when a fsspec function timed out occurs

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -11,6 +11,7 @@ from fsspec import AbstractFileSystem, filesystem
 from fsspec.callbacks import _DEFAULT_CALLBACK
 from fsspec.compression import compr
 from fsspec.core import BaseCache, MMapCache
+from fsspec.exceptions import BlocksizeMismatchError
 from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import infer_compression
 
@@ -327,7 +328,7 @@ class CachingFileSystem(AbstractFileSystem):
             f = compr[comp](f, mode="rb")
         if "blocksize" in detail:
             if detail["blocksize"] != f.blocksize:
-                raise ValueError(
+                raise BlocksizeMismatchError(
                     "Cached file must be reopened with same block"
                     "size as original (old: %i, new %i)"
                     "" % (detail["blocksize"], f.blocksize)

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -7,6 +7,7 @@ import pytest
 
 import fsspec
 from fsspec.compression import compr
+from fsspec.exceptions import BlocksizeMismatchError
 from fsspec.implementations.cached import CachingFileSystem
 
 from .test_ftp import FTPFileSystem
@@ -213,7 +214,7 @@ def test_blocksize(ftp_writable):
 
     with fs.open("/out_block", block_size=20) as f:
         assert f.read(1) == b"t"
-    with pytest.raises(ValueError):
+    with pytest.raises(BlocksizeMismatchError):
         fs.open("/out_block", block_size=30)
 
 


### PR DESCRIPTION
For our purposes, we are interested in catching exceptions caused by trying to open a cached file with a different block size than it was written with.  Currently, the only way to identify such exceptions is by inspecting the error message, which is not the wisest choice.  This PR thus replaces the `ValueError` raised on block size mismatches with a custom `BlocksizeMismatchError` (a subclass of `ValueError`) to ease identification.