### PR TITLE
uniform handling of path argument gievn as a list of strings or a single string in read mode

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -664,15 +664,11 @@ def get_fs_token_paths(
             update_storage_options(options, storage_options)
             fs = cls(**options)
 
-    if isinstance(paths, (list, tuple, set)):
+    if not isinstance(paths, (list, tuple, set)):
+        paths = [paths]
+    if expand:
         paths = expand_paths_if_needed(paths, mode, num, fs, name_function)
-    else:
-        if "w" in mode and expand:
-            paths = _expand_paths(paths, name_function, num)
-        elif "*" in paths:
-            paths = [f for f in sorted(fs.glob(paths)) if not fs.isdir(f)]
-        else:
-            paths = [paths]
+    paths = sorted([f for f in paths if not fs.isdir(f)])
 
     return fs, fs._fs_token, paths
 

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -120,9 +120,10 @@ def test_list():
     here = os.path.abspath(os.path.dirname(__file__))
     flist = os.listdir(here)
     plist = [os.path.join(here, p).replace("\\", "/") for p in flist]
+    plist = [p for p in plist if not os.path.isdir(p)]
     of = open_files(plist)
-    assert len(of) == len(flist)
-    assert [f.path for f in of] == plist
+    assert len(of) == len(plist)
+    assert [f.path for f in of] == sorted(plist)
 
 
 def test_pathobject(tmpdir):


### PR DESCRIPTION

Issue #957 was solved by PR #961 when path is a list of string but not when path is a string.
This PR solves this problem.

However, it also changes other behaviors. For instance, paths were sorted and filtered with not fs.isdir(f) only in read mode and only if a string was given with a wildcard. i.e. list of paths in read mode was not filtered+sorted. Write mode was not filtered+sorted. A single path without wildcard was not filtered+sorted.

This PR is an improvement imho with a more uniform handling of all these cases. dirs are filtered out in all the case, and sorting is also applied in all the cases. However, I hope this does not break expected behaviors that I'm ignoring.

