### PR TITLE
localfs: add link/symlink/islink methods

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -138,6 +138,19 @@ class LocalFileSystem(AbstractFileSystem):
         path2 = self._strip_protocol(path2).rstrip("/")
         shutil.move(path1, path2)
 
+    def link(self, src, dst, **kwargs):
+        src = self._strip_protocol(src)
+        dst = self._strip_protocol(dst)
+        os.link(src, dst, **kwargs)
+
+    def symlink(self, src, dst, **kwargs):
+        src = self._strip_protocol(src)
+        dst = self._strip_protocol(dst)
+        os.symlink(src, dst, **kwargs)
+
+    def islink(self, path) -> bool:
+        return os.path.islink(self._strip_protocol(path))
+
     def rm_file(self, path):
         os.remove(path)
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -785,3 +785,25 @@ def test_numpy_fromfile(tmpdir):
     arr = np.arange(10, dtype=dt)
     arr.tofile(fn)
     assert np.array_equal(np.fromfile(fn, dtype=dt), arr)
+
+
+def test_link(tmpdir):
+    target = os.path.join(tmpdir, "target")
+    link = os.path.join(tmpdir, "link")
+
+    fs = LocalFileSystem()
+    fs.touch(target)
+
+    fs.link(target, link)
+    assert fs.info(link)["nlink"] > 1
+
+
+def test_symlink(tmpdir):
+    target = os.path.join(tmpdir, "target")
+    link = os.path.join(tmpdir, "link")
+
+    fs = LocalFileSystem()
+    fs.touch(target)
+
+    fs.symlink(target, link)
+    assert fs.islink(link)


### PR DESCRIPTION
This PR adds `link`/`symlink` APIs to create hardlink/symlink, and `islink` to check for symlinks.
The APIs mirror what we have in `os` and `os.path`.

There are some open questions about APIs. In DVC, we use `hardlink()`, `symlink()` and `is_symlink()` APIs which I find to be much better, but I went with other APIs to be consistent with python. Python has not been very consistent though ([`Path.is_symlink()`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.is_symlink), [`Path.symlink_to`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.symlink_to), [`Path.hardlink_to`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.hardlink_to), etc).

Also, do we need these APIs in `AbstractFileSystem`?