### PR TITLE
Add package links to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="http://github.com/fsspec/filesystem_spec",
+    project_urls={
+        "Changelog": "https://filesystem-spec.readthedocs.io/en/latest/changelog.html",
+        "Documentation": "https://filesystem-spec.readthedocs.io/en/latest/",
+    },
     maintainer="Martin Durant",
     maintainer_email="mdurant@anaconda.com",
     license="BSD",


### PR DESCRIPTION
Add two links to the sidebar on PyPI, to make it easier for folks to jump to the relevant pages. Example: https://pypi.org/project/django-htmx/ (PyPI adds the icons based on the link names).