### PR TITLE
Update readthedocs config to version 2

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -13,6 +13,7 @@ python:
     - method: pip
       path: .
 
+
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: true

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: miniconda3-4.7
+
 conda:
-    file: docs/environment.yml
+  environment: docs/environment.yml
+
+python:
+  install:
+    - method: pip
+      path: .
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
This updates the `readthedocs.yml` file to version 2 (https://docs.readthedocs.io/en/stable/config-file/v2.html), primarily to set it to fail on warnings.