### PR TITLE
Change put_file loop condition to f1.tell

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -809,7 +809,7 @@ class AbstractFileSystem(up, metaclass=_Cached):
 
             self.mkdirs(self._parent(os.fspath(rpath)), exist_ok=True)
             with self.open(rpath, "wb", **kwargs) as f2:
-                while f2.tell() < size:
+                while f1.tell() < size:
                     data = f1.read(self.blocksize)
                     segment_len = f2.write(data)
                     callback.relative_update(segment_len)


### PR DESCRIPTION
Handles a possible rare edge case where `f2.write` could silently fail to upload and cause the loop to never end (since `f1.read` thinks it's done and won't return any more data to write).