### PR TITLE
Use builtin types.MappingProxyType rather than custom ReadOnlyRegistry

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,7 +46,6 @@ Base Classes
    fsspec.core.get_fs_token_paths
    fsspec.core.url_to_fs
    fsspec.dircache.DirCache
-   fsspec.registry.ReadOnlyRegistry
    fsspec.registry.register_implementation
    fsspec.callbacks.Callback
    fsspec.callbacks.NoOpCallback
@@ -82,9 +81,6 @@ Base Classes
 .. autofunction:: fsspec.core.url_to_fs
 
 .. autoclass:: fsspec.dircache.DirCache
-   :members: __init__
-
-.. autoclass:: fsspec.registry.ReadOnlyRegistry
    :members: __init__
 
 .. autofunction:: fsspec.registry.register_implementation

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -1,6 +1,6 @@
 import importlib
-import warnings
 import types
+import warnings
 
 __all__ = ["registry", "get_filesystem_class", "default"]
 

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -1,44 +1,15 @@
 import importlib
 import warnings
+import types
 
 __all__ = ["registry", "get_filesystem_class", "default"]
 
-# mapping protocol: implementation class object
-_registry = {}  # internal, mutable
+# internal, mutable
+_registry = {}
 
-
-class ReadOnlyError(TypeError):
-    pass
-
-
-class ReadOnlyRegistry(dict):
-    """Dict-like registry, but immutable
-
-    Maps backend name to implementation class
-
-    To add backend implementations, use ``register_implementation``
-    """
-
-    def __init__(self, target):
-        self.target = target
-
-    def __getitem__(self, item):
-        return self.target[item]
-
-    def __delitem__(self, key):
-        raise ReadOnlyError
-
-    def __setitem__(self, key, value):
-        raise ReadOnlyError
-
-    def clear(self):
-        raise ReadOnlyError
-
-    def __contains__(self, item):
-        return item in self.target
-
-    def __iter__(self):
-        yield from self.target
+# external, immutable
+registry = types.MappingProxyType(_registry)
+default = "file"
 
 
 def register_implementation(name, cls, clobber=True, errtxt=None):
@@ -79,9 +50,6 @@ def register_implementation(name, cls, clobber=True, errtxt=None):
             )
         _registry[name] = cls
 
-
-registry = ReadOnlyRegistry(_registry)
-default = "file"
 
 # protocols mapped to the class which implements them. This dict can
 # updated with register_implementation

--- a/fsspec/tests/test_registry.py
+++ b/fsspec/tests/test_registry.py
@@ -4,7 +4,6 @@ from unittest.mock import create_autospec, patch
 import pytest
 
 from fsspec.registry import (
-    ReadOnlyError,
     _registry,
     filesystem,
     get_filesystem_class,
@@ -43,11 +42,11 @@ def test_registry_readonly():
     get_filesystem_class("file")
     assert "file" in registry
     assert "file" in list(registry)
-    with pytest.raises(ReadOnlyError):
+    with pytest.raises(TypeError):
         del registry["file"]
-    with pytest.raises(ReadOnlyError):
+    with pytest.raises(TypeError):
         registry["file"] = None
-    with pytest.raises(ReadOnlyError):
+    with pytest.raises(AttributeError):
         registry.clear()
 
 


### PR DESCRIPTION
Seems better to use the built-in immutable mapping proxy type rather than making a custom one. Was added in Python 3.3. https://docs.python.org/3/library/types.html#types.MappingProxyType