### PR TITLE
avoid ESA snappy

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -140,7 +140,7 @@ try:
     # standard implementation.
     register_compression("snappy", SnappyFile, [])
 
-except (ImportError, NameError):
+except (ImportError, NameError, AttributeError):
     pass
 
 try:


### PR DESCRIPTION
This patch avoids an error if one has the European Space Agency (ESA) snappy ( https://senbox.atlassian.net/wiki/spaces/SNAP/pages/19300362/How+to+use+the+SNAP+API+from+Python ) instead of the snappy compression library. 