### PR TITLE
async: add set_session

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -307,6 +307,14 @@ class AsyncFileSystem(AbstractFileSystem):
             raise RuntimeError("This class is not fork-safe")
         return self._loop
 
+    async def set_session(self, *args, **kwargs):
+        """Establish a connection.
+        Returns
+        -------
+        Session to be closed later with await .close()
+        """
+        raise NotImplementedError
+
     async def _rm_file(self, path, **kwargs):
         raise NotImplementedError
 


### PR DESCRIPTION
This is used in multiple implementations (s3fs, http, etc) that allow
_external_ async use and is documented in fsspec docs (but the example
is http-specific), so let's add it to the spec, so that we could officially
wrap it in #745