### PR TITLE
Consistent recursive cp, get and put into non-existent target directory

### DIFF
--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -696,9 +696,9 @@ def test_copy_errors(tmpdir):
 
     localfs.copy([file1, file2, dne], dest1, on_error="ignore")
 
-    assert sorted(localfs.ls(os.path.join(dest1, "src"))) == [
-        make_path_posix(os.path.join(dest1, "src", "afile1")),
-        make_path_posix(os.path.join(dest1, "src", "afile2")),
+    assert sorted(localfs.ls(dest1)) == [
+        make_path_posix(os.path.join(dest1, "afile1")),
+        make_path_posix(os.path.join(dest1, "afile2")),
     ]
 
     # Recursive should raise an error only if we specify raise
@@ -707,12 +707,12 @@ def test_copy_errors(tmpdir):
     current_files = localfs.expand_path(src, recursive=True)
     with patch.object(localfs, "expand_path", return_value=current_files + [dne]):
         with pytest.raises(FileNotFoundError):
-            localfs.copy(src, dest2, recursive=True, on_error="raise")
+            localfs.copy(src + "/", dest2, recursive=True, on_error="raise")
 
-        localfs.copy(src, dest2, recursive=True)
-        assert sorted(localfs.ls(os.path.join(dest2, "src"))) == [
-            make_path_posix(os.path.join(dest2, "src", "afile1")),
-            make_path_posix(os.path.join(dest2, "src", "afile2")),
+        localfs.copy(src + "/", dest2, recursive=True)
+        assert sorted(localfs.ls(dest2)) == [
+            make_path_posix(os.path.join(dest2, "afile1")),
+            make_path_posix(os.path.join(dest2, "afile2")),
         ]
 
 
@@ -907,3 +907,24 @@ def test_cp_get_put_directory_recursive(tmpdir, funcname):
         func(src + "/", target, recursive=True)
         assert fs.isdir(target)
         assert fs.find(target) == [make_path_posix(os.path.join(target, "file"))]
+
+
+def test_cp_two_files(tmpdir):
+    fs = LocalFileSystem(auto_mkdir=True)
+    src = os.path.join(str(tmpdir), "src")
+    file0 = os.path.join(src, "file0")
+    file1 = os.path.join(src, "file1")
+    fs.mkdir(src)
+    fs.touch(file0)
+    fs.touch(file1)
+
+    target = os.path.join(str(tmpdir), "target")
+    assert not fs.exists(target)
+
+    fs.cp([file0, file1], target)
+
+    assert fs.isdir(target)
+    assert sorted(fs.find(target)) == [
+        make_path_posix(os.path.join(target, "file0")),
+        make_path_posix(os.path.join(target, "file1")),
+    ]

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -214,3 +214,23 @@ def test_cp_get_put_directory_recursive(m, tmpdir, funcname):
         func(src + "/", target, recursive=True)
         assert target_fs.isdir(target)
         assert target_fs.find(target) == [make_path_posix(os.path.join(target, "file"))]
+
+
+def test_cp_two_files(m):
+    src = "/src"
+    file0 = os.path.join(src, "file0")
+    file1 = os.path.join(src, "file1")
+    m.mkdir(src)
+    m.touch(file0)
+    m.touch(file1)
+
+    target = "/target"
+    assert not m.exists(target)
+
+    m.cp([file0, file1], target)
+
+    assert m.isdir(target)
+    assert sorted(m.find(target)) == [
+        "/target/file0",
+        "/target/file1",
+    ]

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -882,18 +882,13 @@ class AbstractFileSystem(metaclass=_Cached):
 
         if isinstance(lpath, str):
             lpath = make_path_posix(lpath)
-        trailing_slash = isinstance(rpath, str) and rpath.endswith("/")
         rpaths = self.expand_path(rpath, recursive=recursive)
-        if isinstance(lpath, str):
-            local_fs = LocalFileSystem()
-            isdir = local_fs.isdir(lpath)
-        else:
-            isdir = False
+        isdir = isinstance(lpath, str) and LocalFileSystem().isdir(lpath)
         lpaths = other_paths(
             rpaths,
             lpath,
-            exists=isdir and not trailing_slash,
-            is_dir=isdir and len(rpaths) == 1,
+            exists=isdir and isinstance(rpath, str) and not rpath.endswith("/"),
+            is_dir=isdir,
         )
 
         callback.set_size(len(lpaths))
@@ -939,17 +934,14 @@ class AbstractFileSystem(metaclass=_Cached):
         )
         if isinstance(lpath, str):
             lpath = make_path_posix(lpath)
-            trailing_slash = lpath.endswith("/")
-        else:
-            trailing_slash = False
         fs = LocalFileSystem()
         lpaths = fs.expand_path(lpath, recursive=recursive)
         isdir = isinstance(rpath, str) and self.isdir(rpath)
         rpaths = other_paths(
             lpaths,
             rpath,
-            exists=isdir and not trailing_slash,
-            is_dir=isdir and len(lpaths) == 1,
+            exists=isdir and isinstance(lpath, str) and not lpath.endswith("/"),
+            is_dir=isdir,
         )
 
         callback.set_size(len(rpaths))
@@ -984,14 +976,13 @@ class AbstractFileSystem(metaclass=_Cached):
         elif on_error is None:
             on_error = "raise"
 
-        trailing_slash = isinstance(path1, str) and path1.endswith("/")
         paths = self.expand_path(path1, recursive=recursive)
         isdir = isinstance(path2, str) and self.isdir(path2)
         path2 = other_paths(
             paths,
             path2,
-            exists=isdir and not trailing_slash,
-            is_dir=isdir and len(paths) == 1,
+            exists=isdir and isinstance(path1, str) and not path1.endswith("/"),
+            is_dir=isdir,
         )
 
         for p1, p2 in zip(paths, path2):

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -162,9 +162,17 @@ def test_recursive_get_put(tmpdir, m):
 
     fs.put(str(tmpdir), "test", recursive=True)
 
+    # get to directory with slash
+    d = tempfile.mkdtemp()
+    fs.get("test/", d, recursive=True)
+    for file in ["one", "two", "nest/other"]:
+        with open(f"{d}/{file}", "rb") as f:
+            f.read() == b"data"
+
+    # get to directory without slash
     d = tempfile.mkdtemp()
     fs.get("test", d, recursive=True)
-    for file in ["one", "two", "nest/other"]:
+    for file in ["test/one", "test/two", "test/nest/other"]:
         with open(f"{d}/{file}", "rb") as f:
             f.read() == b"data"
 


### PR DESCRIPTION
This is a WIP for #1062. Running the test script from that issue gives the following output:
```
==> cp
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a', '/tmp/target/source', '/tmp/target/source/a']
==> cp, slash
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a']
==> rsync
  loop 0: ['/tmp/target/source', '/tmp/target/source/a']
  loop 1: ['/tmp/target/source', '/tmp/target/source/a']
==> rsync, slash
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a']
==> scp
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a', '/tmp/target/source', '/tmp/target/source/a']
==> scp, slash
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a']
==> fs.cp
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a', '/tmp/target/source', '/tmp/target/source/a']
==> fs.cp, slash
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a']
==> fs.get
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a', '/tmp/target/source', '/tmp/target/source/a']
==> fs.get, slash
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a']
==> fs.put
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a', '/tmp/target/source', '/tmp/target/source/a']
==> fs.put, slash
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a']
==> mem.cp
  loop 0: ['/remote_target/a']
  loop 1: ['/remote_target/a', '/remote_target/remote_source', '/remote_target/remote_source/a']
==> mem.cp, slash
  loop 0: ['/remote_target/a']
  loop 1: ['/remote_target/a']
==> mem.get
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a', '/tmp/target/remote_source', '/tmp/target/remote_source/a']
==> mem.get, slash
  loop 0: ['/tmp/target/a']
  loop 1: ['/tmp/target/a']
==> mem.put
  loop 0: ['/remote_target/a']
  loop 1: ['/remote_target/a', '/remote_target/source', '/remote_target/source/a']
==> mem.put, slash
  loop 0: ['/remote_target/a']
  loop 1: ['/remote_target/a']
```
showing that the `fsspec` functions `cp`, `get` and `put` are consistent with command-line `cp` and `scp`.

The solution is mostly about passing the correct arguments to `utils.other_paths()` to obtain the required behaviour.

It is only a WIP for two reasons:

1. I have broken the use case of `fs.copy(['/tmp/source/a', '/tmp/source/b'], '/tmp/target')` and don't yet have a fix for it.
2. I have only fixed `other_paths()` calls in `spec.py` not in `asyn.py`, which presumably needs similar logic.