### PR TITLE
Add `wandbfs` registry for `wandbfsspec`

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -208,6 +208,7 @@ Other Known Implementations
 - `dropbox`_ for access to dropbox shares
 - `ocifs`_ for access to Oracle Cloud Object Storage
 - `gdrive`_ to access Google Drive and shares (experimental)
+- `wandbfsspec`_ to access Wandb run data
 - `wandbfs`_ to access Wandb run data (experimental)
 - `ossfs`_ for Alibaba Cloud (Aliyun) Object Storage System (OSS)
 - `webdav4`_ for WebDAV
@@ -219,6 +220,7 @@ Other Known Implementations
 .. _dropbox: https://github.com/MarineChap/intake_dropbox
 .. _ocifs: https://pypi.org/project/ocifs
 .. _gdrive: https://github.com/fsspec/gdrivefs
+.. _wandbfsspec: https://github.com/alvarobartt/wandbfsspec
 .. _wandbfs: https://github.com/jkulhanek/wandbfs
 .. _ossfs: https://github.com/fsspec/ossfs
 .. _webdav4: https://github.com/skshetry/webdav4

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -140,6 +140,10 @@ known_implementations = {
     "s3": {"class": "s3fs.S3FileSystem", "err": "Install s3fs to access S3"},
     "s3a": {"class": "s3fs.S3FileSystem", "err": "Install s3fs to access S3"},
     "wandb": {"class": "wandbfs.WandbFS", "err": "Install wandbfs to access wandb"},
+    "wandbfs": {
+        "class": "wandbfsspec.core.WandbFileSystem",
+        "err": "Install wandbfsspec to access wandb",
+    },
     "oci": {
         "class": "ocifs.OCIFileSystem",
         "err": "Install ocifs to access OCI Object Storage",

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "libarchive": ["libarchive-c"],
         "gui": ["panel"],
         "tqdm": ["tqdm"],
+        "wandb": ["wandbfsspec"],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
As you may know, there's already a `wandb` implementation of `fsspec` available, but it's no longer maintained as I contacted the author @/jkulhanek via email and he told me that he's no longer maintaining it. `wandbfs` available at https://github.com/jkulhanek/wandbfs

I realized there was another Python package for `wandb`'s fsspec implementation once I was in the later development stages of `wandbfsspec`, that's the reason why I created another Python package. Find the `wandbfsspec` repository at https://github.com/alvarobartt/wandbfsspec, and the v0.1.0 released published on PyPI at https://pypi.org/project/wandbfsspec/

Besides the fact that `wandbfsspec` contains more functionality implemented than `wandbfs`, I'm also planning to add an interface for the [WandB Artifact Store](https://docs.wandb.ai/guides/artifacts) so as to support both "file systems" available in `wandb`.

Note that this is relevant, as `fsspec` makes everything easy providing a common interface to access different storage systems and some packages such as [zenml](https://github.com/zenml-io/zenml) that aim to build portable MLOps solutions, use these interfaces so as to allow the user to easily change the steps of their pipelines. This can also be extended to data pipelines, model pipelines, etc.

So on, I find this new implementation useful and I'm planning to actively maintain it, and start developing some integrations of both `wandb` file system and artifact store, for some packages based on `fsspec` components.