### PR TITLE
Change sftp rename from posix_rename() to rename()

### DIFF
--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -155,7 +155,7 @@ class SFTPFileSystem(AbstractFileSystem):
 
     def mv(self, old, new):
         logger.debug("Renaming %s into %s" % (old, new))
-        self.ftp.posix_rename(old, new)
+        self.ftp.rename(old, new)
 
 
 def commit_a_file(self):


### PR DESCRIPTION
See discussion on https://stackoverflow.com/questions/70658956/paramiko-sftp-file-renaming-oserrorextended-request-not-supported/70668235. The posix_rename() appears to limit the usage of the SFTPFileSystem.rename() method to sFTP servers that run on Posix-like servers.