### PR TITLE
Improve du

### DIFF
--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -823,3 +823,36 @@ def test_put_file_to_dir(tmpdir):
     fs.put(src_file, target_dir)
 
     assert fs.isfile(target_file)
+
+
+def test_du(tmpdir):
+    file = os.path.join(tmpdir, "file")
+    subdir = os.path.join(tmpdir, "subdir")
+    subfile = os.path.join(subdir, "subfile")
+
+    fs = LocalFileSystem()
+    with open(file, "wb") as f:
+        f.write(b"4444")
+    fs.mkdir(subdir)
+    with open(subfile, "wb") as f:
+        f.write(b"7777777")
+
+    assert fs.du(tmpdir) == 11
+    assert fs.du(tmpdir, total=False) == {file: 4, subfile: 7}
+    # Note directory size is OS-specific, but must be positive
+    assert fs.du(tmpdir, withdirs=True) > 11
+
+    d = fs.du(tmpdir, total=False, withdirs=True)
+    assert len(d) == 4
+    assert d[file] == 4
+    assert d[subfile] == 7
+    assert d[tmpdir] > 0
+    assert d[subdir] > 0
+
+    assert fs.du(tmpdir, maxdepth=2) == 11
+    assert fs.du(tmpdir, maxdepth=1) == 4
+    assert fs.du(tmpdir, maxdepth=0) == 4
+
+    # Size of file only.
+    assert fs.du(file) == 4
+    assert fs.du(file, withdirs=True) == 4

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -826,9 +826,9 @@ def test_put_file_to_dir(tmpdir):
 
 
 def test_du(tmpdir):
-    file = os.path.join(tmpdir, "file")
-    subdir = os.path.join(tmpdir, "subdir")
-    subfile = os.path.join(subdir, "subfile")
+    file = tmpdir / "file"
+    subdir = tmpdir / "subdir"
+    subfile = subdir / "subfile"
 
     fs = LocalFileSystem()
     with open(file, "wb") as f:
@@ -837,17 +837,23 @@ def test_du(tmpdir):
     with open(subfile, "wb") as f:
         f.write(b"7777777")
 
+    # Switch to posix paths for comparisons
+    tmpdir_posix = Path(tmpdir).as_posix()
+    file_posix = Path(file).as_posix()
+    subdir_posix = Path(subdir).as_posix()
+    subfile_posix = Path(subfile).as_posix()
+
     assert fs.du(tmpdir) == 11
-    assert fs.du(tmpdir, total=False) == {file: 4, subfile: 7}
-    # Note directory size is OS-specific, but must be positive
-    assert fs.du(tmpdir, withdirs=True) > 11
+    assert fs.du(tmpdir, total=False) == {file_posix: 4, subfile_posix: 7}
+    # Note directory size is OS-specific, but must be >= 0
+    assert fs.du(tmpdir, withdirs=True) >= 11
 
     d = fs.du(tmpdir, total=False, withdirs=True)
     assert len(d) == 4
-    assert d[file] == 4
-    assert d[subfile] == 7
-    assert d[tmpdir] > 0
-    assert d[subdir] > 0
+    assert d[file_posix] == 4
+    assert d[subfile_posix] == 7
+    assert d[tmpdir_posix] >= 0
+    assert d[subdir_posix] >= 0
 
     assert fs.du(tmpdir, maxdepth=2) == 11
     assert fs.du(tmpdir, maxdepth=1) == 4

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -465,25 +465,33 @@ class AbstractFileSystem(metaclass=_Cached):
         else:
             return {name: out[name] for name in names}
 
-    def du(self, path, total=True, maxdepth=None, **kwargs):
-        """Space used by files within a path
+    def du(self, path, total=True, maxdepth=None, withdirs=False, **kwargs):
+        """Space used by files and optionally directories within a path
+
+        Directory size does not include the size of its contents.
 
         Parameters
         ----------
         path: str
         total: bool
-            whether to sum all the file sizes
+            Whether to sum all the file sizes
         maxdepth: int or None
-            maximum number of directory levels to descend, None for unlimited.
-        kwargs: passed to ``ls``
+            Maximum number of directory levels to descend, None for unlimited.
+        withdirs: bool
+            Whether to include directory paths in the output.
+        kwargs: passed to ``find``
 
         Returns
         -------
-        Dict of {fn: size} if total=False, or int otherwise, where numbers
+        Dict of {path: size} if total=False, or int otherwise, where numbers
         refer to bytes used.
         """
         sizes = {}
-        for f in self.find(path, maxdepth=maxdepth, **kwargs):
+        if withdirs and self.isdir(path):
+            # Include top-level directory in output
+            info = self.info(path)
+            sizes[info["name"]] = info["size"]
+        for f in self.find(path, maxdepth=maxdepth, withdirs=withdirs, **kwargs):
             info = self.info(f)
             sizes[info["name"]] = info["size"]
         if total:

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -103,8 +103,29 @@ def test_du(m):
         }
     )
     assert fs.du("/dir") == 6
-    assert fs.du("/dir", total=False)["/dir/dirb/afile"] == 2
+    assert fs.du("/dir", total=False) == {
+        "/dir/afile": 1,
+        "/dir/dirb/afile": 2,
+        "/dir/dirb/bfile": 3,
+    }
+    assert fs.du("/dir", withdirs=True) == 6
+    assert fs.du("/dir", total=False, withdirs=True) == {
+        "/dir": 0,
+        "/dir/afile": 1,
+        "/dir/dirb": 0,
+        "/dir/dirb/afile": 2,
+        "/dir/dirb/bfile": 3,
+    }
     assert fs.du("/dir", maxdepth=0) == 1
+    assert fs.du("/dir", total=False, withdirs=True, maxdepth=1) == {
+        "/dir": 0,
+        "/dir/afile": 1,
+        "/dir/dirb": 0,
+    }
+
+    # Size of file only.
+    assert fs.du("/dir/afile") == 1
+    assert fs.du("/dir/afile", withdirs=True) == 1
 
 
 def test_head_tail(m):


### PR DESCRIPTION
Fixes most of #1043.

Changes:

1. Calling `fs.du(path, withdirs=True)` with `path` a directory will include the directory in the output as the first line (i.e. in alphabetical order).
2. Added `withdirs` as an explicit `kwarg` to function to make it easier for users to understand.
3. Docstring improvements.
4. Extended `test_api.py::test_du` and added `test_local.py::test_du`.

There was the question of whether the reported size of a directory should include the size of its contained files and directories. Linux command `du` does include the size of its contents, e.g. using something like `du -Ah -B1 some_directory`. However, I am not sure it is a good idea. It is fine if `maxdepth=None` as the directory walk will fully recurse and can add up directory totals as it walks, but what should happen if `maxdepth=1` for example? Command-line `du` gives the fully-recursed directory size, so if we are aiming for the same functionality here then to get that information we would have to fully recurse, even though the user has specified a `maxdepth`. That seems an undesirable thing to do on a potentially large filesystem. So I have  left it as it was and made it clearer in the docstring that directory size does not include its contents.