### PR TITLE
Add reference from CachingFileSystem to MMapCache

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -25,8 +25,8 @@ class CachingFileSystem(AbstractFileSystem):
     access after the initial download. The files are stored in a given
     directory with random hashes for the filenames. If no directory is given,
     a temporary one is used, which should be cleaned up by the OS after the
-    process ends. The files themselves as sparse (as implemented in
-    MMapCache), so only the data which is accessed takes up space.
+    process ends. The files themselves are sparse (as implemented in
+    :class:`~fsspec.core.MMapCache`), so only the data which is accessed takes up space.
 
     Restrictions:
 


### PR DESCRIPTION
I was reading the docs and wanted to click on MMapCache but it wasn't linked. Made this edit from the GitHub editor so not sure if the docs are rendered correctly yet.