### PR TITLE
Add missing await statement to GenericFileSystem._cp_file

### DIFF
--- a/fsspec/generic.py
+++ b/fsspec/generic.py
@@ -170,7 +170,7 @@ class GenericFileSystem(AsyncFileSystem):
                 if hasattr(fs, "open_async")
                 else fs.open(url, "rb", **kw)
             )
-            callback.set_size(maybe_await(f1.size))
+            callback.set_size(await maybe_await(f1.size))
             f2 = (
                 await fs2.open_async(url2, "wb")
                 if hasattr(fs2, "open_async")


### PR DESCRIPTION
### Reference Issues/PRs
Closes #1093 

### What did you change/fix?
The function _cp_file of GenericFileSystem was missing an await statement for an asynchronous function. This PR adds the missing await statement.