### PR TITLE
callbacks: use existing methods instead of .call/.lazy_call

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -234,9 +234,7 @@ async def _run_coros_in_chunks(
         ]
         if callback is not _DEFAULT_CALLBACK:
             [
-                t.add_done_callback(
-                    lambda *_, **__: callback.call("relative_update", 1)
-                )
+                t.add_done_callback(lambda *_, **__: callback.relative_update(1))
                 for t in chunk
             ]
         results.extend(
@@ -476,7 +474,7 @@ class AsyncFileSystem(AbstractFileSystem):
         batch_size = batch_size or self.batch_size
 
         coros = []
-        callback.call("set_size", len(file_pairs))
+        callback.set_size(len(file_pairs))
         for lfile, rfile in file_pairs:
             callback.branch(lfile, rfile, kwargs)
             coros.append(self._put_file(lfile, rfile, **kwargs))
@@ -515,7 +513,7 @@ class AsyncFileSystem(AbstractFileSystem):
         batch_size = kwargs.pop("batch_size", self.batch_size)
 
         coros = []
-        callback.lazy_call("set_size", len, lpaths)
+        callback.set_size(len(lpaths))
         for lpath, rpath in zip(lpaths, rpaths):
             callback.branch(rpath, lpath, kwargs)
             coros.append(self._get_file(rpath, lpath, **kwargs))

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -239,10 +239,10 @@ class ReferenceFileSystem(AsyncFileSystem):
         if self.isdir(rpath):
             return os.makedirs(lpath, exist_ok=True)
         data = self.cat_file(rpath, **kwargs)
-        callback.lazy_call("set_size", len, data)
+        callback.set_size(len(data))
         with open(lpath, "wb") as f:
             f.write(data)
-        callback.lazy_call("absolute_update", len, data)
+        callback.absolute_update(len(data))
 
     def get(self, rpath, lpath, recursive=False, **kwargs):
         if self.fs.async_impl:


### PR DESCRIPTION
After implementing tests for callbacks in s3fs I noticed that there are some inconsistencies in the way callbacks are used throughout fsspec. It required overriding `.call` and `.lazy_call` to allow to pass through callbacks. See here: https://github.com/fsspec/s3fs/blob/6f844d4dfb70ad7f2397220663b907398659ccd6/s3fs/tests/test_s3fs.py#L914-L925

I believe `.lazy_call` might be a left over of a previous callback implementation and should be dropped, since it is not present in the `fsspec.callbacks.Callback` base class.

I also believe that `.call` should be reserved for calling user provided hooks, and not used for operations that have explicit methods in the `Callback` base class.


#### Changes

This commit uses `.set_size`, `.relative_update` and `.absolute_update` instead of `.call` and `.lazy_call` throughout the fsspec codebase.

After this commit `.lazy_call` is not occurring anywhere in the codebase
anymore.


Let me know what you think,
Cheers,
Andreas 😃 
