### PR TITLE
Add methods to retrieve available protocols and compression

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,8 +10,8 @@ User Functions
    fsspec.open_files
    fsspec.open
    fsspec.open_local
-   fsspec.available_compression
-   fsspec.available_protocol
+   fsspec.available_compressions
+   fsspec.available_protocols
    fsspec.filesystem
    fsspec.get_filesystem_class
    fsspec.get_mapper

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,6 +10,8 @@ User Functions
    fsspec.open_files
    fsspec.open
    fsspec.open_local
+   fsspec.available_compression
+   fsspec.available_protocol
    fsspec.filesystem
    fsspec.get_filesystem_class
    fsspec.get_mapper
@@ -19,6 +21,8 @@ User Functions
 .. autofunction:: fsspec.open_files
 .. autofunction:: fsspec.open
 .. autofunction:: fsspec.open_local
+.. autofunction:: fsspec.available_compression
+.. autofunction:: fsspec.available_protocol
 .. autofunction:: fsspec.filesystem
 .. autofunction:: fsspec.get_filesystem_class
 .. autofunction:: fsspec.get_mapper

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -21,8 +21,8 @@ User Functions
 .. autofunction:: fsspec.open_files
 .. autofunction:: fsspec.open
 .. autofunction:: fsspec.open_local
-.. autofunction:: fsspec.available_compression
-.. autofunction:: fsspec.available_protocol
+.. autofunction:: fsspec.available_compressions
+.. autofunction:: fsspec.available_protocols
 .. autofunction:: fsspec.filesystem
 .. autofunction:: fsspec.get_filesystem_class
 .. autofunction:: fsspec.get_mapper

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -68,8 +68,10 @@ Transparent text-mode and compression
 
 As mentioned above, the ``OpenFile`` class allows for the opening of files on a binary store,
 which appear to be in text mode and/or allow for a compression/decompression layer between the
-caller and the back-end storage system. From the user's point of view, this is achieved simply
-by passing arguments to the :func:`fsspec.open_files` or :func:`fsspec.open` functions, and
+caller and the back-end storage system. The list of ``fsspec`` supported codec
+can be retrieved using :func:`fsspec.available_compression`.
+From the user's point of view, this is achieved simply by passing arguments to
+the :func:`fsspec.open_files` or :func:`fsspec.open` functions, and
 thereafter happens transparently.
 
 Key-value stores

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -69,7 +69,7 @@ Transparent text-mode and compression
 As mentioned above, the ``OpenFile`` class allows for the opening of files on a binary store,
 which appear to be in text mode and/or allow for a compression/decompression layer between the
 caller and the back-end storage system. The list of ``fsspec`` supported codec
-can be retrieved using :func:`fsspec.available_compression`.
+can be retrieved using :func:`fsspec.available_compressions`.
 From the user's point of view, this is achieved simply by passing arguments to
 the :func:`fsspec.open_files` or :func:`fsspec.open` functions, and
 thereafter happens transparently.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -28,7 +28,7 @@ Look-up via registry:
 
     import fsspec
 
-    fs = fsspec.filesystem('local')
+    fs = fsspec.filesystem('file')
 
 Many filesystems also take extra parameters, some of which may be options - see :doc:`api`, or use
 :func:`fsspec.get_filesystem_class` to get the class object and inspect its docstring.
@@ -39,7 +39,7 @@ Many filesystems also take extra parameters, some of which may be options - see 
 
     fs = fsspec.filesystem('ftp', host=host, port=port, username=user, password=pw)
 
-The list of implemented ``fsspec`` protocols can be retrieved using :func:`fsspec.available_protocol`.
+The list of implemented ``fsspec`` protocols can be retrieved using :func:`fsspec.available_protocols`.
 
 Use a file-system
 -----------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -28,7 +28,7 @@ Look-up via registry:
 
     import fsspec
 
-    fs = fsspec.filesystem('file')
+    fs = fsspec.filesystem('local')
 
 Many filesystems also take extra parameters, some of which may be options - see :doc:`api`, or use
 :func:`fsspec.get_filesystem_class` to get the class object and inspect its docstring.
@@ -38,6 +38,8 @@ Many filesystems also take extra parameters, some of which may be options - see 
     import fsspec
 
     fs = fsspec.filesystem('ftp', host=host, port=port, username=user, password=pw)
+
+The list of implemented ``fsspec`` protocols can be retrieved using :func:`fsspec.available_protocol`.
 
 Use a file-system
 -----------------

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -9,12 +9,12 @@ except ImportError:  # python < 3.8
 
 from . import _version, caching
 from .callbacks import Callback
-from .compression import available_compression
+from .compression import available_compressions
 from .core import get_fs_token_paths, open, open_files, open_local
 from .exceptions import FSTimeoutError
 from .mapping import FSMap, get_mapper
 from .registry import (
-    available_protocol,
+    available_protocols,
     filesystem,
     get_filesystem_class,
     register_implementation,
@@ -39,8 +39,8 @@ __all__ = [
     "registry",
     "caching",
     "Callback",
-    "available_protocol",
-    "available_compression",
+    "available_protocols",
+    "available_compressions",
 ]
 
 

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -9,10 +9,12 @@ except ImportError:  # python < 3.8
 
 from . import _version, caching
 from .callbacks import Callback
+from .compression import available_compression
 from .core import get_fs_token_paths, open, open_files, open_local
 from .exceptions import FSTimeoutError
 from .mapping import FSMap, get_mapper
 from .registry import (
+    available_protocol,
     filesystem,
     get_filesystem_class,
     register_implementation,
@@ -37,6 +39,8 @@ __all__ = [
     "registry",
     "caching",
     "Callback",
+    "available_protocol",
+    "available_compression",
 ]
 
 

--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -169,5 +169,5 @@ except ImportError:
 
 
 def available_compression():
-    """Return a list of the available compressions."""
+    """Return a list of the implemented compressions."""
     return list(compr.keys())

--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -166,3 +166,8 @@ try:
     register_compression("zstd", zstandard_file, "zst")
 except ImportError:
     pass
+
+
+def available_compression():
+    """Return a list of the available compressions."""
+    return list(compr.keys())

--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -168,6 +168,6 @@ except ImportError:
     pass
 
 
-def available_compression():
+def available_compressions():
     """Return a list of the implemented compressions."""
-    return list(compr.keys())
+    return list(compr)

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -86,7 +86,6 @@ default = "file"
 # updated with register_implementation
 known_implementations = {
     "file": {"class": "fsspec.implementations.local.LocalFileSystem"},
-    "local": {"class": "fsspec.implementations.local.LocalFileSystem"},
     "memory": {"class": "fsspec.implementations.memory.MemoryFileSystem"},
     "dropbox": {
         "class": "dropboxdrivefs.DropboxDriveFileSystem",
@@ -254,6 +253,6 @@ def filesystem(protocol, **storage_options):
     return cls(**storage_options)
 
 
-def available_protocol():
+def available_protocols():
     """Return a list of the implemented protocols."""
-    return list(known_implementations.keys())
+    return list(known_implementations)

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -251,3 +251,8 @@ def filesystem(protocol, **storage_options):
     """
     cls = get_filesystem_class(protocol)
     return cls(**storage_options)
+
+
+def available_protocol():
+    """Return a list of the available protocols."""
+    return list(known_implementations.keys())

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -86,6 +86,7 @@ default = "file"
 # updated with register_implementation
 known_implementations = {
     "file": {"class": "fsspec.implementations.local.LocalFileSystem"},
+    "local": {"class": "fsspec.implementations.local.LocalFileSystem"},
     "memory": {"class": "fsspec.implementations.memory.MemoryFileSystem"},
     "dropbox": {
         "class": "dropboxdrivefs.DropboxDriveFileSystem",
@@ -254,5 +255,5 @@ def filesystem(protocol, **storage_options):
 
 
 def available_protocol():
-    """Return a list of the available protocols."""
+    """Return a list of the implemented protocols."""
     return list(known_implementations.keys())

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -254,5 +254,8 @@ def filesystem(protocol, **storage_options):
 
 
 def available_protocols():
-    """Return a list of the implemented protocols."""
+    """Return a list of the implemented protocols.
+    
+    Note that any given protocol may require extra packages to be importable.
+    """
     return list(known_implementations)

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -255,7 +255,7 @@ def filesystem(protocol, **storage_options):
 
 def available_protocols():
     """Return a list of the implemented protocols.
-    
+
     Note that any given protocol may require extra packages to be importable.
     """
     return list(known_implementations)


### PR DESCRIPTION
This is just a little PR proposal adding methods to easily retrieve the available protocols and compressions. 

Usage:
```
import fsspec
fsspec.available_protocol()
# ['file', 'memory', 'dropbox', 'http', 'https', 'zip', 'tar', 'gcs', 'gs', 'gdrive', ...]

fsspec.available_compression()
# [None, 'zip', 'bz2', 'gzip', 'lzma', 'xz']
```