### PR TITLE
Fix _parent function rstrip

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -949,8 +949,7 @@ class AbstractFileSystem(metaclass=_Cached):
 
     @classmethod
     def _parent(cls, path):
-        # This PR is only to check whether tests pass in unmodified env.
-        path = cls._strip_protocol(path.rstrip("/"))
+        path = cls._strip_protocol(path)
         if "/" in path:
             parent = path.rsplit("/", 1)[0].lstrip(cls.root_marker)
             return cls.root_marker + parent

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -949,6 +949,7 @@ class AbstractFileSystem(metaclass=_Cached):
 
     @classmethod
     def _parent(cls, path):
+        # This PR is only to check whether tests pass in unmodified env.
         path = cls._strip_protocol(path.rstrip("/"))
         if "/" in path:
             parent = path.rsplit("/", 1)[0].lstrip(cls.root_marker)


### PR DESCRIPTION
This PR attempts to solve #1020 by removing the unnecessary `rstrip` in the `_parent` function.

Since `_strip_protocol` already calls `rstrip`, this should be safe and not change any functionality.