### PR TITLE
 Fix #954: don't crash when reading empty file from libarchive 

### DIFF
--- a/fsspec/implementations/libarchive.py
+++ b/fsspec/implementations/libarchive.py
@@ -202,6 +202,11 @@ class LibArchiveFileSystem(AbstractArchiveFileSystem):
             for entry in arc:
                 if entry.pathname != path:
                     continue
+                    
+                if entry.size == 0:
+                    # empty file, so there are no blocks
+                    break
+
                 for block in entry.get_blocks(entry.size):
                     data = block
                     break

--- a/fsspec/implementations/libarchive.py
+++ b/fsspec/implementations/libarchive.py
@@ -202,7 +202,7 @@ class LibArchiveFileSystem(AbstractArchiveFileSystem):
             for entry in arc:
                 if entry.pathname != path:
                     continue
-                    
+
                 if entry.size == 0:
                     # empty file, so there are no blocks
                     break

--- a/fsspec/implementations/tests/test_archive.py
+++ b/fsspec/implementations/tests/test_archive.py
@@ -364,7 +364,7 @@ class TestAnyArchive:
 
             assert lhs_dirs == {e for e in entries if fs.isdir(e)}
             assert lhs_files == {e for e in entries if fs.isfile(e)}
-            
+
     def test_read_empty_file(self, scenario: ArchiveTestScenario):
         with scenario.provider(archive_data) as archive:
             fs = fsspec.filesystem(scenario.protocol, fo=archive)

--- a/fsspec/implementations/tests/test_archive.py
+++ b/fsspec/implementations/tests/test_archive.py
@@ -364,3 +364,8 @@ class TestAnyArchive:
 
             assert lhs_dirs == {e for e in entries if fs.isdir(e)}
             assert lhs_files == {e for e in entries if fs.isfile(e)}
+            
+    def test_read_empty_file(self, scenario: ArchiveTestScenario):
+        with scenario.provider(archive_data) as archive:
+            fs = fsspec.filesystem(scenario.protocol, fo=archive)
+            assert fs.open("a").read() == b""


### PR DESCRIPTION
As above, added a simple unit test and verified it crashes without the patch