### PR TITLE
Add adl, abfs and abfss to infer_storage_options

### DIFF
--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -204,7 +204,7 @@ def test_infer_options():
     # include it in the path. Test that:
     # - Parsing doesn't lowercase the bucket
     # - The bucket is included in path
-    for protocol in ["s3", "s3a", "gcs", "gs"]:
+    for protocol in ["s3", "s3a", "gcs", "gs", "adl", "abfs", "abfss", "gdrive"]:
         options = infer_storage_options("%s://Bucket-name.com/test.csv" % protocol)
         assert options["path"] == "Bucket-name.com/test.csv"
 

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -74,7 +74,7 @@ def infer_storage_options(urlpath, inherit_storage_options=None):
         # https://github.com/dask/dask/issues/1417
         options["host"] = parsed_path.netloc.rsplit("@", 1)[-1].rsplit(":", 1)[0]
 
-        if protocol in ("s3", "s3a", "gcs", "gs"):
+        if protocol in ("s3", "s3a", "gcs", "gs", "adl", "abfs", "abfss"):
             options["path"] = options["host"] + options["path"]
         else:
             options["host"] = options["host"]

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -74,7 +74,7 @@ def infer_storage_options(urlpath, inherit_storage_options=None):
         # https://github.com/dask/dask/issues/1417
         options["host"] = parsed_path.netloc.rsplit("@", 1)[-1].rsplit(":", 1)[0]
 
-        if protocol in ("s3", "s3a", "gcs", "gs", "adl", "abfs", "abfss"):
+        if protocol in ("s3", "s3a", "gcs", "gs", "adl", "abfs", "abfss", "gdrive"):
             options["path"] = options["host"] + options["path"]
         else:
             options["host"] = options["host"]


### PR DESCRIPTION
Parsing filepaths in `infer_storage_options` with azure protocols, "adl", "abfs", "abfss" doesn't return the expected path. For example, the filepath, `adl://bucket/file.txt`, returns `{"path": "/file.txt"}` while the filepath, `s3://bucket/file.txt`,  returns `{"path": "bucket/file.txt"}`. 

To fix this we should add the extra protocols to the `if` statement that checks for cloud protocols.