### PR TITLE
Support append mode for ArrowFSWrapper

### DIFF
--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -149,6 +149,8 @@ class ArrowFSWrapper(AbstractFileSystem):
             method = self.fs.open_input_stream
         elif mode == "wb":
             method = self.fs.open_output_stream
+        elif mode == "ab":
+            method = self.fs.open_append_stream
         else:
             raise ValueError(f"unsupported mode for Arrow filesystem: {mode!r}")
 

--- a/fsspec/implementations/tests/test_arrow.py
+++ b/fsspec/implementations/tests/test_arrow.py
@@ -181,3 +181,16 @@ def test_open_rw_flush(fs, remote_dir):
 
     with fs.open(remote_dir + "/b.txt", "rb") as stream:
         assert stream.read() == data * 400
+
+
+def test_open_append(fs, remote_dir):
+    data = b"dvc.org"
+
+    with fs.open(remote_dir + "/a.txt", "wb") as stream:
+        stream.write(data)
+
+    with fs.open(remote_dir + "/a.txt", "ab") as stream:
+        stream.write(data)
+
+    with fs.open(remote_dir + "/a.txt") as stream:
+        assert stream.read() == 2 * data


### PR DESCRIPTION
This PR adds support append mode for ArrowFSWrapper.

https://github.com/apache/arrow/blob/apache-arrow-1.0.0/python/pyarrow/_fs.pyx#L673

It seems that from v1.0.0, pyarrow supports `open_append_stream`.