### PR TITLE
tox: gcsfs: fix build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -106,8 +106,6 @@ whitelist_externals=
 setenv=
     GOOGLE_APPLICATION_CREDENTIALS=gcsfs/gcsfs/tests/fake-secret.json
 commands=
-    pip install .
     rm -rf gcsfs
     git clone https://github.com/fsspec/gcsfs
-    pip install ./gcsfs  --no-deps
     pytest -vv gcsfs/gcsfs -k 'not fuse'


### PR DESCRIPTION
Makes so that the tests at least run. gcsfs fix is https://github.com/fsspec/gcsfs/pull/479