### PR TITLE
Fix `pip install --pre fsspec[http]`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "gs": ["gcsfs"],
         "hdfs": ["pyarrow >= 1"],
         "arrow": ["pyarrow >= 1"],
-        "http": ["requests", "aiohttp"],
+        "http": ["requests", "aiohttp !=4.0.0a0, !=4.0.0a1"],
         "sftp": ["paramiko"],
         "s3": ["s3fs"],
         "oci": ["ocifs"],


### PR DESCRIPTION
It is not possible to run `pip install --pre fsspec[http]` right now because the two latest pre-releases of `aiohttp` are broken (v4.0.0a0 and v4.0.0a1).  These two alpha releases were uploaded in 2019 and seem to have been abandoned in favor of 3.x releases for now (cf. https://github.com/aio-libs/aiohttp/issues/6799).

This PR proposes excluding these two versions from fsspec's `setup.py`.

I encountered this issue because AstroPy's CI includes a run where dependencies are installed using `pip install --pre` to catch breaking changes in upstream packages. Adding fsspec as a dependency to Astropy causes this run to fail (cf. https://github.com/astropy/astropy/pull/13238).  I can exclude `aiohttp !=4.0.0a0, !=4.0.0a1` in the Astropy config, but it may be useful for others to exclude them here as well?

## Example error
```
$ python -m venv example
$ source example/bin/activate
$ pip install --pre "fsspec[http]"
Collecting fsspec[http]
  Using cached fsspec-2022.7.1-py3-none-any.whl (141 kB)
Collecting aiohttp
  Using cached aiohttp-4.0.0a1.tar.gz (1.1 MB)
Collecting requests
  Using cached requests-2.28.1-py3-none-any.whl (62 kB)
Collecting attrs>=17.3.0
  Using cached attrs-22.1.0-py2.py3-none-any.whl (58 kB)
Collecting chardet<4.0,>=2.0
  Using cached chardet-3.0.4-py2.py3-none-any.whl (133 kB)
Collecting multidict<5.0,>=4.5
  Using cached multidict-4.7.6-cp310-cp310-macosx_12_0_x86_64.whl
Collecting async_timeout<4.0,>=3.0
  Using cached async_timeout-3.0.1-py3-none-any.whl (8.2 kB)
Collecting yarl<2.0,>=1.0
  Using cached yarl-1.8.1-cp310-cp310-macosx_10_9_x86_64.whl (61 kB)
Collecting typing_extensions>=3.6.5
  Using cached typing_extensions-4.3.0-py3-none-any.whl (25 kB)
Collecting idna>=2.0
  Using cached idna-3.3-py3-none-any.whl (61 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.11-py2.py3-none-any.whl (139 kB)
Collecting certifi>=2017.4.17
  Using cached certifi-2022.6.15-py3-none-any.whl (160 kB)
Collecting charset-normalizer<3,>=2
  Using cached charset_normalizer-2.1.0-py3-none-any.whl (39 kB)
Using legacy 'setup.py install' for aiohttp, since package 'wheel' is not installed.
Installing collected packages: multidict, idna, yarl, urllib3, typing-extensions, charset-normalizer, chardet, certifi, attrs, async-timeout, requests, fsspec, aiohttp
    Running setup.py install for aiohttp ... error
    ERROR: Command errored out with exit status 1:
     command: /Users/gb/tmp/fsspec-play/example/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/x4/y38zs5fj4szf7xj3354kv74m0000gn/T/pip-install-x1gije_2/aiohttp_1f0f1933cdbe43a280a7df83505dbafe/setup.py'"'"'; __file__='"'"'/private/var/folders/x4/y38zs5fj4szf7xj3354kv74m0000gn/T/pip-install-x1gije_2/aiohttp_1f0f1933cdbe43a280a7df83505dbafe/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /private/var/folders/x4/y38zs5fj4szf7xj3354kv74m0000gn/T/pip-record-kfn5eo8x/install-record.txt --single-version-externally-managed --compile --install-headers /Users/gb/tmp/fsspec-play/example/include/site/python3.10/aiohttp
         cwd: /private/var/folders/x4/y38zs5fj4szf7xj3354kv74m0000gn/T/pip-install-x1gije_2/aiohttp_1f0f1933cdbe43a280a7df83505dbafe/
    Complete output (507 lines):
    **********************
    * Accellerated build *
    **********************
    running install
    running build
    running build_py
    creating build
    creating build/lib.macosx-12.2-x86_64-3.10
    creating build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_ws.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/worker.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/multipart.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_response.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/signals.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/client_ws.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/test_utils.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/tracing.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_exceptions.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_middlewares.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/http_exceptions.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_app.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/streams.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_protocol.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/log.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/client.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_urldispatcher.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_request.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/http_websocket.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/client_proto.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/locks.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/__init__.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_runner.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_server.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/base_protocol.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/payload.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/client_reqrep.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/http.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_log.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/resolver.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/formdata.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_routedef.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/connector.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/client_exceptions.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/typedefs.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/hdrs.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/web_fileresponse.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/http_writer.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/tcp_helpers.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/helpers.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/frozenlist.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/http_parser.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/cookiejar.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/pytest_plugin.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/abc.py -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    running egg_info
    writing aiohttp.egg-info/PKG-INFO
    writing dependency_links to aiohttp.egg-info/dependency_links.txt
    writing requirements to aiohttp.egg-info/requires.txt
    writing top-level names to aiohttp.egg-info/top_level.txt
    reading manifest file 'aiohttp.egg-info/SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    warning: no files found matching 'aiohttp' anywhere in distribution
    warning: no previously-included files matching '*.pyc' found anywhere in distribution
    warning: no previously-included files matching '*.pyd' found anywhere in distribution
    warning: no previously-included files matching '*.so' found anywhere in distribution
    warning: no previously-included files matching '*.lib' found anywhere in distribution
    warning: no previously-included files matching '*.dll' found anywhere in distribution
    warning: no previously-included files matching '*.a' found anywhere in distribution
    warning: no previously-included files matching '*.obj' found anywhere in distribution
    warning: no previously-included files found matching 'aiohttp/*.html'
    no previously-included directories found matching 'docs/_build'
    adding license file 'LICENSE.txt'
    writing manifest file 'aiohttp.egg-info/SOURCES.txt'
    copying aiohttp/_cparser.pxd -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_find_header.c -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_find_header.h -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_find_header.pxd -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_frozenlist.c -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_frozenlist.pyx -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_headers.pxi -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_helpers.c -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_helpers.pyi -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_helpers.pyx -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_http_parser.c -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_http_parser.pyx -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_http_writer.c -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_http_writer.pyx -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_websocket.c -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/_websocket.pyx -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/frozenlist.pyi -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/py.typed -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    copying aiohttp/signals.pyi -> build/lib.macosx-12.2-x86_64-3.10/aiohttp
    running build_ext
    building 'aiohttp._websocket' extension
    creating build/temp.macosx-12.2-x86_64-3.10
    creating build/temp.macosx-12.2-x86_64-3.10/aiohttp
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Users/gb/tmp/fsspec-play/example/include -I/Users/gb/.pyenv/versions/3.10.2/include/python3.10 -c aiohttp/_websocket.c -o build/temp.macosx-12.2-x86_64-3.10/aiohttp/_websocket.o
    aiohttp/_websocket.c:2166:22: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                         ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:261:7: note: expanded from macro 'PyUnicode_GET_SIZE'
          PyUnicode_WSTR_LENGTH(op) :                    \
          ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2166:22: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                         ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:262:14: note: expanded from macro 'PyUnicode_GET_SIZE'
          ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
                 ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2166:22: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                         ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:264:8: note: expanded from macro 'PyUnicode_GET_SIZE'
           PyUnicode_WSTR_LENGTH(op)))
           ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2166:52: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                       ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:261:7: note: expanded from macro 'PyUnicode_GET_SIZE'
          PyUnicode_WSTR_LENGTH(op) :                    \
          ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2166:52: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                       ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:262:14: note: expanded from macro 'PyUnicode_GET_SIZE'
          ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
                 ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2166:52: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                       ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:264:8: note: expanded from macro 'PyUnicode_GET_SIZE'
           PyUnicode_WSTR_LENGTH(op)))
           ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2182:26: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                             ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:261:7: note: expanded from macro 'PyUnicode_GET_SIZE'
          PyUnicode_WSTR_LENGTH(op) :                    \
          ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2182:26: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                             ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:262:14: note: expanded from macro 'PyUnicode_GET_SIZE'
          ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
                 ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2182:26: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                             ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:264:8: note: expanded from macro 'PyUnicode_GET_SIZE'
           PyUnicode_WSTR_LENGTH(op)))
           ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2182:59: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                              ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:261:7: note: expanded from macro 'PyUnicode_GET_SIZE'
          PyUnicode_WSTR_LENGTH(op) :                    \
          ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2182:59: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                              ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:262:14: note: expanded from macro 'PyUnicode_GET_SIZE'
          ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
                 ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_websocket.c:2182:59: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                              ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:264:8: note: expanded from macro 'PyUnicode_GET_SIZE'
           PyUnicode_WSTR_LENGTH(op)))
           ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    12 warnings generated.
    clang -bundle -undefined dynamic_lookup -L/usr/local/opt/readline/lib -L/usr/local/opt/readline/lib -L/Users/gb/.pyenv/versions/3.10.2/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/readline/lib -L/Users/gb/.pyenv/versions/3.10.2/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib build/temp.macosx-12.2-x86_64-3.10/aiohttp/_websocket.o -o build/lib.macosx-12.2-x86_64-3.10/aiohttp/_websocket.cpython-310-darwin.so
    building 'aiohttp._http_parser' extension
    creating build/temp.macosx-12.2-x86_64-3.10/vendor
    creating build/temp.macosx-12.2-x86_64-3.10/vendor/http-parser
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -DHTTP_PARSER_STRICT=0 -I/Users/gb/tmp/fsspec-play/example/include -I/Users/gb/.pyenv/versions/3.10.2/include/python3.10 -c aiohttp/_find_header.c -o build/temp.macosx-12.2-x86_64-3.10/aiohttp/_find_header.o
    aiohttp/_find_header.c:21:11: warning: initializing 'char *' with an expression of type 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        char *pchar = str;
              ^       ~~~
    aiohttp/_find_header.c:9997:1: warning: unused label 'missing' [-Wunused-label]
    missing:
    ^~~~~~~~
    aiohttp/_find_header.c:27:1: warning: unused label 'INITIAL' [-Wunused-label]
    INITIAL:
    ^~~~~~~~
    3 warnings generated.
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -DHTTP_PARSER_STRICT=0 -I/Users/gb/tmp/fsspec-play/example/include -I/Users/gb/.pyenv/versions/3.10.2/include/python3.10 -c aiohttp/_http_parser.c -o build/temp.macosx-12.2-x86_64-3.10/aiohttp/_http_parser.o
    aiohttp/_http_parser.c:11739:148: warning: passing 'const char *' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
          __pyx_t_1 = ((struct __pyx_vtabstruct_7aiohttp_12_http_parser_HttpParser *)__pyx_v_pyparser->__pyx_vtab)->_on_header_field(__pyx_v_pyparser, __pyx_v_at, __pyx_v_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 638, __pyx_L3_error)
                                                                                                                                                       ^~~~~~~~~~
    aiohttp/_http_parser.c:11643:34: warning: comparison of integers of different signs: 'Py_ssize_t' (aka 'long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
          __pyx_t_6 = ((__pyx_v_size > __pyx_v_pyparser->_max_field_size) != 0);
                        ~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    aiohttp/_http_parser.c:12057:148: warning: passing 'const char *' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
          __pyx_t_1 = ((struct __pyx_vtabstruct_7aiohttp_12_http_parser_HttpParser *)__pyx_v_pyparser->__pyx_vtab)->_on_header_value(__pyx_v_pyparser, __pyx_v_at, __pyx_v_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 655, __pyx_L3_error)
                                                                                                                                                       ^~~~~~~~~~
    aiohttp/_http_parser.c:11961:34: warning: comparison of integers of different signs: 'Py_ssize_t' (aka 'long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
          __pyx_t_6 = ((__pyx_v_size > __pyx_v_pyparser->_max_field_size) != 0);
                        ~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    aiohttp/_http_parser.c:16227:5: error: expression is not assignable
        ++Py_REFCNT(o);
        ^ ~~~~~~~~~~~~
    aiohttp/_http_parser.c:16229:5: error: expression is not assignable
        --Py_REFCNT(o);
        ^ ~~~~~~~~~~~~
    aiohttp/_http_parser.c:19932:16: warning: 'PyUnicode_FromUnicode' is deprecated [-Wdeprecated-declarations]
            return PyUnicode_FromUnicode(NULL, 0);
                   ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:551:1: note: 'PyUnicode_FromUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(PyObject*) PyUnicode_FromUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20030:22: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                         ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:261:7: note: expanded from macro 'PyUnicode_GET_SIZE'
          PyUnicode_WSTR_LENGTH(op) :                    \
          ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20030:22: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                         ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:262:14: note: expanded from macro 'PyUnicode_GET_SIZE'
          ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
                 ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20030:22: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                         ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:264:8: note: expanded from macro 'PyUnicode_GET_SIZE'
           PyUnicode_WSTR_LENGTH(op)))
           ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20030:52: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                       ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:261:7: note: expanded from macro 'PyUnicode_GET_SIZE'
          PyUnicode_WSTR_LENGTH(op) :                    \
          ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20030:52: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                       ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:262:14: note: expanded from macro 'PyUnicode_GET_SIZE'
          ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
                 ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20030:52: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                        (PyUnicode_GET_SIZE(**name) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                       ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:264:8: note: expanded from macro 'PyUnicode_GET_SIZE'
           PyUnicode_WSTR_LENGTH(op)))
           ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20046:26: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                             ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:261:7: note: expanded from macro 'PyUnicode_GET_SIZE'
          PyUnicode_WSTR_LENGTH(op) :                    \
          ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20046:26: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                             ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:262:14: note: expanded from macro 'PyUnicode_GET_SIZE'
          ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
                 ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20046:26: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                             ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:264:8: note: expanded from macro 'PyUnicode_GET_SIZE'
           PyUnicode_WSTR_LENGTH(op)))
           ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20046:59: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                              ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:261:7: note: expanded from macro 'PyUnicode_GET_SIZE'
          PyUnicode_WSTR_LENGTH(op) :                    \
          ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20046:59: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                              ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:262:14: note: expanded from macro 'PyUnicode_GET_SIZE'
          ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
                 ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:20046:59: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
                            (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
                                                              ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:264:8: note: expanded from macro 'PyUnicode_GET_SIZE'
           PyUnicode_WSTR_LENGTH(op)))
           ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
    #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                      ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3)
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:21230:16: warning: 'PyUnicode_FromUnicode' is deprecated [-Wdeprecated-declarations]
            return PyUnicode_FromUnicode(NULL, 0);
                   ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/cpython/unicodeobject.h:551:1: note: 'PyUnicode_FromUnicode' has been explicitly marked deprecated here
    Py_DEPRECATED(3.3) PyAPI_FUNC(PyObject*) PyUnicode_FromUnicode(
    ^
    /Users/gb/.pyenv/versions/3.10.2/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
    #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                         ^
    aiohttp/_http_parser.c:23271:19: error: implicit declaration of function '_PyGen_Send' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                      ^
    aiohttp/_http_parser.c:23271:17: warning: incompatible integer to pointer conversion assigning to 'PyObject *' (aka 'struct _object *') from 'int' [-Wint-conversion]
                ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                    ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    aiohttp/_http_parser.c:23276:19: error: implicit declaration of function '_PyGen_Send' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                      ^
    aiohttp/_http_parser.c:23276:17: warning: incompatible integer to pointer conversion assigning to 'PyObject *' (aka 'struct _object *') from 'int' [-Wint-conversion]
                ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
                    ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    aiohttp/_http_parser.c:23360:19: error: implicit declaration of function '_PyGen_Send' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                ret = _PyGen_Send((PyGenObject*)yf, NULL);
                      ^
    aiohttp/_http_parser.c:23360:17: warning: incompatible integer to pointer conversion assigning to 'PyObject *' (aka 'struct _object *') from 'int' [-Wint-conversion]
                ret = _PyGen_Send((PyGenObject*)yf, NULL);
                    ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    21 warnings and 5 errors generated.
    error: command '/usr/bin/clang' failed with exit code 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /Users/gb/tmp/fsspec-play/example/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/x4/y38zs5fj4szf7xj3354kv74m0000gn/T/pip-install-x1gije_2/aiohttp_1f0f1933cdbe43a280a7df83505dbafe/setup.py'"'"'; __file__='"'"'/private/var/folders/x4/y38zs5fj4szf7xj3354kv74m0000gn/T/pip-install-x1gije_2/aiohttp_1f0f1933cdbe43a280a7df83505dbafe/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /private/var/folders/x4/y38zs5fj4szf7xj3354kv74m0000gn/T/pip-record-kfn5eo8x/install-record.txt --single-version-externally-managed --compile --install-headers /Users/gb/tmp/fsspec-play/example/include/site/python3.10/aiohttp Check the logs for full command output.
```