### PR TITLE
memfs: add global_store flag

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -13,14 +13,25 @@ logger = logging.Logger("fsspec.memoryfs")
 class MemoryFileSystem(AbstractFileSystem):
     """A filesystem based on a dict of BytesIO objects
 
-    This is a global filesystem so instances of this class all point to the same
-    in memory filesystem.
+    Parameters
+    ----------
+    global_store : bool (True)
+        Whether to use global store, so instances of this class all point to
+        the same in memory filesystem. If False, every instance will have its
+        own store.
     """
 
-    store = {}  # global, do not overwrite!
-    pseudo_dirs = [""]  # global, do not overwrite!
+    store = {}  # global
+    pseudo_dirs = [""]  # global
     protocol = "memory"
     root_marker = "/"
+
+    def __init__(self, *args, **storage_options):
+        super().__init__(*args, **storage_options)
+        if not storage_options.get("global_store", True):
+            # detach from global
+            self.store = {}
+            self.pseudo_dirs = [""]
 
     @classmethod
     def _strip_protocol(cls, path):

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from fsspec.implementations.memory import MemoryFileSystem
+
 
 def test_1(m):
     m.touch("/somefile")  # NB: is found with or without initial /
@@ -156,3 +158,15 @@ def test_remove_all(m):
     m.touch("afile")
     m.rm("/", recursive=True)
     assert not m.ls("/")
+
+
+def test_global_store():
+    global_memfs1 = MemoryFileSystem()
+    global_memfs2 = MemoryFileSystem(global_store=True)
+    local_memfs = MemoryFileSystem(global_store=False)
+
+    global_memfs1.pipe_file("foo/bar", b"12345")
+
+    assert global_memfs1.exists("foo/bar")
+    assert global_memfs2.exists("foo/bar")
+    assert not local_memfs.exists("foo/bar")


### PR DESCRIPTION
By default, all instances of `MemoryFileSystem` use the same global store,
which has a few implications for users. For example:

* "memory leaks" if forgetting to delete files after use
* degrading performance (e.g. `info()` that looks through all entries in
  `store` and  `pseudo_dirs`) if storing 1K+ files (our use-case)

This PR allows one to choose whether to use a global store or not, allowing
for easy cleanup and more managable performance implications.

Having thousands of files stored in memfs would still result in a significant
performance hit, especially with complex tree structure. For cases like that,
we might want to create a trie-based memfs, that would be slightly slower to
build, but should be much faster and easier to traverse and read. We don't
have a need for this just yet, but we've ran into this problem in scmrepo's
gitfs, where we are using pygtrie ([1]).

[1] https://github.com/iterative/scmrepo/blob/main/scmrepo/fs.py