### PR TITLE
Validate maxdepth kwarg

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -464,7 +464,7 @@ Fixes:
 - random appending of a directory within the filesystems ``find()`` method (#507, 537)
 - fix git tests (#501)
 - fix recursive memfs operations (#502)
-- fix recorsive/maxdepth for cp (#508)
+- fix recursive/maxdepth for cp (#508)
 - fix listings cache timeout (#513)
 - big endian bytes tests (#519)
 - docs syntax (#535, 524, 520, 542)

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -858,7 +858,8 @@ def test_du(tmpdir):
 
     assert fs.du(tmpdir, maxdepth=2) == 11
     assert fs.du(tmpdir, maxdepth=1) == 4
-    assert fs.du(tmpdir, maxdepth=0) == 4
+    with pytest.raises(ValueError):
+        fs.du(tmpdir, maxdepth=0)
 
     # Size of file only.
     assert fs.du(file) == 4

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -390,6 +390,9 @@ class AbstractFileSystem(metaclass=_Cached):
             the bottom upwards.
         kwargs: passed to ``ls``
         """
+        if maxdepth is not None and maxdepth < 1:
+            raise ValueError("maxdepth must be at least 1")
+
         path = self._strip_protocol(path)
         full_dirs = {}
         dirs = {}
@@ -429,6 +432,8 @@ class AbstractFileSystem(metaclass=_Cached):
         if maxdepth is not None:
             maxdepth -= 1
             if maxdepth < 1:
+                if not topdown:
+                    yield path, dirs, files
                 return
 
         for d in full_dirs:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -982,11 +982,12 @@ class AbstractFileSystem(metaclass=_Cached):
     def expand_path(self, path, recursive=False, maxdepth=None):
         """Turn one or more globs or directories into a list of all matching paths
         to files or directories."""
+        if maxdepth is not None and maxdepth < 1:
+            raise ValueError("maxdepth must be at least 1")
+
         if isinstance(path, str):
             out = self.expand_path([path], recursive, maxdepth)
         else:
-            # reduce depth on each recursion level unless None or 0
-            maxdepth = maxdepth if not maxdepth else maxdepth - 1
             out = set()
             path = [self._strip_protocol(p) for p in path]
             for p in path:
@@ -1008,6 +1009,8 @@ class AbstractFileSystem(metaclass=_Cached):
                 if p not in out and (recursive is False or self.exists(p)):
                     # should only check once, for the root
                     out.add(p)
+            # reduce depth on each recursion level unless None or 0
+            maxdepth = maxdepth if not maxdepth else maxdepth - 1
         if not out:
             raise FileNotFoundError(path)
         return list(sorted(out))

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -368,11 +368,11 @@ def test_url_to_fs():
 
 def test_walk(m):
     dir0 = "/dir0"
-    dir1 = os.path.join(dir0, "dir1")
-    dir2 = os.path.join(dir1, "dir2")
-    file1 = os.path.join(dir0, "file1")
-    file2 = os.path.join(dir1, "file2")
-    file3 = os.path.join(dir2, "file3")
+    dir1 = dir0 + "/dir1"
+    dir2 = dir1 + "/dir2"
+    file1 = dir0 + "/file1"
+    file2 = dir1 + "/file2"
+    file3 = dir2 + "/file3"
 
     m.mkdir(dir2)  # Creates parents too
     m.touch(file1)

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -116,7 +116,8 @@ def test_du(m):
         "/dir/dirb/afile": 2,
         "/dir/dirb/bfile": 3,
     }
-    assert fs.du("/dir", maxdepth=0) == 1
+    with pytest.raises(ValueError):
+        assert fs.du("/dir", maxdepth=0) == 1
     assert fs.du("/dir", total=False, withdirs=True, maxdepth=1) == {
         "/dir": 0,
         "/dir/afile": 1,
@@ -363,3 +364,53 @@ def test_url_to_fs():
 
     assert isinstance(fs, MemoryFileSystem)
     assert url2 == "/a.txt"
+
+
+def test_walk(m):
+    dir0 = "/dir0"
+    dir1 = os.path.join(dir0, "dir1")
+    dir2 = os.path.join(dir1, "dir2")
+    file1 = os.path.join(dir0, "file1")
+    file2 = os.path.join(dir1, "file2")
+    file3 = os.path.join(dir2, "file3")
+
+    m.mkdir(dir2)  # Creates parents too
+    m.touch(file1)
+    m.touch(file2)
+    m.touch(file3)
+
+    # No maxdepth
+    assert list(m.walk(dir0, topdown=True)) == [
+        (dir0, ["dir1"], ["file1"]),
+        (dir1, ["dir2"], ["file2"]),
+        (dir2, [], ["file3"]),
+    ]
+    assert list(m.walk(dir0, topdown=False)) == [
+        (dir2, [], ["file3"]),
+        (dir1, ["dir2"], ["file2"]),
+        (dir0, ["dir1"], ["file1"]),
+    ]
+
+    # maxdepth=2
+    assert list(m.walk(dir0, maxdepth=2, topdown=True)) == [
+        (dir0, ["dir1"], ["file1"]),
+        (dir1, ["dir2"], ["file2"]),
+    ]
+    assert list(m.walk(dir0, maxdepth=2, topdown=False)) == [
+        (dir1, ["dir2"], ["file2"]),
+        (dir0, ["dir1"], ["file1"]),
+    ]
+
+    # maxdepth=1
+    assert list(m.walk(dir0, maxdepth=1, topdown=True)) == [
+        (dir0, ["dir1"], ["file1"]),
+    ]
+    assert list(m.walk(dir0, maxdepth=1, topdown=False)) == [
+        (dir0, ["dir1"], ["file1"]),
+    ]
+
+    # maxdepth=0
+    with pytest.raises(ValueError):
+        list(m.walk(dir0, maxdepth=0, topdown=True))
+    with pytest.raises(ValueError):
+        list(m.walk(dir0, maxdepth=0, topdown=False))

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -202,6 +202,17 @@ def test_expand_path_recursive(test_paths, expected):
     paths = test_fs.expand_path(list(test_paths), recursive=True)
     assert sorted(paths) == sorted(expected)
 
+    # test with maxdepth
+    assert test_fs.expand_path("top_level", recursive=True, maxdepth=1) == [
+        "top_level",
+        "top_level/second_level",
+    ]
+
+    with pytest.raises(ValueError):
+        test_fs.expand_path("top_level", recursive=True, maxdepth=0)
+    with pytest.raises(ValueError):
+        test_fs.expand_path("top_level", maxdepth=0)
+
 
 @pytest.mark.xfail
 def test_find():


### PR DESCRIPTION
Fixes #1135.

This PR adds checks that kwarg `maxdepth` passed to `walk` and `expand_paths` is at least `1` and raises a `ValueError` if not.

Strictly speaking the check isn't really needed in `expand_paths` as it eventually calls `find` which calls `walk`, but I thought it better to add an explicit check at the top of the function so that the traceback is clear.

I have also added the fix to the `asyn.py` functions `_walk` and `_expand_paths` and corresponding async tests in `test_http.py`. This is my first attempt to write async tests in `fsspec` so I expect they could be improved; any advice gratefully received!