### PR TITLE
Add `LocalFileOpener.fileno()` to make `numpy.fromfile()` work again

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -348,6 +348,9 @@ class LocalFileOpener(io.IOBase):
     def closed(self):
         return self.f.closed
 
+    def fileno(self):
+        return self.raw.fileno()
+
     def __iter__(self):
         return self.f.__iter__()
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -775,3 +775,13 @@ def test_seekable(tmpdir):
     f.seek(1)
     assert f.read(1) == "a"
     assert f.tell() == 2
+
+
+def test_numpy_fromfile(tmpdir):
+    # Regression test for #1005.
+    np = pytest.importorskip("numpy")
+    fn = str(tmpdir / "test_arr.npy")
+    dt = np.int64
+    arr = np.arange(10, dtype=dt)
+    arr.tofile(fn)
+    assert np.array_equal(np.fromfile(fn, dtype=dt), arr)


### PR DESCRIPTION
Passing a `LocalFileOpener` to `numpy.fromfile()` stopped working in fsspec v2022.7.1 for reasons discussed in https://github.com/fsspec/filesystem_spec/pull/1005#issuecomment-1203436575.

This PR adds a `fileno()` method to `LocalFileOpener` which restores the ability to use `numpy.fromfile`.