### PR TITLE
FIX: allow opening another file in TarFileSystem after one is closed.

### DIFF
--- a/fsspec/implementations/tar.py
+++ b/fsspec/implementations/tar.py
@@ -27,7 +27,7 @@ class TarFileSystem(AbstractArchiveFileSystem):
     protocol = "tar"
     cachable = False
 
-    _files_borrowing_fo: weakref.WeakSet["TarFileSystem"]
+    _files_borrowing_fo: "weakref.WeakSet[TarFileSystem]"
     _orig_fo: BinaryIO
     _compressor: Optional[Callable[[BinaryIO], BinaryIO]] = None
     _closer: Optional[Callable[[], None]] = None

--- a/fsspec/implementations/tar.py
+++ b/fsspec/implementations/tar.py
@@ -1,9 +1,9 @@
 import copy
+import io
 import logging
 import os
 import tarfile
 import weakref
-import io
 from typing import BinaryIO, Callable, Optional
 
 import fsspec
@@ -137,7 +137,8 @@ class TarFileSystem(AbstractArchiveFileSystem):
     def _open(self, path, mode="rb", **kwargs):
         if self._files_borrowing_fo:
             raise ValueError(
-                "underlying file object is borrowed by another file object and it cannot be shared"
+                "underlying file object is borrowed by another file "
+                "object and it cannot be shared"
             )
         if mode != "rb":
             raise ValueError("Read-only filesystem implementation")

--- a/fsspec/implementations/tests/test_tar.py
+++ b/fsspec/implementations/tests/test_tar.py
@@ -4,7 +4,7 @@ import tarfile
 import tempfile
 from io import BytesIO
 from pathlib import Path
-from typing import Dict
+from typing import Sequence, Tuple
 
 import pytest
 
@@ -204,39 +204,155 @@ def test_url_to_fs_cached(recipe, tmpdir):
 @pytest.mark.parametrize(
     "compression", ["", "gz", "bz2", "xz"], ids=["tar", "tar-gz", "tar-bz2", "tar-xz"]
 )
-def test_ls_with_folders(compression: str, tmp_path: Path):
-    """
-    Create a tar file that doesn't include the intermediate folder structure,
-    but make sure that the reading filesystem is still able to resolve the
-    intermediate folders, like the ZipFileSystem.
-    """
-    tar_data: Dict[str, bytes] = {
-        "a.pdf": b"Hello A!",
-        "b/c.pdf": b"Hello C!",
-        "d/e/f.pdf": b"Hello F!",
-        "d/g.pdf": b"Hello G!",
-    }
-    if compression:
-        temp_archive_file = tmp_path / f"test_tar_file.tar.{compression}"
-    else:
-        temp_archive_file = tmp_path / "test_tar_file.tar"
-    with open(temp_archive_file, "wb") as fd:
-        # We need to manually write the tarfile here, because temptar
-        # creates intermediate directories which is not how tars are always created
-        with tarfile.open(fileobj=fd, mode=f"w:{compression}") as tf:
-            for tar_file_path, data in tar_data.items():
-                content = data
-                info = tarfile.TarInfo(name=tar_file_path)
-                info.size = len(content)
-                tf.addfile(info, BytesIO(content))
-    with open(temp_archive_file, "rb") as fd:
-        fs = TarFileSystem(fd)
-        assert fs.find("/", withdirs=True) == [
-            "a.pdf",
-            "b/",
-            "b/c.pdf",
-            "d/",
-            "d/e/",
-            "d/e/f.pdf",
-            "d/g.pdf",
+class TestOperationsOnTarFile:
+    @pytest.fixture
+    def tar_file(self, compression: str, tmp_path: Path):
+        tar_data: Sequence[Tuple[str, bytes]] = [
+            ("a.pdf", b"Hello A!"),
+            ("b/c.pdf", b"Hello C!"),
+            ("d/e/f.pdf", b"Hello F!"),
+            ("d/g.pdf", b"Hello G!"),
         ]
+        if compression:
+            temp_archive_file = tmp_path / f"test_tar_file.tar.{compression}"
+        else:
+            temp_archive_file = tmp_path / "test_tar_file.tar"
+        with open(temp_archive_file, "wb") as fd:
+            # We need to manually write the tarfile here, because temptar
+            # creates intermediate directories which is not how tars are always created
+            with tarfile.open(fileobj=fd, mode=f"w:{compression}") as tf:
+                for tar_file_path, data in tar_data:
+                    content = data
+                    info = tarfile.TarInfo(name=tar_file_path)
+                    info.size = len(content)
+                    tf.addfile(info, BytesIO(content))
+        return temp_archive_file
+
+    def test_ls_with_folders(self, tar_file):
+        """
+        Open a tar file that doesn't include the intermediate folder structure,
+        but make sure that the reading filesystem is still able to resolve the
+        intermediate folders, like the ZipFileSystem.
+        """
+        with open(tar_file, "rb") as fd:
+            fs = TarFileSystem(fd)
+            assert fs.find("/", withdirs=True) == [
+                "a.pdf",
+                "b/",
+                "b/c.pdf",
+                "d/",
+                "d/e/",
+                "d/e/f.pdf",
+                "d/g.pdf",
+            ]
+
+    def test_open_files(self, tar_file):
+        """
+        Open a tar file as a filesystem, obtain file objects corresponding to some of
+        its members.
+
+        Make sure any consequences leading to close operation (e.g.  reference lost)
+        of the file object will not close the one bound to the filesystem where it
+        belongs.
+        """
+        with open(tar_file, "rb") as fd:
+            fs = TarFileSystem(fd)
+            f1 = fs.open("a.pdf")
+            f2 = fs.open("b/c.pdf")
+            f1.close()
+            f2.close()
+            f1 = fs.open("a.pdf")
+            f2 = fs.open("b/c.pdf")
+            f1.close()
+            f2.close()
+
+        with open(tar_file, "rb") as fd:
+            fs = TarFileSystem(fd)
+            f1 = fs.open("a.pdf")
+            del f1
+            f2 = fs.open("b/c.pdf")
+            del f2
+            f1 = fs.open("a.pdf")
+            del f1
+            f2 = fs.open("b/c.pdf")
+            del f2
+
+    def test_open_files_backed_by_in_memory_archive(self, tar_file):
+        """
+        Open a tar file backed by no OS-level file descriptor as a filesystem,
+        obtain file objects corresponding to some of its members.
+
+        Make sure any consequences leading to close operation (e.g. reference lost)
+        of the file object will not close the one bound to the filesystem where it
+        belongs.
+        """
+        fd = BytesIO(Path(tar_file).read_bytes())
+        fd.name = tar_file.name
+        fs = TarFileSystem(fd)
+
+        f1 = fs.open("a.pdf")
+        f1.close()
+        f2 = fs.open("b/c.pdf")
+        f2.close()
+        f1 = fs.open("a.pdf")
+        f1.close()
+        f2 = fs.open("b/c.pdf")
+        f2.close()
+
+        fd = BytesIO(Path(tar_file).read_bytes())
+        fd.name = tar_file.name
+        fs = TarFileSystem(fd)
+
+        f1 = fs.open("a.pdf")
+        del f1
+        f2 = fs.open("b/c.pdf")
+        del f2
+        f1 = fs.open("a.pdf")
+        del f1
+        f2 = fs.open("b/c.pdf")
+        del f2
+
+        fd = BytesIO(Path(tar_file).read_bytes())
+        fd.name = tar_file.name
+        fs = TarFileSystem(fd)
+
+        f1 = fs.open("a.pdf")
+        f2 = fs.open("b/c.pdf")
+        f1.close()
+        f2.close()
+        f1 = fs.open("a.pdf")
+        f2 = fs.open("b/c.pdf")
+        f1.close()
+        f2.close()
+
+    def test_open_files_backed_by_non_seekable(self, compression, tar_file):
+        """
+        Open a tar file backed by non-seekable file object, obtain file objects to
+        its members in the order those occur in the archive.
+
+        Make sure any consequences leading to close operation (e.g. reference lost)
+        of the file object will not close the one bound to the filesystem where it
+        belongs.
+        """
+        if compression in ("xz", "bz2"):
+            # skip the test because those compression methods require underlying file object to be seekable.
+            return
+
+        # should be able to open the files sequentially
+        fd = BytesIO(Path(tar_file).read_bytes())
+        fd.seekable = lambda: False
+        fd.name = tar_file.name
+        fs = TarFileSystem(fd)
+
+        fs.open("a.pdf")
+        fs.open("b/c.pdf")
+
+        # but not simultaneously
+        fd = BytesIO(Path(tar_file).read_bytes())
+        fd.seekable = lambda: False
+        fd.name = tar_file.name
+        fs = TarFileSystem(fd)
+
+        f1 = fs.open("a.pdf")
+        with pytest.raises(ValueError):
+            fs.open("b/c.pdf")

--- a/fsspec/implementations/tests/test_tar.py
+++ b/fsspec/implementations/tests/test_tar.py
@@ -335,7 +335,8 @@ class TestOperationsOnTarFile:
         belongs.
         """
         if compression in ("xz", "bz2"):
-            # skip the test because those compression methods require underlying file object to be seekable.
+            # skip the test because those compression methods require underlying
+            # file object to be seekable.
             return
 
         # should be able to open the files sequentially
@@ -353,6 +354,6 @@ class TestOperationsOnTarFile:
         fd.name = tar_file.name
         fs = TarFileSystem(fd)
 
-        f1 = fs.open("a.pdf")
+        fs.open("a.pdf")
         with pytest.raises(ValueError):
             fs.open("b/c.pdf")


### PR DESCRIPTION
## Background

The current TarFileSystem implementation handles the underlying file object in a naive approach, and because of that, it fails to open another archive member after one gets closed as the file object that corresponds to the member in question shares the same file object as the filesystem and it eventually closes it afterwards.

## The fix

To correctly fix this, one should at least try to get the file object that underlies the member file object cloned before it gets passed to the constructor.  In case the backing file object is a stream, of course it's infeasible. The one should then have to share it between the filesystem and the member file object and also prevent it from being shared with another member file object.
