### PR TITLE
registry: add asynclocalfs to the registry

### DIFF
--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -145,6 +145,10 @@ known_implementations = {
         "class": "ocifs.OCIFileSystem",
         "err": "Install ocifs to access OCI Object Storage",
     },
+    "asynclocalfs": {
+        "class": "morefs.asyn_local.AsyncLocalFileSystem",
+        "err": "Install 'morefs[asynclocalfs]' to use AsyncLocalFileSystem",
+    },
     "adl": {
         "class": "adlfs.AzureDatalakeFileSystem",
         "err": "Install adlfs to access Azure Datalake Gen1",

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -145,7 +145,7 @@ known_implementations = {
         "class": "ocifs.OCIFileSystem",
         "err": "Install ocifs to access OCI Object Storage",
     },
-    "asynclocalfs": {
+    "asynclocal": {
         "class": "morefs.asyn_local.AsyncLocalFileSystem",
         "err": "Install 'morefs[asynclocalfs]' to use AsyncLocalFileSystem",
     },


### PR DESCRIPTION
We need a new fsspec release to take advantage of disabled-mirroring for faster sync methods in [`AsyncLocalFileSystem`](https://github.com/iterative/morefs/blob/619809fc7d275215416c804704b17723c03ad808/src/morefs/asyn_local.py), but I think we can add it to the registry even without it (I also need to make a release there). :)

Closes #1052.
