### PR TITLE
memory.py: Avoid bytes copies where possible

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -154,9 +154,7 @@ class MemoryFileSystem(AbstractFileSystem):
             filelike = self.store[path]
             return {
                 "name": path,
-                "size": filelike.size
-                if hasattr(filelike, "size")
-                else _flen(filelike),
+                "size": filelike.size if hasattr(filelike, "size") else _flen(filelike),
                 "type": "file",
                 "created": getattr(filelike, "created", None),
             }

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -184,7 +184,7 @@ class MemoryFileSystem(AbstractFileSystem):
             else:
                 raise FileNotFoundError(path)
         if mode == "wb":
-            m = MemoryFile(self, path)
+            m = MemoryFile(self, path, kwargs.get('data'))
             if not self._intrans:
                 m.commit()
             return m

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -119,9 +119,7 @@ class MemoryFileSystem(AbstractFileSystem):
 
         Avoids copies of the data if possible
         """
-        with self.open(path, "wb", data=value, **kwargs) as f:
-            # value passed into initializer to avoid copy
-            assert f.getvalue() is value
+        self.open(path, "wb", data=value)
 
     def rmdir(self, path):
         path = self._strip_protocol(path)

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -114,6 +114,15 @@ class MemoryFileSystem(AbstractFileSystem):
             if not exist_ok:
                 raise
 
+    def pipe_file(self, path, value, **kwargs):
+        """Set the bytes of given file
+
+        Avoids copies of the data if possible
+        """
+        with self.open(path, "wb", data=value, **kwargs) as f:
+            # value passed into initializer to avoid copy
+            assert f.getvalue() is value
+
     def rmdir(self, path):
         path = self._strip_protocol(path)
         if path == "":


### PR DESCRIPTION
## Changes and reasoning
There are three cases (one of them used in a few locations) that cause a `BytesIO` (and therefore a `MemoryFile`) to become 'dirty', in the sense that CPython thinks a write has occurred, and therefore makes a copy of the underlying data when one is not necessary.

* Checking file length
  * `memoryfile.getbuffer().nbytes` creates a writable buffer
    * at this point Python assumes that a write has occurred, which forces a copy of the data when the data is read
  * Change: Created a function `_flen()` that uses `f.seek()` and `f.tell()` to check the length of the data
* Creation from another `BytesIO` or `MemoryFile` object
  * `newfile = MemoryFile(mem_fs, path, oldfile.getbuffer())` creates a writable buffer
    * this buffer is immediately copied from to create the contents of the new `BytesIO` or `MemoryFile`
    * this also forces `oldfile` to make a copy if `oldfile` is read again.
  * Change: Use `newfile = MemoryFile(mem_fs, path, oldfile.getvalue()`
    * if `oldfile` was previously modified, one copy of the data is made
    * if `oldfile` was not modified, both files use a reference to the same `bytes` object, and no copies are made
* Creation of a `MemoryFile`
  * `MemoryFile.__init__()` creates a buffer and then copies the new data into it, rather than calling `super()`
    * This causes a copy where none is needed when `data` is a `bytes` object
  * Change: Use `super().__init__(data)`
    * Whenever `data` is a `bytes` object, it will be used without a copy


## Notes
* `_flen()` could arguably be better placed as a classmethod, but I suppose that depends on project / style preferences -- happy to change it
* `_flen()` could instead be a magic method `MemoryFile.__len__()`, but this seemed to blur string and filelike object APIs too much, and would probably be considered too big of a change for a PR of this limited scope.

