### PR TITLE
Reference improvements

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -438,7 +438,14 @@ class AsyncFileSystem(AbstractFileSystem):
             return out[0]
 
     async def _cat_ranges(
-        self, paths, starts, ends, max_gap=None, batch_size=None, **kwargs
+        self,
+        paths,
+        starts,
+        ends,
+        max_gap=None,
+        batch_size=None,
+        on_error="return",
+        **kwargs,
     ):
         # TODO: on_error
         if max_gap is not None:
@@ -457,7 +464,9 @@ class AsyncFileSystem(AbstractFileSystem):
             for p, s, e in zip(paths, starts, ends)
         ]
         batch_size = batch_size or self.batch_size
-        return await _run_coros_in_chunks(coros, batch_size=batch_size, nofiles=True)
+        return await _run_coros_in_chunks(
+            coros, batch_size=batch_size, nofiles=True, return_exceptions=True
+        )
 
     async def _put_file(self, lpath, rpath, **kwargs):
         raise NotImplementedError

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -383,3 +383,24 @@ def test_merging(m):
     )
     out = fs.cat(["a", "b", "c", "d"])
     assert out == {"a": b"e", "b": b"s", "c": other, "d": other[4:10]}
+
+
+def test_cat_file_ranges(m):
+    other = b"other test data"
+    m.pipe("/b", other)
+    fs = fsspec.filesystem(
+        "reference",
+        fo={
+            "c": ["memory://b"],
+            "d": ["memory://b", 4, 6],
+        },
+    )
+    assert fs.cat_file("c") == other
+    assert fs.cat_file("c", start=1) == other[1:]
+    assert fs.cat_file("c", start=-5) == other[-5:]
+    assert fs.cat_file("c", 1, -5) == other[1:-5]
+
+    assert fs.cat_file("d") == other[4:10]
+    assert fs.cat_file("d", start=1) == other[4:10][1:]
+    assert fs.cat_file("d", start=-5) == other[4:10][-5:]
+    assert fs.cat_file("d", 1, -3) == other[4:10][1:-3]

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -366,3 +366,19 @@ def test_fss_has_defaults(m):
 
     fs = fsspec.filesystem("reference", fo={"key": ["memory://a"], "blah": ["path"]})
     assert fs.fss[None] is fs.fss["memory"]
+
+
+def test_merging(m):
+    m.pipe("/a", b"test data")
+    m.pipe("/b", b"other test data")
+    fs = fsspec.filesystem(
+        "reference",
+        fo={
+            "a": ["memory://a", 1, 1],
+            "b": ["memory://a", 2, 1],
+            "c": ["memory://b"],
+            "d": ["memory://b", 4, 6],
+        },
+    )
+    out = fs.cat(["a", "b", "c"])
+    assert out == {"a": b"e", "b": b"s", "c": b"other test data"}

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -370,7 +370,8 @@ def test_fss_has_defaults(m):
 
 def test_merging(m):
     m.pipe("/a", b"test data")
-    m.pipe("/b", b"other test data")
+    other = b"other test data"
+    m.pipe("/b", other)
     fs = fsspec.filesystem(
         "reference",
         fo={
@@ -380,5 +381,5 @@ def test_merging(m):
             "d": ["memory://b", 4, 6],
         },
     )
-    out = fs.cat(["a", "b", "c"])
-    assert out == {"a": b"e", "b": b"s", "c": b"other test data"}
+    out = fs.cat(["a", "b", "c", "d"])
+    assert out == {"a": b"e", "b": b"s", "c": other, "d": other[4:10]}

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -745,7 +745,9 @@ class AbstractFileSystem(metaclass=_Cached):
         else:
             raise ValueError("path must be str or dict")
 
-    def cat_ranges(self, paths, starts, ends, max_gap=None, **kwargs):
+    def cat_ranges(
+        self, paths, starts, ends, max_gap=None, on_error="return", **kwargs
+    ):
         if max_gap is not None:
             raise NotImplementedError
         if not isinstance(paths, list):
@@ -756,7 +758,16 @@ class AbstractFileSystem(metaclass=_Cached):
             ends = [starts] * len(paths)
         if len(starts) != len(paths) or len(ends) != len(paths):
             raise ValueError
-        return [self.cat_file(p, s, e) for p, s, e in zip(paths, starts, ends)]
+        out = []
+        for p, s, e in zip(paths, starts, ends):
+            try:
+                out.append(self.cat_file(p, s, e))
+            except Exception as e:
+                if False:  # on_error == "return":
+                    out.append(e)
+                else:
+                    raise
+        return out
 
     def cat(self, path, recursive=False, on_error="raise", **kwargs):
         """Fetch (potentially multiple) paths' contents

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -496,7 +496,6 @@ def merge_offset_ranges(paths, starts, ends, max_gap=0, max_block=None, sort=Tru
     order. If the user can guarantee that the inputs are already
     sorted, passing `sort=False` will skip the re-ordering.
     """
-
     # Check input
     if not isinstance(paths, list):
         raise TypeError


### PR DESCRIPTION
- rationalise use of the .fss attribute and how sets of filesystems are passed in
- allow start/end positions to be passed to cat_file
- optionally merge concurrent requests in the same file if they are close enough together, like in fsspec.parquet.