### PR TITLE
drop python 3.6

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TOXENV: [py36, py37, py38, py39, s3fs, gcsfs]
+        TOXENV: [py37, py38, py39, s3fs, gcsfs]
 
     env:
       TOXENV: ${{ matrix.TOXENV }}

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -12,7 +12,7 @@ from glob import has_magic
 from .callbacks import _DEFAULT_CALLBACK
 from .exceptions import FSTimeoutError
 from .spec import AbstractFileSystem
-from .utils import PY36, is_exception, other_paths
+from .utils import is_exception, other_paths
 
 private = re.compile("_[^_]")
 
@@ -29,12 +29,6 @@ async def _runner(event, coro, result, timeout=None):
         event.set()
 
 
-if PY36:
-    grl = asyncio.events._get_running_loop
-else:
-    grl = asyncio.events.get_running_loop
-
-
 def sync(loop, func, *args, timeout=None, **kwargs):
     """
     Make loop run coroutine until it returns. Runs in other thread
@@ -45,7 +39,7 @@ def sync(loop, func, *args, timeout=None, **kwargs):
     if loop is None or loop.is_closed():
         raise RuntimeError("Loop is not running")
     try:
-        loop0 = grl()
+        loop0 = asyncio.events.get_running_loop()
         if loop0 is loop:
             raise NotImplementedError("Calling sync() from within a running loop")
     except RuntimeError:
@@ -789,9 +783,6 @@ def _dump_running_tasks(
     printout=True, cancel=True, exc=FSSpecCoroutineCancel, with_task=False
 ):
     import traceback
-
-    if PY36:
-        raise NotImplementedError("Do not call this on Py 3.6")
 
     tasks = [t for t in asyncio.tasks.all_tasks(loop[0]) if not t.done()]
     if printout:

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -516,7 +516,6 @@ def test_async_other_thread(server):
     loop.call_soon_threadsafe(loop.stop)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in py36")
 def test_async_this_thread(server):
     async def _():
         fs = fsspec.filesystem("http", asynchronous=True)
@@ -565,7 +564,6 @@ def test_processes(server, method):
 
 
 @pytest.mark.parametrize("get_client", [get_aiohttp, get_proxy])
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
 def test_close(get_client):
     fs = fsspec.filesystem("http", skip_instance_cache=True)
     fs.close_session(None, asyncio.run(get_client()))

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -182,9 +182,6 @@ def test_open_files_text_mode(encoding):
 @pytest.mark.parametrize("mode", ["rt", "rb"])
 @pytest.mark.parametrize("fmt", list(compression.compr))
 def test_compressions(fmt, mode, tmpdir):
-    if fmt == "zip" and sys.version_info < (3, 6):
-        pytest.xfail("zip compression requires python3.6 or higher")
-
     tmpdir = str(tmpdir)
     fn = os.path.join(tmpdir, ".tmp.getsize")
     fs = LocalFileSystem()

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -3,7 +3,6 @@
 import contextlib
 import os
 import pickle
-import sys
 import tempfile
 
 import pytest
@@ -213,7 +212,6 @@ def test_multilevel_chained_fs():
             assert f.read().decode("utf-8") == f.name
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no seek in old zipfile")
 def test_multilevel_chained_fs_zip_zip_file():
     """This test reproduces fsspec/filesystem_spec#334"""
     import zipfile

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import os
-import sys
 import time
 
 import pytest
@@ -18,7 +17,6 @@ def test_sync_methods():
     assert not inspect.iscoroutinefunction(inst.info)
 
 
-@pytest.mark.skipif(fsspec.asyn.PY36, reason="missing asyncio features o py36")
 def test_interrupt():
     loop = fsspec.asyn.get_loop()
 
@@ -46,32 +44,27 @@ class _DummyAsyncKlass:
     dummy_func = fsspec.asyn.sync_wrapper(_dummy_async_func)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
 def test_sync_wrapper_timeout_on_less_than_expected_wait_time_not_finish_function():
     test_obj = _DummyAsyncKlass()
     with pytest.raises(fsspec.FSTimeoutError):
         test_obj.dummy_func(timeout=0.1)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
 def test_sync_wrapper_timeout_on_more_than_expected_wait_time_will_finish_function():
     test_obj = _DummyAsyncKlass()
     assert test_obj.dummy_func(timeout=5)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
 def test_sync_wrapper_timeout_none_will_wait_func_finished():
     test_obj = _DummyAsyncKlass()
     assert test_obj.dummy_func(timeout=None)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
 def test_sync_wrapper_treat_timeout_0_as_none():
     test_obj = _DummyAsyncKlass()
     assert test_obj.dummy_func(timeout=0)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="no asyncio.run in <3.7")
 def test_run_coros_in_chunks(monkeypatch):
     total_running = 0
 

--- a/fsspec/tests/test_file.py
+++ b/fsspec/tests/test_file.py
@@ -1,6 +1,5 @@
 """Tests abstract buffered file API, using FTP implementation"""
 import pickle
-import sys
 
 import pytest
 
@@ -9,10 +8,6 @@ from fsspec.implementations.tests.test_ftp import FTPFileSystem
 data = b"hello" * 10000
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 6),
-    reason="py35 error, see https://github.com/fsspec/filesystem_spec/issues/147",
-)
 def test_pickle(ftp_writable):
     host, port, user, pw = ftp_writable
     ftp = FTPFileSystem(host=host, port=port, username=user, password=pw)

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -10,7 +10,6 @@ from hashlib import md5
 from urllib.parse import urlsplit
 
 DEFAULT_BLOCK_SIZE = 5 * 2 ** 20
-PY36 = sys.version_info < (3, 7)
 
 
 def infer_storage_options(urlpath, inherit_storage_options=None):
@@ -301,8 +300,8 @@ def stringify_path(filepath):
 
     Notes
     -----
-    Objects supporting the fspath protocol (Python 3.6+) are coerced
-    according to its __fspath__ method.
+    Objects supporting the fspath protocol are coerced according to its
+    __fspath__ method.
 
     For backwards compatibility with older Python version, pathlib.Path
     objects are specially coerced.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -32,7 +31,7 @@ setup(
     license="BSD",
     keywords="file",
     packages=["fsspec", "fsspec.implementations"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=open("requirements.txt").read().strip().split("\n"),
     extras_require={
         "entrypoints": ["importlib_metadata ; python_version < '3.8' "],


### PR DESCRIPTION
3.6 has reached the EOL.

fsspec (along with pydata) dropped support for it early 2021, but we brought
it back for dvc in #575.