### PR TITLE
pyarrow.hdfs.HadoopFileSystem deprecated

### DIFF
--- a/fsspec/implementations/hdfs.py
+++ b/fsspec/implementations/hdfs.py
@@ -46,7 +46,7 @@ from fsspec.utils import infer_storage_options, mirror_from
 class PyArrowHDFS(AbstractFileSystem):
     """Adapted version of Arrow's HadoopFileSystem
 
-    This is a very simple wrapper over the pyarrow.hdfs.HadoopFileSystem, which
+    This is a very simple wrapper over the pyarrow.fs.HadoopFileSystem, which
     passes on all calls to the underlying class."""
 
     protocol = "hdfs", "file"


### PR DESCRIPTION
Starting with pyarrow 2.0.0, `pyarrow.hdfs.HadoopFileSystem` has been replaced by `pyarrow.fs.HadoopFileSystem`.

Start with fixing the documentation.

Partially addresses #874.

