### PR TITLE
Add petl package to docs section who uses

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,7 @@ The following libraries use ``fsspec`` internally for path and file handling:
 ``fsspec`` filesystems are also supported by:
 
 #. `pyarrow`_, the in-memory data layout engine
+#. `petl`_, a general purpose package for extracting, transforming and loading tables of data.
 
 ... plus many more that we don't know about.
 
@@ -66,7 +67,7 @@ The following libraries use ``fsspec`` internally for path and file handling:
 .. _DVC: https://dvc.org/
 .. _kedro: https://kedro.readthedocs.io/en/stable/01_introduction/01_introduction.html
 .. _pyarrow: https://arrow.apache.org/docs/python/
-
+.. _petl: https://petl.readthedocs.io/en/stable/io.html#petl.io.remotes.RemoteSource
 
 Installation
 ------------


### PR DESCRIPTION
Petl is a general-purpose Python package for extracting, transforming, and loading tables of data.
It uses `fsspec` as optional integration for reading and writing data from remote filesystems.
Coupling both packages enable the creation of pipelines for transferring and transforming data 
between pairs of remote servers, cloud filesystems, databases, compressed files, Webservices, 
and many diverse file formats like spreadsheets, avro, jons, XML, csv and others.