### PR TITLE
asyncfs: allow disabling mirroring sync methods

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -307,6 +307,7 @@ class AsyncFileSystem(AbstractFileSystem):
     # for _* methods and inferred for overridden methods.
 
     async_impl = True
+    mirror_sync_methods = True
     disable_throttling = False
 
     def __init__(self, *args, asynchronous=False, loop=None, batch_size=None, **kwargs):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -78,7 +78,7 @@ class _Cached(type):
             obj._fs_token_ = token
             obj.storage_args = args
             obj.storage_options = kwargs
-            if obj.async_impl:
+            if obj.async_impl and obj.mirror_sync_methods:
                 from .asyn import mirror_sync_methods
 
                 mirror_sync_methods(obj)
@@ -104,6 +104,7 @@ class AbstractFileSystem(metaclass=_Cached):
     protocol = "abstract"
     _latest = None
     async_impl = False
+    mirror_sync_methods = False
     root_marker = ""  # For some FSs, may require leading '/' or other character
 
     #: Extra *class attributes* that should be considered when hashing.

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -14,7 +14,18 @@ def test_sync_methods():
     inst = fsspec.asyn.AsyncFileSystem()
     assert inspect.iscoroutinefunction(inst._info)
     assert hasattr(inst, "info")
+    assert inst.info.__qualname__ == "AsyncFileSystem._info"
     assert not inspect.iscoroutinefunction(inst.info)
+
+
+def test_when_sync_methods_are_disabled():
+    class TestFS(fsspec.asyn.AsyncFileSystem):
+        mirror_sync_methods = False
+
+    inst = TestFS()
+    assert inspect.iscoroutinefunction(inst._info)
+    assert not inspect.iscoroutinefunction(inst.info)
+    assert inst.info.__qualname__ == "AbstractFileSystem.info"
 
 
 def test_interrupt():


### PR DESCRIPTION
In [`AsyncLocalFileSystem`](https://github.com/iterative/morefs/blob/fe9e3ffece423a3fa527b118162cde5a601cd12c/src/morefs/asyn_local.py#L31), I want to fallback to fsspec's `LocalFileSystem` for sync methods, but the current architecture don't allow that.

I am proposing `mirror_sync_methods = True | False` to disable this mirroring and fallback to `AbstractFileSystem`'s behaviour. This would allow me to fallback to `LocalFileSystem` for sync methods instead of a generated ones.
It does feel a bit hacky, so suggestions are welcome. :)

Currently, what I am doing is something like this:
```python
class AsyncLocalFileSystem(AsyncFileSystem, LocalFileSystem):
    async_impl = False
```
