### PR TITLE
Fix read the docs build process

### DIFF
--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -147,5 +147,3 @@ available as the attribute ``.loop``.
 .. autofunction:: fsspec.asyn.sync_wrapper
 
 .. autofunction:: fsspec.asyn.get_loop
-
-.. autofunction:: fsspec.asyn.fsspec_loop

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -13,7 +13,6 @@ python:
     - method: pip
       path: .
 
-
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
   fail_on_warning: true


### PR DESCRIPTION
Read the docs builds are failing as the version 2 config file wasn't correct, and the function `fsspec_loop` has been removed.