### PR TITLE
Add topdown kwarg to AbstractFileSystem.walk()

### DIFF
--- a/fsspec/implementations/tests/test_archive.py
+++ b/fsspec/implementations/tests/test_archive.py
@@ -301,7 +301,8 @@ class TestAnyArchive:
             assert fs.find("deeply") == ["deeply/nested/path"]
             assert fs.find("deeply/") == fs.find("deeply")
 
-    def test_walk(self, scenario: ArchiveTestScenario):
+    @pytest.mark.parametrize("topdown", [True, False])
+    def test_walk(self, scenario: ArchiveTestScenario, topdown):
         with scenario.provider(archive_data) as archive:
             fs = fsspec.filesystem(scenario.protocol, fo=archive)
             expected = [
@@ -310,7 +311,9 @@ class TestAnyArchive:
                 ("deeply", ["nested"], []),
                 ("deeply/nested", [], ["path"]),
             ]
-            for lhs, rhs in zip(fs.walk(""), expected):
+            if not topdown:
+                expected.reverse()
+            for lhs, rhs in zip(fs.walk("", topdown=topdown), expected):
                 assert lhs[0] == rhs[0]
                 assert sorted(lhs[1]) == sorted(rhs[1])
                 assert sorted(lhs[2]) == sorted(rhs[2])


### PR DESCRIPTION
This PR adds a new boolean kwarg `topdown` to `AbstractFileSystem.walk()`. Closes #1042.

I have extended the existing `test_walk` to cover both `topdown=True` and `topdown=False`. 

Code produces the same output as `os.walk` which I have manually verified. I'll reproduce my test here in case it is of interest to anyone else.

Test directory structure:
```
$ cd ~/Desktop/temp && mkdir -p a/c/e a/d b && touch a/a0 b/b0 a/c/c0 a/d/d0 a/c/e/e0
$ tree 
# .
# ├── a
# │   ├── a0
# │   ├── c
# │   │   ├── c0
# │   │   └── e
# │   │       └── e0
# │   └── d
# │       └── d0
# └── b
#     └── b0
```

Test code:
```python
import fsspec
import os

directory = "/Users/iant/Desktop/temp"
fs = fsspec.filesystem('file')

for topdown in [True, False]:
    for lib, name in zip([fs, os], ["fsspec", "os"]):
        print(f"topdown={topdown} {name}")
        for paths, dirs, files in lib.walk(directory, topdown=topdown):
            print(f"  paths={paths} dirs={dirs} files={files}")
```

Output:
```
$ python test.py 
topdown=True fsspec
  paths=/Users/iant/Desktop/temp dirs=['a', 'b'] files=[]
  paths=/Users/iant/Desktop/temp/a dirs=['c', 'd'] files=['a0']
  paths=/Users/iant/Desktop/temp/a/c dirs=['e'] files=['c0']
  paths=/Users/iant/Desktop/temp/a/c/e dirs=[] files=['e0']
  paths=/Users/iant/Desktop/temp/a/d dirs=[] files=['d0']
  paths=/Users/iant/Desktop/temp/b dirs=[] files=['b0']
topdown=True os
  paths=/Users/iant/Desktop/temp dirs=['a', 'b'] files=[]
  paths=/Users/iant/Desktop/temp/a dirs=['c', 'd'] files=['a0']
  paths=/Users/iant/Desktop/temp/a/c dirs=['e'] files=['c0']
  paths=/Users/iant/Desktop/temp/a/c/e dirs=[] files=['e0']
  paths=/Users/iant/Desktop/temp/a/d dirs=[] files=['d0']
  paths=/Users/iant/Desktop/temp/b dirs=[] files=['b0']
topdown=False fsspec
  paths=/Users/iant/Desktop/temp/a/c/e dirs=[] files=['e0']
  paths=/Users/iant/Desktop/temp/a/c dirs=['e'] files=['c0']
  paths=/Users/iant/Desktop/temp/a/d dirs=[] files=['d0']
  paths=/Users/iant/Desktop/temp/a dirs=['c', 'd'] files=['a0']
  paths=/Users/iant/Desktop/temp/b dirs=[] files=['b0']
  paths=/Users/iant/Desktop/temp dirs=['a', 'b'] files=[]
topdown=False os
  paths=/Users/iant/Desktop/temp/a/c/e dirs=[] files=['e0']
  paths=/Users/iant/Desktop/temp/a/c dirs=['e'] files=['c0']
  paths=/Users/iant/Desktop/temp/a/d dirs=[] files=['d0']
  paths=/Users/iant/Desktop/temp/a dirs=['c', 'd'] files=['a0']
  paths=/Users/iant/Desktop/temp/b dirs=[] files=['b0']
  paths=/Users/iant/Desktop/temp dirs=['a', 'b'] files=[]
```