### PR TITLE
Add yarl to readthedocs dependencies

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - python=3.9
   - docutils<0.17
   - numpydoc
+  - yarl


### PR DESCRIPTION
Fixes #1090.

I've opted for the simplest change which is to explicitly add `yarl` to the list of dependencies for the readthedocs build.

There is another possibility which is to use a more complicated readthedocs build that follows the usual package build process so that the package and docs dependencies cannot get out of sync, but this would be a much bigger change that should probably be part of a longer-term strategy. Such an approach might also want to include building the docs explicitly as part of CI so that docs failures are reported directly as CI failures.