### PR TITLE
Update `pyarrow` version parsing

### DIFF
--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -7,7 +7,12 @@ from contextlib import suppress
 from functools import cached_property, wraps
 
 from fsspec.spec import AbstractFileSystem
-from fsspec.utils import infer_storage_options, mirror_from, tokenize
+from fsspec.utils import (
+    get_package_version_without_import,
+    infer_storage_options,
+    mirror_from,
+    tokenize,
+)
 
 
 def wrap_exceptions(func):
@@ -43,10 +48,8 @@ class ArrowFSWrapper(AbstractFileSystem):
     root_marker = "/"
 
     def __init__(self, fs, **kwargs):
-        from pyarrow import __version__
-
         global PYARROW_VERSION
-        PYARROW_VERSION = tuple(map(int, __version__.split(".")))
+        PYARROW_VERSION = get_package_version_without_import("pyarrow")
         self.fs = fs
         super().__init__(**kwargs)
 
@@ -165,7 +168,7 @@ class ArrowFSWrapper(AbstractFileSystem):
 
         _kwargs = {}
         if mode != "rb" or not seekable:
-            if PYARROW_VERSION[0] >= 4:
+            if int(PYARROW_VERSION.split(".")[0]) >= 4:
                 # disable compression auto-detection
                 _kwargs["compression"] = None
         stream = method(path, **_kwargs)


### PR DESCRIPTION
When using `ArrowFSWrapper` with the nightly release of `pyarrow`, I got the failing error with the current version parsing logic since, for the nightly release of `pyarrow`, `pyarrow=11.0.0.dev294`:

```python
self = <fsspec.implementations.arrow.ArrowFSWrapper object at 0x13245f2e0>, fs = <pyarrow._fs.LocalFileSystem object at 0x131030270>, kwargs = {}
__version__ = '11.0.0.dev294'

    def __init__(self, fs, **kwargs):
        from pyarrow import __version__

        global PYARROW_VERSION
>       PYARROW_VERSION = tuple(map(int, __version__.split(".")))
E       ValueError: invalid literal for int() with base 10: 'dev294'

../../../mambaforge/envs/dask/lib/python3.10/site-packages/fsspec/implementations/arrow.py:49: ValueError
```

This PR updates the version parsing logic to handle this case (in addition to the usual `X.Y.Z` version format) 