### PR TITLE
Seek by offset before write for fuse

### DIFF
--- a/fsspec/fuse.py
+++ b/fsspec/fuse.py
@@ -82,6 +82,7 @@ class FUSEr(Operations):
     def write(self, path, data, offset, fh):
         logger.debug("write %s", (path, offset))
         f = self.cache[fh]
+        f.seek(offset)
         f.write(data)
         return len(data)
 

--- a/fsspec/tests/test_fuse.py
+++ b/fsspec/tests/test_fuse.py
@@ -125,6 +125,7 @@ def test_chmod(mount_local):
     assert set(os.listdir(source_dir)) == set(["text", "new"])
     assert open(mount_dir / "new").read() == "test"
 
+
 def test_seek_rw(mount_local):
     source_dir, mount_dir = mount_local
     fh = open(mount_dir / "text", "w")

--- a/fsspec/tests/test_fuse.py
+++ b/fsspec/tests/test_fuse.py
@@ -124,3 +124,17 @@ def test_chmod(mount_local):
     assert cp.stdout == b""
     assert set(os.listdir(source_dir)) == set(["text", "new"])
     assert open(mount_dir / "new").read() == "test"
+
+def test_seek_rw(mount_local):
+    source_dir, mount_dir = mount_local
+    fh = open(mount_dir / "text", "w")
+    fh.write("teST")
+    fh.seek(2)
+    fh.write("st")
+    fh.close()
+
+    fh = open(mount_dir / "text", "r")
+    assert fh.read() == "test"
+    fh.seek(2)
+    assert fh.read() == "st"
+    fh.close()


### PR DESCRIPTION
Writes after seeks on the fuse mounted filesystem fail, this fixes it and things like `pd.HDFStore` operability on these mounted filesystems.