### PR TITLE
Specify the git branch name for tests

### DIFF
--- a/fsspec/implementations/tests/test_git.py
+++ b/fsspec/implementations/tests/test_git.py
@@ -17,8 +17,8 @@ def repo():
     d = tempfile.mkdtemp()
     try:
         os.chdir(d)
-        subprocess.call("git init", shell=True, cwd=d)
-        subprocess.call("git init", shell=True, cwd=d)
+        subprocess.call("git init -b master", shell=True, cwd=d)
+        subprocess.call("git init -b master", shell=True, cwd=d)
         subprocess.call('git config user.email "you@example.com"', shell=True, cwd=d)
         subprocess.call('git config user.name "Your Name"', shell=True, cwd=d)
         open(os.path.join(d, "file1"), "wb").write(b"data0")


### PR DESCRIPTION
On some systems, the default branch name might not be `master` (e.g. `main` is becoming more common,
https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/).