### PR TITLE
speedup FSMap._key_to_str

### DIFF
--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -134,6 +134,8 @@ class FSMap(MutableMapping):
             if isinstance(key, list):
                 key = tuple(key)
             key = str(key)
+        if ":" in key and "://" in key:
+            raise ValueError(f"keys must not contain protocols, got: {key!r}")
         return f"{self._root_prefix}{key}"
 
     def _str_to_key(self, s):

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -1,5 +1,6 @@
 import array
 import os.path
+import warnings
 from collections.abc import MutableMapping
 
 from .core import url_to_fs
@@ -122,6 +123,15 @@ class FSMap(MutableMapping):
 
     def _key_to_str(self, key):
         """Generate full path for the key"""
+        if not isinstance(key, str):
+            # raise TypeError("key must be of type `str`, got `{type(key).__name__}`"
+            warnings.warn(
+                "from fsspec 2023.5 onward FSMap non-str keys will raise TypeError,"
+                f" got: {key!r} of type `{type(key).__name__}`",
+                FutureWarning,
+                stacklevel=2,
+            )
+            key = str(key)
         return f"{self._root_prefix}{key}"
 
     def _str_to_key(self, s):

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -126,7 +126,7 @@ class FSMap(MutableMapping):
             warnings.warn(
                 "from fsspec 2023.5 onward FSMap non-str keys will raise TypeError,"
                 f" got: {key!r} of type `{type(key).__name__}`",
-                FutureWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
             if isinstance(key, list):

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -1,4 +1,5 @@
 import array
+import os.path
 from collections.abc import MutableMapping
 
 from .core import url_to_fs
@@ -37,6 +38,7 @@ class FSMap(MutableMapping):
         self.root = fs._strip_protocol(root).rstrip(
             "/"
         )  # we join on '/' in _key_to_str
+        self._root_prefix = fs._strip_protocol(os.path.join(root, "x"))[:-1]
         if missing_exceptions is None:
             missing_exceptions = (
                 FileNotFoundError,
@@ -120,11 +122,7 @@ class FSMap(MutableMapping):
 
     def _key_to_str(self, key):
         """Generate full path for the key"""
-        if isinstance(key, (tuple, list)):
-            key = str(tuple(key))
-        else:
-            key = str(key)
-        return self.fs._strip_protocol("/".join([self.root, key]) if self.root else key)
+        return f"{self._root_prefix}{key}"
 
     def _str_to_key(self, s):
         """Strip path of to leave key name"""

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -131,6 +131,8 @@ class FSMap(MutableMapping):
                 FutureWarning,
                 stacklevel=2,
             )
+            if isinstance(key, list):
+                key = tuple(key)
             key = str(key)
         return f"{self._root_prefix}{key}"
 

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -1,5 +1,5 @@
 import array
-import os.path
+import posixpath
 import warnings
 from collections.abc import MutableMapping
 
@@ -37,7 +37,7 @@ class FSMap(MutableMapping):
     def __init__(self, root, fs, check=False, create=False, missing_exceptions=None):
         self.fs = fs
         self.root = fs._strip_protocol(root).rstrip("/")
-        self._root_key_to_str = fs._strip_protocol(os.path.join(root, "x"))[:-1]
+        self._root_key_to_str = fs._strip_protocol(posixpath.join(root, "x"))[:-1]
         if missing_exceptions is None:
             missing_exceptions = (
                 FileNotFoundError,

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -124,10 +124,8 @@ class FSMap(MutableMapping):
         if not isinstance(key, str):
             # raise TypeError("key must be of type `str`, got `{type(key).__name__}`"
             warnings.warn(
-                "from fsspec 2023.5 onward FSMap non-str keys will raise TypeError,"
-                f" got: {key!r} of type `{type(key).__name__}`",
+                "from fsspec 2023.5 onward FSMap non-str keys will raise TypeError",
                 DeprecationWarning,
-                stacklevel=2,
             )
             if isinstance(key, list):
                 key = tuple(key)

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -1,6 +1,5 @@
 import array
 import os.path
-import platform
 import warnings
 from collections.abc import MutableMapping
 
@@ -40,15 +39,12 @@ class FSMap(MutableMapping):
         self.root = fs._strip_protocol(root).rstrip("/")
         self._root_key_to_str = fs._strip_protocol(os.path.join(root, "x"))[:-1]
         if missing_exceptions is None:
-            missing_exceptions = [
+            missing_exceptions = (
                 FileNotFoundError,
                 IsADirectoryError,
                 NotADirectoryError,
-            ]
-            if platform.system() == "Windows":
-                # see: https://bugs.python.org/issue43095
-                missing_exceptions.append(PermissionError)
-        self.missing_exceptions = tuple(missing_exceptions)
+            )
+        self.missing_exceptions = missing_exceptions
         self.check = check
         self.create = create
         if create:

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -132,8 +132,6 @@ class FSMap(MutableMapping):
             if isinstance(key, list):
                 key = tuple(key)
             key = str(key)
-        if ":" in key and "://" in key:
-            raise ValueError(f"keys must not contain protocols, got: {key!r}")
         return f"{self._root_key_to_str}{key}"
 
     def _str_to_key(self, s):

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -1,5 +1,6 @@
 import array
 import os.path
+import platform
 import warnings
 from collections.abc import MutableMapping
 
@@ -41,12 +42,15 @@ class FSMap(MutableMapping):
         )  # we join on '/' in _key_to_str
         self._root_prefix = fs._strip_protocol(os.path.join(root, "x"))[:-1]
         if missing_exceptions is None:
-            missing_exceptions = (
+            missing_exceptions = [
                 FileNotFoundError,
                 IsADirectoryError,
                 NotADirectoryError,
-            )
-        self.missing_exceptions = missing_exceptions
+            ]
+            if platform.system() == "Windows":
+                # see: https://bugs.python.org/issue43095
+                missing_exceptions.append(PermissionError)
+        self.missing_exceptions = tuple(missing_exceptions)
         self.check = check
         self.create = create
         if create:

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -37,10 +37,8 @@ class FSMap(MutableMapping):
 
     def __init__(self, root, fs, check=False, create=False, missing_exceptions=None):
         self.fs = fs
-        self.root = fs._strip_protocol(root).rstrip(
-            "/"
-        )  # we join on '/' in _key_to_str
-        self._root_prefix = fs._strip_protocol(os.path.join(root, "x"))[:-1]
+        self.root = fs._strip_protocol(root).rstrip("/")
+        self._root_key_to_str = fs._strip_protocol(os.path.join(root, "x"))[:-1]
         if missing_exceptions is None:
             missing_exceptions = [
                 FileNotFoundError,
@@ -140,7 +138,7 @@ class FSMap(MutableMapping):
             key = str(key)
         if ":" in key and "://" in key:
             raise ValueError(f"keys must not contain protocols, got: {key!r}")
-        return f"{self._root_prefix}{key}"
+        return f"{self._root_key_to_str}{key}"
 
     def _str_to_key(self, s):
         """Strip path of to leave key name"""

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -165,3 +165,32 @@ def test_fsmap_access_with_root_prefix(tmp_path):
     assert m["/a"] == b"data"
     with pytest.raises(KeyError):
         _ = m["a"]
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param(b"k", id="bytes"),
+        pytest.param(1234, id="int"),
+        pytest.param((1,), id="tuple"),
+        pytest.param([""], id="list"),
+    ],
+)
+def test_fsmap_non_str_keys(key):
+    m = fsspec.get_mapper()
+
+    # Once the deprecation period passes
+    # FSMap.__getitem__ should raise TypeError for non-str keys
+    #   with pytest.raises(TypeError):
+    #       _ = m[key]
+
+    with pytest.warns(FutureWarning):
+        with pytest.raises(KeyError):
+            _ = m[key]
+
+
+def test_fsmap_error_on_protocol_keys():
+    m = fsspec.get_mapper()
+
+    with pytest.raises(ValueError):
+        _ = m["protocol://key"]

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -194,3 +194,14 @@ def test_fsmap_error_on_protocol_keys():
 
     with pytest.raises(ValueError):
         _ = m["protocol://key"]
+
+
+def test_fsmap_access_with_suffix(tmp_path):
+    tmp_path.joinpath("b").mkdir()
+    tmp_path.joinpath("b", "a").write_bytes(b"data")
+    m = fsspec.get_mapper(f"file://{tmp_path}")
+
+    with pytest.raises(KeyError):
+        _ = m["b/"]
+
+    assert m["b/a/"] == b"data"

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import platform
 import sys
 import uuid
 
@@ -196,6 +197,11 @@ def test_fsmap_error_on_protocol_keys():
         _ = m["protocol://key"]
 
 
+# on Windows opening a directory will raise PermissionError
+# see: https://bugs.python.org/issue43095
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="raises PermissionError on windows"
+)
 def test_fsmap_access_with_suffix(tmp_path):
     tmp_path.joinpath("b").mkdir()
     tmp_path.joinpath("b", "a").write_bytes(b"data")

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -185,7 +185,7 @@ def test_fsmap_non_str_keys(key):
     #   with pytest.raises(TypeError):
     #       _ = m[key]
 
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         with pytest.raises(KeyError):
             _ = m[key]
 

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -191,10 +191,13 @@ def test_fsmap_non_str_keys(key):
 
 
 def test_fsmap_error_on_protocol_keys():
-    m = fsspec.get_mapper()
+    root = uuid.uuid4()
+    m = fsspec.get_mapper(f"memory://{root}", create=True)
+    m["a"] = b"data"
 
-    with pytest.raises(ValueError):
-        _ = m["protocol://key"]
+    assert m["a"] == b"data"
+    with pytest.raises(KeyError):
+        _ = m[f"memory://{root}/a"]
 
 
 # on Windows opening a directory will raise PermissionError

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ conda_deps=
     {[core]conda_deps}
     httpretty
     aiobotocore
-    "moto<3.0"
+    "moto>=4"
     flask
 changedir=.tox/s3fs/tmp
 whitelist_externals=


### PR DESCRIPTION
Hello everyone,

I had a look at the FSMap code and noticed that `_key_to_str` is calling `fs._strip_protocol` on every call. Also there's code that casts tuples to strings, and it looks wrong (and maybe obsolete) to me. Is there a scenario where FSMap keys will include protocols or where FSMap keys will be tuples?
It seems that simplifying `_key_to_str` still passes the tests.

If there's a use case where keys are prefixed with protocols or tuples I will change this PR and work add a test to the test suite.

Cheers,
Andreas :smiley:


#### Updated TODOs:

- [x] should non-str keys be allowed? **No**
      _"This was probably a mistake to allow and should be removed. I don't believe it is used, but we should have a long depr cycle around it if we decide to remove, to give the few a chance to object."_   

- [x] should protocols be allowed in keys? **No**

- [x] should `m['/abc']` and `m['abc']` return different things?
      _"Only if they evaluate to the same path in the target FS, we shouldn't put extra logic around ensuring it."_

- [x] do `abc/` and `abc` potentially return different things using the FSMap interface?
      _"Since keys refer to files not directories, the former will not be allowed by most FS implementations."_

