### PR TITLE
fix dircache iter changing size (#987)

### DIFF
--- a/fsspec/dircache.py
+++ b/fsspec/dircache.py
@@ -87,7 +87,9 @@ class DirCache(MutableMapping):
         del self._cache[key]
 
     def __iter__(self):
-        return (k for k in self._cache if k in self)
+        entries = list(self._cache)
+
+        return (k for k in entries if k in self)
 
     def __reduce__(self):
         return (


### PR DESCRIPTION
This fixes #987, by putting the cache keys into a list. Happy to change if a better approach would work!

I'm not able to get the tests running locally with tox, but also don't have a ton of experience with it 😬 (can try it out a bit more...)