### PR TITLE
Make OpenFile filelike

### DIFF
--- a/fsspec/implementations/tar.py
+++ b/fsspec/implementations/tar.py
@@ -83,7 +83,7 @@ class TarFileSystem(AbstractArchiveFileSystem):
 
         self._fo_ref = fo
         weakref.finalize(self, fo.close)
-        self.fo = fo.__enter__()  # the whole instance is a context
+        self.fo = fo  # the whole instance is a context
         self.tar = tarfile.TarFile(fileobj=self.fo)
         self.dir_cache = None
 

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -183,6 +183,13 @@ def test_openfile_pickle_newline():
     assert test.newline == restored.newline
 
 
+def test_pickle_after_open_open():
+    test = fsspec.open(__file__, mode="rt").open()
+    test2 = pickle.loads(pickle.dumps(test))
+    test.close()
+    assert not test2.closed
+
+
 def test_mismatch():
     with pytest.raises(ValueError, match="protocol"):
         open_files(["s3://test/path.csv", "/other/path.csv"])

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -7,8 +7,6 @@ import sys
 from contextlib import contextmanager
 from functools import partial
 from hashlib import md5
-from types import TracebackType
-from typing import IO, AnyStr, Callable, Iterable, Iterator, List, Optional, Type
 from urllib.parse import urlsplit
 
 DEFAULT_BLOCK_SIZE = 5 * 2**20
@@ -542,83 +540,6 @@ def merge_offset_ranges(paths, starts, ends, max_gap=0, max_block=None, sort=Tru
 
     # `paths` is empty. Just return input lists
     return paths, starts, ends
-
-
-class IOWrapper(IO):
-    """Wrapper for a file-like object that can be used in situations where we might
-    want to, e.g., monkey-patch the close method but can't.
-    (cf https://github.com/fsspec/filesystem_spec/issues/725)
-    """
-
-    def __init__(self, fp: IO, closer: Callable[[], None]):
-        self.fp = fp
-        self.closer = closer
-
-    def close(self) -> None:
-        self.fp.close()
-
-    def fileno(self) -> int:
-        return self.fp.fileno()
-
-    def flush(self) -> None:
-        self.fp.flush()
-
-    def isatty(self) -> bool:
-        return self.fp.isatty()
-
-    def read(self, n: int = ...) -> AnyStr:
-        return self.fp.read(n)
-
-    def readable(self) -> bool:
-        return self.fp.readable()
-
-    def readline(self, limit: int = ...) -> AnyStr:
-        return self.fp.readline(limit)
-
-    def readlines(self, hint: int = ...) -> List[AnyStr]:
-        return self.fp.readlines(hint)
-
-    def seek(self, offset: int, whence: int = ...) -> int:
-        return self.fp.seek(offset, whence)
-
-    def seekable(self) -> bool:
-        return self.fp.seekable()
-
-    def tell(self) -> int:
-        return self.fp.tell()
-
-    def truncate(self, size: Optional[int] = ...) -> int:
-        return self.fp.truncate(size)
-
-    def writable(self) -> bool:
-        return self.fp.writable()
-
-    def write(self, s: AnyStr) -> int:
-        return self.fp.write(s)
-
-    def writelines(self, lines: Iterable[AnyStr]) -> None:
-        self.fp.writelines(lines)
-
-    def __next__(self) -> AnyStr:
-        return next(self.fp)
-
-    def __iter__(self) -> Iterator[AnyStr]:
-        return iter(self.fp)
-
-    def __enter__(self) -> IO[AnyStr]:
-        return self.fp.__enter__()
-
-    def __exit__(
-        self,
-        t: Optional[Type[BaseException]],
-        value: Optional[BaseException],
-        traceback: Optional[TracebackType],
-    ) -> Optional[bool]:
-        return self.fp.__exit__(t, value, traceback)
-
-    # forward anything else too
-    def __getattr__(self, name):
-        return getattr(self.fp, name)
 
 
 def file_size(filelike):


### PR DESCRIPTION
@rabernat : a pickleable OpenFile in-a-context looks something like this, see what you think. Now entering `with` returns the OpenFile itself, which is now really file-like. It exists so that a chain of file-likes (compression, text...) can be closed in sequence at the right time. None of this affects what you get when you do a `fs.open()`, which objects are often pickleable (http, s3, local...), but this is not guaranteed.

Note that it breaks a couple of previous pickle tests, I will need to see whether the assumptions there are valid or not. Particularly, what should it mean to unpickle a "w"-mode file - naively, a new file gets opened with mode "w", invalidating the previous copy and truncating the file.