### PR TITLE
remove py36 env from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = {py36,py37,py38,py39}
+envlist = {py37,py38,py39}
 
 [core]
 conda_channels=
@@ -40,7 +40,7 @@ conda_deps=
 deps=
     hadoop-test-cluster==0.1.0
     smbprotocol
-    py36,py37: importlib_metadata
+    py37: importlib_metadata
 
 [testenv]
 description=Run test suite against target versions.


### PR DESCRIPTION
The minimum supported python version of fsspec is now 3.7.
This PR removes the py36 env from tox.ini