### PR TITLE
Add an optional 'seekable' argument for `ArrowFileSystem` to open as file, rather than stream.

### DIFF
--- a/fsspec/implementations/tests/test_arrow.py
+++ b/fsspec/implementations/tests/test_arrow.py
@@ -194,3 +194,14 @@ def test_open_append(fs, remote_dir):
 
     with fs.open(remote_dir + "/a.txt") as stream:
         assert stream.read() == 2 * data
+
+
+def test_open_seekable(fs, remote_dir):
+    data = b"dvc.org"
+
+    with fs.open(remote_dir + "/a.txt", "wb") as stream:
+        stream.write(data)
+
+    with fs.open(remote_dir + "/a.txt", "rb", seekable=True) as file:
+        file.seek(2)
+        assert file.read() == data[2:]


### PR DESCRIPTION
Actually HDFS does support `seek` operation and it is useful for partial reading / chunk reading.

This pull request add a `seekable` argument to `_open()` in `ArrowFSWrapper` (default to `False` to keep a compatible behaviour) and expose the `.size()` method on pyarrow's `NativeFile` as well (see https://arrow.apache.org/docs/python/generated/pyarrow.NativeFile.html#pyarrow.NativeFile.size)