### PR TITLE
Pin docutils so that sphinx renders lists correctly

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,4 +3,5 @@ channels:
   - defaults
 dependencies:
   - python=3.9
+  - docutils<0.17
   - numpydoc


### PR DESCRIPTION
Fixes #1083. Pins `docutils` so that sphinx correctly renders lists.