### PR TITLE
localfs: fix support for pathlib/os.PathLike objects in rm

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -142,7 +142,7 @@ class LocalFileSystem(AbstractFileSystem):
         os.remove(path)
 
     def rm(self, path, recursive=False, maxdepth=None):
-        if isinstance(path, str):
+        if not isinstance(path, list):
             path = [path]
 
         for p in path:


### PR DESCRIPTION
This fixes support for `pathlib.Path` objects in `rm`.
```python
from fsspec import filesystem
from pathlib import Path

fs = filesystem("file")
fs.rm(Path("file"))
```