### PR TITLE
fixes #725: open with ZstdDecompressionReader in binary mode

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -18,6 +18,7 @@ from .caching import (  # noqa: F401
 from .compression import compr
 from .registry import filesystem, get_filesystem_class
 from .utils import (
+    IOWrapper,
     _unstrip_protocol,
     build_name_function,
     infer_compression,
@@ -147,7 +148,11 @@ class OpenFile(object):
             closer()  # original close bound method of the final file-like
             _close(fobjects, mode)  # call close on other dependent file-likes
 
-        out.close = close
+        try:
+            out.close = close
+        except AttributeError:
+            out = IOWrapper(out, lambda: _close(fobjects, mode))
+
         return out
 
     def close(self):

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -118,6 +118,13 @@ def test_zstd_compression(tmpdir):
     ) as infile:
         assert infile.read() == tdat
 
+    # fails in https://github.com/fsspec/filesystem_spec/issues/725
+    infile = fsspec.core.open(
+        str(tmp_path / "out.zst"), mode="rb", compression="infer"
+    ).open()
+
+    infile.close()
+
 
 def test_snappy_compression(tmpdir):
     """No registered compression for snappy, but can be specified."""

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -7,6 +7,8 @@ import sys
 from contextlib import contextmanager
 from functools import partial
 from hashlib import md5
+from types import TracebackType
+from typing import IO, AnyStr, Callable, Iterable, Iterator, List, Optional, Type
 from urllib.parse import urlsplit
 
 DEFAULT_BLOCK_SIZE = 5 * 2**20
@@ -540,3 +542,80 @@ def merge_offset_ranges(paths, starts, ends, max_gap=0, max_block=None, sort=Tru
 
     # `paths` is empty. Just return input lists
     return paths, starts, ends
+
+
+class IOWrapper(IO):
+    """Wrapper for a file-like object that can be used in situations where we might
+    want to, e.g., monkey-patch the close method but can't.
+    (cf https://github.com/fsspec/filesystem_spec/issues/725)
+    """
+
+    def __init__(self, fp: IO, closer: Callable[[], None]):
+        self.fp = fp
+        self.closer = closer
+
+    def close(self) -> None:
+        self.fp.close()
+
+    def fileno(self) -> int:
+        return self.fp.fileno()
+
+    def flush(self) -> None:
+        self.fp.flush()
+
+    def isatty(self) -> bool:
+        return self.fp.isatty()
+
+    def read(self, n: int = ...) -> AnyStr:
+        return self.fp.read(n)
+
+    def readable(self) -> bool:
+        return self.fp.readable()
+
+    def readline(self, limit: int = ...) -> AnyStr:
+        return self.fp.readline(limit)
+
+    def readlines(self, hint: int = ...) -> List[AnyStr]:
+        return self.fp.readlines(hint)
+
+    def seek(self, offset: int, whence: int = ...) -> int:
+        return self.fp.seek(offset, whence)
+
+    def seekable(self) -> bool:
+        return self.fp.seekable()
+
+    def tell(self) -> int:
+        return self.fp.tell()
+
+    def truncate(self, size: Optional[int] = ...) -> int:
+        return self.fp.truncate(size)
+
+    def writable(self) -> bool:
+        return self.fp.writable()
+
+    def write(self, s: AnyStr) -> int:
+        return self.fp.write(s)
+
+    def writelines(self, lines: Iterable[AnyStr]) -> None:
+        self.fp.writelines(lines)
+
+    def __next__(self) -> AnyStr:
+        return next(self.fp)
+
+    def __iter__(self) -> Iterator[AnyStr]:
+        return iter(self.fp)
+
+    def __enter__(self) -> IO[AnyStr]:
+        return self.fp.__enter__()
+
+    def __exit__(
+        self,
+        t: Optional[Type[BaseException]],
+        value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
+        return self.fp.__exit__(t, value, traceback)
+
+    # forward anything else too
+    def __getattr__(self, name):
+        return getattr(self.fp, name)


### PR DESCRIPTION
Implemented more or less along the lines that @martindurant suggested in the issue. I didn't try to keep pickleability, as the ZstdDecompressionReader isn't pickleable anyway, so it didn't seem like a major thing to go for.