### PR TITLE
Don't autoclose OpenFile - user must do it

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -121,10 +121,6 @@ class OpenFile:
     def __exit__(self, *args):
         self.close()
 
-    def __del__(self):
-        if hasattr(self, "fobjects"):
-            self.close()
-
     @property
     def full_name(self):
         return _unstrip_protocol(self.path, self.fs)

--- a/fsspec/implementations/tests/test_arrow.py
+++ b/fsspec/implementations/tests/test_arrow.py
@@ -108,7 +108,7 @@ def test_rm(fs, remote_dir):
     fs.touch(remote_dir + "/dir/a")
     fs.touch(remote_dir + "/dir/b")
     fs.mkdir(remote_dir + "/dir/c/")
-    fs.touch(remote_dir + "/dir/c/a/")
+    fs.touch(remote_dir + "/dir/c/a")
     fs.rm(remote_dir + "/dir", recursive=True)
     assert not fs.exists(remote_dir + "/dir")
 


### PR DESCRIPTION
Only affects those using OpenFile.open(), which already has caveats.

Fixes #1032 