### PR TITLE
show path in exceptions

### DIFF
--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -110,7 +110,7 @@ class FTPFileSystem(AbstractFileSystem):
                     if info["type"] == "file":
                         out = [(path, info)]
                 except (Error, IndexError):
-                    raise FileNotFoundError
+                    raise FileNotFoundError(path)
         files = self.dircache.get(path, out)
         if not detail:
             return sorted([fn for fn, details in files])

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -118,7 +118,7 @@ class LocalFileSystem(AbstractFileSystem):
         elif self.isdir(path1):
             self.mkdirs(path2, exist_ok=True)
         else:
-            raise FileNotFoundError
+            raise FileNotFoundError(path1)
 
     def get_file(self, path1, path2, callback=None, **kwargs):
         if isfilelike(path2):

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -96,7 +96,7 @@ class MemoryFileSystem(AbstractFileSystem):
     def mkdir(self, path, create_parents=True, **kwargs):
         path = self._strip_protocol(path)
         if path in self.store or path in self.pseudo_dirs:
-            raise FileExistsError
+            raise FileExistsError(path)
         if self._parent(path).strip("/") and self.isfile(self._parent(path)):
             raise NotADirectoryError(self._parent(path))
         if create_parents and self._parent(path).strip("/"):
@@ -165,7 +165,7 @@ class MemoryFileSystem(AbstractFileSystem):
     ):
         path = self._strip_protocol(path)
         if path in self.pseudo_dirs:
-            raise IsADirectoryError
+            raise IsADirectoryError(path)
         parent = path
         while len(parent) > 1:
             parent = self._parent(parent)
@@ -198,7 +198,7 @@ class MemoryFileSystem(AbstractFileSystem):
             if path2 not in self.pseudo_dirs:
                 self.pseudo_dirs.append(path2)
         else:
-            raise FileNotFoundError
+            raise FileNotFoundError(path1)
 
     def cat_file(self, path, start=None, end=None, **kwargs):
         path = self._strip_protocol(path)
@@ -212,7 +212,7 @@ class MemoryFileSystem(AbstractFileSystem):
         try:
             del self.store[path]
         except KeyError as e:
-            raise FileNotFoundError from e
+            raise FileNotFoundError(path) from e
 
     def rm(self, path, recursive=False, maxdepth=None):
         if isinstance(path, str):

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -490,7 +490,7 @@ class ReferenceFileSystem(AsyncFileSystem):
             self._dircache_from_items()
         out = self._ls_from_cache(path)
         if out is None:
-            raise FileNotFoundError
+            raise FileNotFoundError(path)
         if detail:
             return out
         return [o["name"] for o in out]


### PR DESCRIPTION
Some errors like `FileNotFoundError` are raised with no arguments. For example:
```
from fsspec.implementations.local import LocalFileSystem
LocalFileSystem().get_file('a', 'b')
```
This outputs an empty exception:
```
FileNotFoundError
```
It would be more informative to pass the path to the raised exception