### PR TITLE
Implement recursive parameter in the get method of SFTP 

### DIFF
--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -1,9 +1,8 @@
 import datetime
 import logging
+import os
 import types
 import uuid
-import os
-from pathlib import Path
 from stat import S_ISDIR, S_ISLNK
 
 import paramiko

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -131,30 +131,11 @@ class SFTPFileSystem(AbstractFileSystem):
         logger.debug("Put file %s into %s" % (lpath, rpath))
         self.ftp.put(lpath, rpath)
 
-    def get(self, rpath, lpath, callback=None, **kwargs):
-        # parse rpath if needed
-        if ":" in rpath:
-            rpath = rpath.split(":")[-1]  # remove protocol and host part
-            if rpath[0] != "/":
-                rpath = "/" + rpath.partition("/")[-1]  # remove port if any
-
-        if "recursive" in kwargs and self.isdir(rpath):
-            Path(lpath).mkdir(parents=True, exist_ok=True)
-            for sub in self.ftp.listdir(rpath):
-                self.get(
-                    os.path.join(rpath, sub),
-                    os.path.join(lpath, sub),
-                    callback=callback,
-                    **kwargs,
-                )
+    def get_file(self, rpath, lpath, **kwargs):
+        if self.isdir(rpath):
+            os.makedirs(lpath, exist_ok=True)
         else:
-            if lpath == ".":
-                raise Exception(
-                    "Cannot download '%s' to '.', have you forget to set recursive parameter?"
-                    % rpath
-                )
-            logger.debug("Get file %s into %s" % (rpath, lpath))
-            self.ftp.get(rpath, lpath)
+            self.ftp.get(self._strip_protocol(rpath), lpath)
 
     def _open(self, path, mode="rb", block_size=None, **kwargs):
         """

--- a/fsspec/implementations/tests/test_sftp.py
+++ b/fsspec/implementations/tests/test_sftp.py
@@ -93,6 +93,21 @@ def test_with_url(protocol, ssh):
         assert f.read() == b"hello"
 
 
+@pytest.mark.parametrize("protocol", ["sftp", "ssh"])
+def test_get_dir(protocol, ssh, root_path):
+    f = fsspec.get_filesystem_class(protocol)(**ssh)
+    f.mkdirs(root_path + "deeper", exist_ok=True)
+    f.touch(root_path + "deeper/afile")
+    f.get(root_path + "deeper", ".", recursive=True)
+
+    f.get(
+        protocol + "://{username}:{password}@{host}:{port}"
+        "{root_path}deeper".format(root_path=root_path, **ssh),
+        ".",
+        recursive=True,
+    )
+
+
 @pytest.fixture(scope="module")
 def netloc(ssh):
     username = ssh.get("username")

--- a/fsspec/implementations/tests/test_sftp.py
+++ b/fsspec/implementations/tests/test_sftp.py
@@ -2,6 +2,7 @@ import shlex
 import subprocess
 import time
 from tarfile import TarFile
+import os
 
 import pytest
 
@@ -98,14 +99,20 @@ def test_get_dir(protocol, ssh, root_path):
     f = fsspec.filesystem(protocol, **ssh)
     f.mkdirs(root_path + "deeper", exist_ok=True)
     f.touch(root_path + "deeper/afile")
-    f.get(root_path + "deeper", ".", recursive=True)
+    f.get(root_path, ".", recursive=True)
+
+    assert os.path.isdir("./deeper")
+    assert os.path.isfile("./deeper/afile")
 
     f.get(
         protocol + "://{username}:{password}@{host}:{port}"
-        "{root_path}deeper".format(root_path=root_path, **ssh),
-        ".",
+        "{root_path}".format(root_path=root_path, **ssh),
+        "./test2",
         recursive=True,
     )
+
+    assert os.path.isdir("./test2/deeper")
+    assert os.path.isfile("./test2/deeper/afile")
 
 
 @pytest.fixture(scope="module")

--- a/fsspec/implementations/tests/test_sftp.py
+++ b/fsspec/implementations/tests/test_sftp.py
@@ -1,8 +1,8 @@
+import os
 import shlex
 import subprocess
 import time
 from tarfile import TarFile
-import os
 
 import pytest
 

--- a/fsspec/implementations/tests/test_sftp.py
+++ b/fsspec/implementations/tests/test_sftp.py
@@ -95,7 +95,7 @@ def test_with_url(protocol, ssh):
 
 @pytest.mark.parametrize("protocol", ["sftp", "ssh"])
 def test_get_dir(protocol, ssh, root_path):
-    f = fsspec.get_filesystem_class(protocol)(**ssh)
+    f = fsspec.filesystem(protocol, **ssh)
     f.mkdirs(root_path + "deeper", exist_ok=True)
     f.touch(root_path + "deeper/afile")
     f.get(root_path + "deeper", ".", recursive=True)


### PR DESCRIPTION
Current implementation does not support downloading directories recursively in the get method. Unfortunately, this is what prefect.io is doing so that prefect agent is crashing when using SFTP storage block. 

I've implemented a simple recursive downloading as well as a test for this case.

Also, prefect is passing a URL to this method, not the remote FTP path, so that I've added URL parsing to this method too. I am not sure if this URL parsing should be added to all other methods of the class too, so I've tried to keep changes to a bare minimum required for Prefect to work.