### PR TITLE
Fix LocalFileSystem put of file to directory

### DIFF
--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -809,3 +809,17 @@ def test_symlink(tmpdir):
 
     fs.symlink(target, link)
     assert fs.islink(link)
+
+
+# https://github.com/fsspec/filesystem_spec/issues/967
+def test_put_file_to_dir(tmpdir):
+    src_file = os.path.join(str(tmpdir), "src")
+    target_dir = os.path.join(str(tmpdir), "target")
+    target_file = os.path.join(target_dir, "src")
+
+    fs = LocalFileSystem()
+    fs.touch(src_file)
+    fs.mkdir(target_dir)
+    fs.put(src_file, target_dir)
+
+    assert fs.isfile(target_file)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -910,8 +910,12 @@ class AbstractFileSystem(metaclass=_Cached):
             lpath = make_path_posix(lpath)
         fs = LocalFileSystem()
         lpaths = fs.expand_path(lpath, recursive=recursive)
+        isdir = isinstance(rpath, str) and self.isdir(rpath)
         rpaths = other_paths(
-            lpaths, rpath, exists=isinstance(rpath, str) and self.isdir(rpath)
+            lpaths,
+            rpath,
+            exists=isdir,
+            is_dir=isdir and len(lpaths) == 1,
         )
 
         callback.set_size(len(rpaths))


### PR DESCRIPTION
This is a candidate fix for issue #967, which is a `LocalFileSystem.put()` of a file to a directory.

There are a number of places that a fix could be applied. I have traced the problem to `AbstractFileSystem.put()` which calls `other_paths()` on the target path. This wasn't passing an `is_dir` kwarg which I think is the fundamental bug behind the OP's issue.

The fix is to pass the `is_dir` kwarg but bearing in mind the `other_paths` docstring which states
```
is_dir: bool (optional)
    For the special case where the input in one element, whether to regard the value
    as the target path, or as a directory to put a file path within. If None, a
    directory is inferred if the path ends in '/'
```
so `is_dir` is only passed as True if the length of the source paths is 1.

I've added a specific test for the OP's issue, which fails before this PR and passes with it. 

This definitely needs to be checked by someone with more `fsspec` experience than I have to confirm the fix doesn't cause problems elsewhere.