### PR TITLE
references with dataframes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup conda
         uses: mamba-org/provision-with-micromamba@main
@@ -45,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup conda
         uses: mamba-org/provision-with-micromamba@main

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,6 +71,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup conda
         uses: mamba-org/provision-with-micromamba@main

--- a/ci/environment-downstream.yml
+++ b/ci/environment-downstream.yml
@@ -15,4 +15,5 @@ dependencies:
   - s3fs
   - requests
   - moto
+  - sqlalchemy
   - flask

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -28,6 +28,7 @@ dependencies:
   - pytest-vcr
   - py
   - fusepy
+  - fastparquet
   - tomli < 2
   - msgpack-python
   - python-libarchive-c

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -187,6 +187,15 @@ def _get_batch_size(nofiles=False):
         return soft_limit // 8
 
 
+def running_async() -> bool:
+    """Being executed by an event loop?"""
+    try:
+        asyncio.get_running_loop()
+        return True
+    except RuntimeError:
+        return False
+
+
 async def _run_coros_in_chunks(
     coros,
     batch_size=None,

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -19,6 +19,7 @@ private = re.compile("_[^_]")
 iothread = [None]  # dedicated fsspec IO thread
 loop = [None]  # global event loop for any non-async instance
 _lock = None  # global lock placeholder
+get_running_loop = asyncio.get_running_loop
 
 
 def get_lock():

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -728,11 +728,12 @@ class DFReferenceFileSystem(AbstractFileSystem):
                     for k in self.dataframes[part]["key"]
                     if "/" in k
                 }
-                self.prefs = ast.literal_eval(
-                    pf.key_value_metadata["prefs"]
+                self.prefs = (
+                    ast.literal_eval(pf.key_value_metadata["prefs"])
                     if "pref" in pf.key_value_metadata
                     else set()
                 )
+
         return self.dataframes[part]
 
     def isdir(self, path):

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -729,7 +729,9 @@ class DFReferenceFileSystem(AbstractFileSystem):
                     if "/" in k
                 }
                 self.prefs = ast.literal_eval(
-                    pf.key_value_metadata.get("prefs", "set()")
+                    pf.key_value_metadata["prefs"]
+                    if "pref" in pf.key_value_metadata
+                    else set()
                 )
         return self.dataframes[part]
 

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -625,6 +625,21 @@ def constant_prefix(x):
 
 
 class DFReferenceFileSystem(AbstractFileSystem):
+    """
+    (Experimental) Parquet-based Reference Filesystem
+
+    Putative replacement or adjunct to ReferenceFileSystem with
+    additional capabilities:
+    - loads from parquet for better on-disk and in-memory space
+    - optional lazy loading by key prefix (lazy=True)
+    - multiple targets for a given key (allow_multi=True), concatenated
+      together by default, of multi_func=
+    - per-chunk processing with extra parameters stored in the parquet
+      (chunk_func=)
+
+    This implementation is not (yet) multable.
+    """
+
     def __init__(
         self,
         fo,

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -532,7 +532,8 @@ def test_df_single(m):
             "raw": [b"raw", None, None],
         }
     )
-    fs = DFReferenceFileSystem(fo=df, remote_protocol="memory")
+    df.to_parquet("memory://df.parq")
+    fs = DFReferenceFileSystem(fo="memory://df.parq", remote_protocol="memory")
     assert fs.cat("a") == b"raw"
     assert fs.cat("b") == data
     assert fs.cat("c") == data[4:8]

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -5,7 +5,11 @@ import pytest
 
 import fsspec
 from fsspec.implementations.local import LocalFileSystem
-from fsspec.implementations.reference import ReferenceNotReachable, _unmodel_hdf5
+from fsspec.implementations.reference import (
+    DFReferenceFileSystem,
+    ReferenceNotReachable,
+    _unmodel_hdf5,
+)
 from fsspec.tests.conftest import data, realfile, reset_files, server, win  # noqa: F401
 
 
@@ -513,3 +517,47 @@ def test_cat_missing(m):
 
     out = mapper.getitems(["c", "d"], on_error="omit")
     assert list(out) == ["c"]
+
+
+def test_df_single(m):
+    pd = pytest.importorskip("pandas")
+    data = b"data0data1data2"
+    m.pipe({"data": data})
+    df = pd.DataFrame(
+        {
+            "key": ["a", "b", "c"],
+            "path": [None, "memory://data", "memory://data"],
+            "offset": [0, 0, 4],
+            "size": [0, 0, 4],
+            "raw": [b"raw", None, None],
+        }
+    )
+    fs = DFReferenceFileSystem(fo=df, remote_protocol="memory")
+    assert fs.cat("a") == b"raw"
+    assert fs.cat("b") == data
+    assert fs.cat("c") == data[4:8]
+
+
+def test_df_multi(m):
+    pd = pytest.importorskip("pandas")
+    data = b"data0data1data2"
+    m.pipe({"data": data, "data2": b"hello"})
+    df = pd.DataFrame(
+        {
+            "key": ["a", "b", "b", "d", "d"],
+            "path": [
+                None,
+                "memory://data",
+                "memory://data",
+                "memory://data",
+                "memory://data2",
+            ],
+            "offset": [0, 0, 4, 4, 1],
+            "size": [0, 0, 4, 2, 2],
+            "raw": [b"raw", None, None, None, None],
+        }
+    )
+    fs = DFReferenceFileSystem(fo=df, remote_protocol="memory", allow_multi=True)
+    assert fs.cat("a") == b"raw"
+    assert fs.cat("b") == data + data[4:8]
+    assert fs.cat("d") == data[4:6] + b"hello"[1:3]

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -558,7 +558,10 @@ def test_df_multi(m):
             "raw": [b"raw", None, None, None, None],
         }
     )
-    fs = DFReferenceFileSystem(fo=df, remote_protocol="memory", allow_multi=True)
+    df.to_parquet("memory://df.parq")
+    fs = DFReferenceFileSystem(
+        fo="memory://df.parq", remote_protocol="memory", allow_multi=True
+    )
     assert fs.cat("a") == b"raw"
     assert fs.cat("b") == data + data[4:8]
     assert fs.cat("d") == data[4:6] + b"hello"[1:3]

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -996,7 +996,9 @@ class AbstractFileSystem(metaclass=_Cached):
                         )
                     continue
                 elif recursive:
-                    rec = set(self.find(p, maxdepth=maxdepth, withdirs=True))
+                    rec = set(
+                        self.find(p, maxdepth=maxdepth, withdirs=True, detail=False)
+                    )
                     out |= rec
                 if p not in out and (recursive is False or self.exists(p)):
                     # should only check once, for the root

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -136,3 +136,12 @@ def test_windows_policy():
     # check ensures that we are restoring the old policy back
     # after our change.
     assert isinstance(policy, asyncio.DefaultEventLoopPolicy)
+
+
+def test_running_async():
+    assert not fsspec.asyn.running_async()
+
+    async def go():
+        assert fsspec.asyn.running_async()
+
+    asyncio.run(go())

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -510,9 +510,17 @@ def merge_offset_ranges(paths, starts, ends, max_gap=0, max_block=None, sort=Tru
     if len(starts) <= 1:
         return paths, starts, ends
 
+    starts = [s or 0 for s in starts]
     # Sort by paths and then ranges if `sort=True`
     if sort:
-        paths, starts, ends = [list(v) for v in zip(*sorted(zip(paths, starts, ends)))]
+        paths, starts, ends = [
+            list(v)
+            for v in zip(
+                *sorted(
+                    zip(paths, starts, ends),
+                )
+            )
+        ]
 
     if paths:
         # Loop through the coupled `paths`, `starts`, and
@@ -521,7 +529,9 @@ def merge_offset_ranges(paths, starts, ends, max_gap=0, max_block=None, sort=Tru
         new_starts = starts[:1]
         new_ends = ends[:1]
         for i in range(1, len(paths)):
-            if (
+            if paths[i] == paths[i - 1] and new_ends[-1] is None:
+                continue
+            elif (
                 paths[i] != paths[i - 1]
                 or ((starts[i] - new_ends[-1]) > max_gap)
                 or ((max_block is not None and (ends[i] - new_starts[-1]) > max_block))


### PR DESCRIPTION
cc @d70-t 

This implements, very experimentally, a parquet/dataframe based referenceFS, inspired by and hopefully compatible with preffs. Hoping to get the best of both! `fsspec.implementations.reference.DFReferenceFileSystem` (is not yet in the fsspec registry)

I have a companion function for kerchunk to convert JSONs to parquet. Still need to decide what to do about templates.

The plan here is to include the following features:
- multiple target filesystems
- keys with multiple targets if allow_multi=True. These can be a combination of raw data and references on multiple targets. The bits are combined with multi_func kwarg
  - a combination of whole file and file ranges
- optional chunk_func applied to the final bytes buffer (solves the different-scale-per-input problem for kerchunk)
- lazy loading of parquet subsets of references when lazy=True keyed by path prefix by default (not yet implemented)
- merging of ranges that are close enough together in target files to reduce the number of calls
- extracting out of the arrays from the parquet dataframe for speed of indexing (actually, fastparquet or pyarrow can load directly to arrays and bypass slow pandas)

This all requires a lot of testing! I am hoping to get preffs users involved now at this very early stage to make sure everything comes out right

Still to implement
- get to files
- any writing functionality and saving the new reference set; could we have a reference set built on a "manifest" where the parquet files are not in the same directory?
- probably other stuff

Optional stretch goal
- zarr does not allow for variable-length chunk sizes, but we could have columns for chunk sizes, and solve it in the storage layer
- a lot of optimisations, since there's loads of loop/comprehensions; maybe they don't matter since we may have tons of references but don't expect to be fetching too many of them in a single call.