### PR TITLE
Add all FSMap constructor arguments as class attributes

### DIFF
--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -44,6 +44,8 @@ class FSMap(MutableMapping):
                 NotADirectoryError,
             )
         self.missing_exceptions = missing_exceptions
+        self.check = check
+        self.create = create
         if create:
             if not self.fs.exists(root):
                 self.fs.mkdir(root)


### PR DESCRIPTION
There are currently two constructor attributes for `FSMap` - `create` and `check` - that are not accessible as instance attributes. This makes it hard to copy an FSMap. Having these accessible would be useful for e.g. https://github.com/zarr-developers/zarr-python/pull/911; it would allow us to completely rebuild an FSMap object from another.