### PR TITLE
Always use "chain" logic on URL, even if only one component

### DIFF
--- a/ci/environment-win.yml
+++ b/ci/environment-win.yml
@@ -21,4 +21,5 @@ dependencies:
   - py
   - numpy
   - nomkl
+  - s3fs
   - tqdm

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -107,7 +107,7 @@ def test_urlpath_inference_errors():
     # Protocols differ
     with pytest.raises(ValueError) as err:
         get_fs_token_paths(["s3://test/path.csv", "/other/path.csv"])
-    assert "protocol" in str(err.value)
+    assert "Protocol" in str(err.value)
 
 
 def test_urlpath_expand_read():

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -194,7 +194,7 @@ def test_pickle_after_open_open():
 
 
 def test_mismatch():
-    with pytest.raises(ValueError, match="protocol"):
+    with pytest.raises(ValueError, match="Protocol"):
         open_files(["s3://test/path.csv", "/other/path.csv"])
 
 


### PR DESCRIPTION
Fixes https://github.com/intake/intake-parquet/issues/26

Now, you can do `fsspec.open` or `fsspec.core.url_to_fs` with chained or simple URLs, and use protocol= kwargs to go to the specific instance, or simple kwargs that go to the outermost instance. This also simplifies the code by not diverging depending on the URLs complexity.