### PR TITLE
Fix type returned by calling .ls on memory file

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -35,6 +35,8 @@ class MemoryFileSystem(AbstractFileSystem):
         path = self._strip_protocol(path)
         if path in self.store:
             # there is a key with this exact name
+            if not detail:
+                return [path]
             return [
                 {
                     "name": path,

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -31,7 +31,7 @@ class MemoryFileSystem(AbstractFileSystem):
         path = path.lstrip("/").rstrip("/")
         return "/" + path if path else ""
 
-    def ls(self, path, detail=False, **kwargs):
+    def ls(self, path, detail=True, **kwargs):
         path = self._strip_protocol(path)
         if path in self.store:
             # there is a key with this exact name

--- a/fsspec/implementations/tests/test_dask.py
+++ b/fsspec/implementations/tests/test_dask.py
@@ -26,5 +26,5 @@ def cli(tmpdir):
 def test_basic(cli):
 
     fs = fsspec.filesystem("dask", target_protocol="memory")
-    assert fs.ls("") == ["/afile"]
+    assert fs.ls("", detail=False) == ["/afile"]
     assert fs.cat("/afile") == b"data"

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -48,6 +48,7 @@ def test_ls(m):
     assert m.ls("/dir/afile", True)[0]["type"] == "file"
 
     assert len(m.ls("/dir/dir1")) == 2
+    assert len(m.ls("/dir/afile")) == 1
 
 
 def test_directories(m):

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -44,6 +44,8 @@ def test_ls(m):
     assert m.ls("/dir", False) == ["/dir/afile", "/dir/dir1"]
     assert m.ls("/dir", True)[0]["type"] == "file"
     assert m.ls("/dir", True)[1]["type"] == "directory"
+    assert m.ls("/dir/afile", False) == ["/dir/afile"]
+    assert m.ls("/dir/afile", True)[0]["type"] == "file"
 
     assert len(m.ls("/dir/dir1")) == 2
 


### PR DESCRIPTION
`MemoryFileSystem.ls()` would always return a list with a single detailed dict in it, even when `detail=False` (the default). It should return a list with a single str as per the docs.