### PR TITLE
Strip protocol in arrowfs.ls and add tests for calling arrowfs with protocol

### DIFF
--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -59,6 +59,7 @@ class ArrowFSWrapper(AbstractFileSystem):
         return path
 
     def ls(self, path, detail=False, **kwargs):
+        path = self._strip_protocol(path)
         from pyarrow.fs import FileSelector
 
         entries = [


### PR DESCRIPTION
Fixed stripping protocol in `ArrowFsWrapper.ls`.
Also, all tests for arrowfs will run twice now, one with protocol and one without.
