### PR TITLE
fix httpfile serialization bug

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -634,7 +634,7 @@ class HTTPFile(AbstractBufferedFile):
                 self.url,
                 self.mode,
                 self.blocksize,
-                self.cache.name,
+                self.cache.name if self.cache else "none",
                 self.size,
             ),
         )

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -350,7 +350,7 @@ class LocalFileOpener(io.IOBase):
 
     def __enter__(self):
         self._incontext = True
-        return self.f.__enter__()
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._incontext = False

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -310,6 +310,11 @@ def test_file_pickle(server):
     # via HTTPFile
     h = fsspec.filesystem("http", headers={"give_length": "true", "head_ok": "true"})
     out = server + "/index/realfile"
+
+    with fsspec.open(out, headers={"give_length": "true", "head_ok": "true"}) as f:
+        pic = pickle.loads(pickle.dumps(f))
+        assert pic.read() == data
+
     with h.open(out, "rb") as f:
         pic = pickle.dumps(f)
         assert f.read() == data

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -607,6 +607,20 @@ def test_pickle(tmpdir):
     with pytest.raises(ValueError):
         pickle.dumps(f)
 
+    # with context
+    with fs.open(fn0, "rb") as f:
+        f.seek(1)
+        f2 = pickle.loads(pickle.dumps(f))
+        assert f2.tell() == 1
+        assert f2.read() == f.read()
+
+    # with fsspec.open https://github.com/fsspec/filesystem_spec/issues/579
+    with fsspec.open(fn0, "rb") as f:
+        f.seek(1)
+        f2 = pickle.loads(pickle.dumps(f))
+        assert f2.tell() == 1
+        assert f2.read() == f.read()
+
 
 def test_strip_protocol_expanduser():
     path = "file://~\\foo\\bar" if WIN else "file://~/foo/bar"


### PR DESCRIPTION
This implements the suggestion in https://github.com/pangeo-forge/pangeo-forge-recipes/pull/370#issuecomment-1140028052, which fixes a bug in how `HTTPFile` is serialized.

It's a bit worrying to me that serialization of `HTTPFile` is not covered by tests sufficiently to have already surfaced this bug. Therefore, I would like to use this PR to contribute some improvements to testing as well.