### PR TITLE
Fix reference to MMapCache in CachingFileSystem docstring

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -138,7 +138,7 @@ Built-in Implementations
 .. autoclass:: fsspec.implementations.arrow.ArrowFSWrapper
    :members: __init__
 
-.. autoclass:: fsspec.implementations.hdfs.HadoopFileSystem
+.. autoclass:: fsspec.implementations.arrow.HadoopFileSystem
    :members: __init__
 
 .. autoclass:: fsspec.implementations.dask.DaskWorkerFileSystem

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,6 +101,7 @@ autodoc_mock_imports = [
     "pygit2",
     "requests",
     "smbprotocol",
+    "smbclient",
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,8 @@ extensions = [
     "numpydoc",
 ]
 
+numpydoc_show_class_members = False
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -69,7 +69,7 @@ Other similar work
 ------------------
 
 It might have been conceivable to reuse code in ``pyfilesystems``, which has an established interface and several
-implementations of its own. However, it supports none of the :ref:`highlight`, critical to
+implementations of its own. However, it supports none of the **critical** features for
 cloud and parallel access, and would not be easy to
 coerce. Following on the success of ``s3fs`` and ``gcsfs``, and their use within Dask, it seemed best to
 have an interface as close to those as possible. See a

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -229,7 +229,7 @@ class BlockCache(BaseCache):
         The statistics on the block cache.
 
         Returns
-        ----------
+        -------
         NamedTuple
             Returned directly from the LRU Cache used internally.
         """

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -26,7 +26,7 @@ class CachingFileSystem(AbstractFileSystem):
     directory with random hashes for the filenames. If no directory is given,
     a temporary one is used, which should be cleaned up by the OS after the
     process ends. The files themselves are sparse (as implemented in
-    :class:`~fsspec.core.MMapCache`), so only the data which is accessed takes up space.
+    :class:`~fsspec.caching.MMapCache`), so only the data which is accessed takes up space.
 
     Restrictions:
 

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -26,7 +26,8 @@ class CachingFileSystem(AbstractFileSystem):
     directory with random hashes for the filenames. If no directory is given,
     a temporary one is used, which should be cleaned up by the OS after the
     process ends. The files themselves are sparse (as implemented in
-    :class:`~fsspec.caching.MMapCache`), so only the data which is accessed takes up space.
+    :class:`~fsspec.caching.MMapCache`), so only the data which is accessed
+    takes up space.
 
     Restrictions:
 

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -109,6 +109,7 @@ class ReferenceFileSystem(AsyncFileSystem):
                 - a dict of protocol:filesystem, where each value is either a filesystem
                   instance, or a dict of kwargs that can be used to create in
                   instance for the given protocol
+
             If this is given, remote_options and remote_protocol are ignored.
         template_overrides : dict
             Swap out any templates in the references file with these - useful for


### PR DESCRIPTION
Fix for #933. Sorry, I didn't think you'd merge that so fast and didn't have time to verify the formatting. This fixes it so the link is actually correct. However, I think I should bring up that there are a lot of warnings in the docs generation that you may want to know about:

```

/home/docs/checkouts/readthedocs.org/user_builds/filesystem-spec/checkouts/latest/fsspec/gui.py:docstring of fsspec.gui.FileSelector:32: WARNING: autosummary: stub file not found 'fsspec.gui.FileSelector.connect'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/filesystem-spec/checkouts/latest/fsspec/gui.py:docstring of fsspec.gui.FileSelector:32: WARNING: autosummary: stub file not found 'fsspec.gui.FileSelector.ignore_events'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/filesystem-spec/checkouts/latest/fsspec/gui.py:docstring of fsspec.gui.FileSelector:32: WARNING: autosummary: stub file not found 'fsspec.gui.FileSelector.open_file'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/filesystem-spec/checkouts/latest/fsspec/gui.py:docstring of fsspec.gui.FileSelector:32: WARNING: autosummary: stub file not found 'fsspec.gui.FileSelector.show'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/filesystem-spec/checkouts/latest/fsspec/spec.py:docstring of fsspec.spec.AbstractFileSystem:26: WARNING: autosummary: stub file not found 'fsspec.spec.AbstractFileSystem.cat'. Check your autosummary_generate setting.
...
```

And there are lot of them.

https://readthedocs.org/projects/filesystem-spec/builds/16528138/