### PR TITLE
Workaround for RTD not showing colons for function args

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,5 @@
+.classifier:before {
+    font-style: normal;
+    margin: 0.5em;
+    content: ":";
+}

--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -147,5 +147,3 @@ available as the attribute ``.loop``.
 .. autofunction:: fsspec.asyn.sync_wrapper
 
 .. autofunction:: fsspec.asyn.get_loop
-
-.. autofunction:: fsspec.asyn.fsspec_loop

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,7 +114,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -127,6 +127,10 @@ html_sidebars = {
         "searchbox.html",
     ]
 }
+
+# Custom CSS file to override read the docs default CSS.
+# Contains workaround for issue #790.
+html_css_files = ["custom.css"]
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -13,7 +13,6 @@ python:
     - method: pip
       path: .
 
-
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
   fail_on_warning: true


### PR DESCRIPTION
Fixes #790 which is that Read the Docs does not display colons between argument names and types.

There is a discussion about this on the `sphinx_rtd_theme` github https://github.com/readthedocs/sphinx_rtd_theme/issues/766. The workaround here is the one recommended in that issue.

This PR is made on top of #1149 so that RTD will successfully build the docs so the workaround can be checked. Ideally #1149 should be merged before this.

Longer term it might be worth us considering a switch from the RTD theme to one that is more actively maintained. Options that work well for relatively small documentation projects are `furo` (https://github.com/pradyunsg/furo) and `sphinx-book-theme` (https://github.com/executablebooks/sphinx-book-theme).