### PR TITLE
Allow empty calls to `get_mapper`

### DIFF
--- a/fsspec/implementations/tests/test_archive.py
+++ b/fsspec/implementations/tests/test_archive.py
@@ -249,7 +249,7 @@ class TestAnyArchive:
     def test_mapping(self, scenario: ArchiveTestScenario):
         with scenario.provider(archive_data) as archive:
             fs = fsspec.filesystem(scenario.protocol, fo=archive)
-            m = fs.get_mapper("")
+            m = fs.get_mapper()
             assert list(m) == ["a", "b", "deeply/nested/path"]
             assert m["b"] == archive_data["b"]
 

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -9,7 +9,7 @@ def test_1(m):
     files = m.find("")
     assert files == ["/afiles/and/another", "/somefile"]
 
-    files = sorted(m.get_mapper("/"))
+    files = sorted(m.get_mapper())
     assert files == ["afiles/and/another", "somefile"]
 
 

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -187,7 +187,7 @@ def maybe_convert(value):
 
 
 def get_mapper(
-    url,
+    url="",
     check=False,
     create=False,
     missing_exceptions=None,

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1153,7 +1153,7 @@ class AbstractFileSystem(metaclass=_Cached):
         # all instances already also derive from pyarrow
         return self
 
-    def get_mapper(self, root, check=False, create=False):
+    def get_mapper(self, root="", check=False, create=False):
         """Create key/value store based on this file-system
 
         Makes a MutableMapping interface to the FS at the given root path.

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 
 import fsspec
+from fsspec.implementations.local import LocalFileSystem
 from fsspec.implementations.memory import MemoryFileSystem
 
 
@@ -143,3 +144,8 @@ def test_setitem_numpy():
         dtype="<m8[ns]",
     )  # timedelta64 scalar
     assert m["c"] == b',M"\x9e\xc6\x99A\x065\x1c\xf0Rn4\xcb+'
+
+
+def test_empty_url():
+    m = fsspec.get_mapper()
+    assert isinstance(m.fs, LocalFileSystem)


### PR DESCRIPTION
Instead of requiring `""` or `"/"`, use `"/"` as the default for both `get_mapper` implementations.

## Related issues
- Closes #877 