### PR TITLE
Route LocalFileSystem.put to LocalFileSystem.cp

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import stat
 import tempfile
+import warnings
 
 from fsspec import AbstractFileSystem
 from fsspec.compression import compr
@@ -132,6 +133,13 @@ class LocalFileSystem(AbstractFileSystem):
 
     def put_file(self, path1, path2, callback=None, **kwargs):
         return self.cp_file(path1, path2, **kwargs)
+
+    def put(self, lpath, rpath, **kwargs):
+        if kwargs.pop("callback", None):
+            warnings.warn(
+                f"'callback' kwarg is ignored by {self.__class__.__name__}.put()"
+            )
+        self.cp(lpath, rpath, **kwargs)
 
     def mv_file(self, path1, path2, **kwargs):
         path1 = self._strip_protocol(path1).rstrip("/")


### PR DESCRIPTION
This is a work in progress to fix #967.

`LocalFileSystem.put` calls `LocalFileSystem.cp` as they are essentially the same thing. I am checking for a `callback` kwarg as `put` accepts it but `cp` doesn't, then removing it from the kwargs and warning the user. Alternatively it might be acceptable to pass it through anyway, or indeed raise an exception.

Strictly speaking the signature of `put` in the abstract base class allows for `callback` to be the third positional arg, whereas I am assuming it is always a kwarg here. This may or may not be a problem?

There is a question of where to the tests for this.