### PR TITLE
Order lists in docs alphabetically

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,76 +7,76 @@ User Functions
 --------------
 
 .. autosummary::
-   fsspec.open_files
-   fsspec.open
-   fsspec.open_local
    fsspec.available_compressions
    fsspec.available_protocols
    fsspec.filesystem
+   fsspec.fuse.run
+   fsspec.generic.rsync
    fsspec.get_filesystem_class
    fsspec.get_mapper
-   fsspec.fuse.run
    fsspec.gui.FileSelector
-   fsspec.generic.rsync
+   fsspec.open
+   fsspec.open_files
+   fsspec.open_local
 
-.. autofunction:: fsspec.open_files
-.. autofunction:: fsspec.open
-.. autofunction:: fsspec.open_local
 .. autofunction:: fsspec.available_compressions
 .. autofunction:: fsspec.available_protocols
 .. autofunction:: fsspec.filesystem
+.. autofunction:: fsspec.fuse.run
+.. autofunction:: fsspec.generic.rsync
 .. autofunction:: fsspec.get_filesystem_class
 .. autofunction:: fsspec.get_mapper
-.. autofunction:: fsspec.fuse.run
 .. autoclass:: fsspec.gui.FileSelector
    :members:
-.. autofunction:: fsspec.generic.rsync
+.. autofunction:: fsspec.open
+.. autofunction:: fsspec.open_files
+.. autofunction:: fsspec.open_local
 
 Base Classes
 ------------
 
 .. autosummary::
-   fsspec.spec.AbstractFileSystem
-   fsspec.spec.Transaction
-   fsspec.spec.AbstractBufferedFile
    fsspec.archive.AbstractArchiveFileSystem
-   fsspec.FSMap
    fsspec.asyn.AsyncFileSystem
+   fsspec.callbacks.Callback
+   fsspec.callbacks.DotPrinterCallback
+   fsspec.callbacks.NoOpCallback
+   fsspec.callbacks.TqdmCallback
+   fsspec.core.BaseCache
    fsspec.core.OpenFile
    fsspec.core.OpenFiles
-   fsspec.core.BaseCache
    fsspec.core.get_fs_token_paths
    fsspec.core.url_to_fs
    fsspec.dircache.DirCache
-   fsspec.registry.register_implementation
-   fsspec.callbacks.Callback
-   fsspec.callbacks.NoOpCallback
-   fsspec.callbacks.DotPrinterCallback
-   fsspec.callbacks.TqdmCallback
+   fsspec.FSMap
    fsspec.generic.GenericFileSystem
-
-.. autoclass:: fsspec.spec.AbstractFileSystem
-   :members:
-
-.. autoclass:: fsspec.spec.Transaction
-   :members:
-
-.. autoclass:: fsspec.spec.AbstractBufferedFile
-   :members:
+   fsspec.registry.register_implementation
+   fsspec.spec.AbstractBufferedFile
+   fsspec.spec.AbstractFileSystem
+   fsspec.spec.Transaction
 
 .. autoclass:: fsspec.archive.AbstractArchiveFileSystem
    :members:
 
-.. autoclass:: fsspec.FSMap
+.. autoclass:: fsspec.callbacks.Callback
+   :members:
+
+.. autoclass:: fsspec.callbacks.DotPrinterCallback
+   :members:
+
+.. autoclass:: fsspec.callbacks.NoOpCallback
+   :members:
+
+.. autoclass:: fsspec.callbacks.TqdmCallback
+   :members:
+
+.. autoclass:: fsspec.core.BaseCache
    :members:
 
 .. autoclass:: fsspec.core.OpenFile
    :members:
 
 .. autoclass:: fsspec.core.OpenFiles
-
-.. autoclass:: fsspec.core.BaseCache
-   :members:
 
 .. autofunction:: fsspec.core.get_fs_token_paths
 
@@ -85,21 +85,21 @@ Base Classes
 .. autoclass:: fsspec.dircache.DirCache
    :members: __init__
 
-.. autofunction:: fsspec.registry.register_implementation
-
-.. autoclass:: fsspec.callbacks.Callback
-   :members:
-
-.. autoclass:: fsspec.callbacks.NoOpCallback
-   :members:
-
-.. autoclass:: fsspec.callbacks.DotPrinterCallback
-   :members:
-
-.. autoclass:: fsspec.callbacks.TqdmCallback
+.. autoclass:: fsspec.FSMap
    :members:
 
 .. autoclass:: fsspec.generic.GenericFileSystem
+
+.. autofunction:: fsspec.registry.register_implementation
+
+.. autoclass:: fsspec.spec.AbstractBufferedFile
+   :members:
+
+.. autoclass:: fsspec.spec.AbstractFileSystem
+   :members:
+
+.. autoclass:: fsspec.spec.Transaction
+   :members:
 
 .. _implementations:
 
@@ -107,31 +107,28 @@ Built-in Implementations
 ------------------------
 
 .. autosummary::
-   fsspec.implementations.ftp.FTPFileSystem
    fsspec.implementations.arrow.ArrowFSWrapper
    fsspec.implementations.arrow.HadoopFileSystem
-   fsspec.implementations.dask.DaskWorkerFileSystem
-   fsspec.implementations.http.HTTPFileSystem
-   fsspec.implementations.local.LocalFileSystem
-   fsspec.implementations.memory.MemoryFileSystem
-   fsspec.implementations.github.GithubFileSystem
-   fsspec.implementations.sftp.SFTPFileSystem
-   fsspec.implementations.webhdfs.WebHDFS
-   fsspec.implementations.zip.ZipFileSystem
    fsspec.implementations.cached.CachingFileSystem
-   fsspec.implementations.cached.WholeFileCacheFileSystem
    fsspec.implementations.cached.SimpleCacheFileSystem
+   fsspec.implementations.cached.WholeFileCacheFileSystem
+   fsspec.implementations.dask.DaskWorkerFileSystem
+   fsspec.implementations.dbfs.DatabricksFileSystem
+   fsspec.implementations.dirfs.DirFileSystem
+   fsspec.implementations.ftp.FTPFileSystem
    fsspec.implementations.git.GitFileSystem
-   fsspec.implementations.smb.SMBFileSystem
+   fsspec.implementations.github.GithubFileSystem
+   fsspec.implementations.http.HTTPFileSystem
    fsspec.implementations.jupyter.JupyterFileSystem
    fsspec.implementations.libarchive.LibArchiveFileSystem
-   fsspec.implementations.dbfs.DatabricksFileSystem
+   fsspec.implementations.local.LocalFileSystem
+   fsspec.implementations.memory.MemoryFileSystem
    fsspec.implementations.reference.ReferenceFileSystem
-   fsspec.implementations.dirfs.DirFileSystem
+   fsspec.implementations.sftp.SFTPFileSystem
+   fsspec.implementations.smb.SMBFileSystem
    fsspec.implementations.tar.TarFileSystem
-
-.. autoclass:: fsspec.implementations.ftp.FTPFileSystem
-   :members: __init__
+   fsspec.implementations.webhdfs.WebHDFS
+   fsspec.implementations.zip.ZipFileSystem
 
 .. autoclass:: fsspec.implementations.arrow.ArrowFSWrapper
    :members: __init__
@@ -139,43 +136,34 @@ Built-in Implementations
 .. autoclass:: fsspec.implementations.arrow.HadoopFileSystem
    :members: __init__
 
-.. autoclass:: fsspec.implementations.dask.DaskWorkerFileSystem
-   :members: __init__
-
-.. autoclass:: fsspec.implementations.http.HTTPFileSystem
-   :members: __init__
-
-.. autoclass:: fsspec.implementations.local.LocalFileSystem
-   :members: __init__
-
-.. autoclass:: fsspec.implementations.memory.MemoryFileSystem
-   :members: __init__
-
-.. autoclass:: fsspec.implementations.sftp.SFTPFileSystem
-   :members: __init__
-
-.. autoclass:: fsspec.implementations.webhdfs.WebHDFS
-   :members: __init__
-
-.. autoclass:: fsspec.implementations.zip.ZipFileSystem
-   :members: __init__
-
 .. autoclass:: fsspec.implementations.cached.CachingFileSystem
-   :members: __init__
-
-.. autoclass:: fsspec.implementations.cached.WholeFileCacheFileSystem
    :members: __init__
 
 .. autoclass:: fsspec.implementations.cached.SimpleCacheFileSystem
    :members: __init__
 
-.. autoclass:: fsspec.implementations.github.GithubFileSystem
+.. autoclass:: fsspec.implementations.cached.WholeFileCacheFileSystem
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.dask.DaskWorkerFileSystem
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.dbfs.DatabricksFileSystem
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.dirfs.DirFileSystem
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.ftp.FTPFileSystem
    :members: __init__
 
 .. autoclass:: fsspec.implementations.git.GitFileSystem
    :members: __init__
 
-.. autoclass:: fsspec.implementations.smb.SMBFileSystem
+.. autoclass:: fsspec.implementations.github.GithubFileSystem
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.http.HTTPFileSystem
    :members: __init__
 
 .. autoclass:: fsspec.implementations.jupyter.JupyterFileSystem
@@ -184,44 +172,56 @@ Built-in Implementations
 .. autoclass:: fsspec.implementations.libarchive.LibArchiveFileSystem
    :members: __init__
 
-.. autoclass:: fsspec.implementations.dbfs.DatabricksFileSystem
+.. autoclass:: fsspec.implementations.local.LocalFileSystem
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.memory.MemoryFileSystem
    :members: __init__
 
 .. autoclass:: fsspec.implementations.reference.ReferenceFileSystem
    :members: __init__
 
-.. autoclass:: fsspec.implementations.dirfs.DirFileSystem
+.. autoclass:: fsspec.implementations.sftp.SFTPFileSystem
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.smb.SMBFileSystem
    :members: __init__
 
 .. autoclass:: fsspec.implementations.tar.TarFileSystem
    :members: __init__
 
+.. autoclass:: fsspec.implementations.webhdfs.WebHDFS
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.zip.ZipFileSystem
+   :members: __init__
+
 Other Known Implementations
 ---------------------------
 
-- `s3fs`_ for Amazon S3 and other compatible stores
-- `gcsfs`_ for Google Cloud Storage
-- `adl`_ for Azure DataLake storage
 - `abfs`_ for Azure Blob service
+- `adl`_ for Azure DataLake storage
 - `dropbox`_ for access to dropbox shares
-- `ocifs`_ for access to Oracle Cloud Object Storage
-- `gdrive`_ to access Google Drive and shares (experimental)
-- `wandbfs`_ to access Wandb run data (experimental)
-- `ossfs`_ for Alibaba Cloud (Aliyun) Object Storage System (OSS)
-- `webdav4`_ for WebDAV
 - `dvc`_ to access DVC/Git repository as a filesystem
+- `gcsfs`_ for Google Cloud Storage
+- `gdrive`_ to access Google Drive and shares (experimental)
+- `ocifs`_ for access to Oracle Cloud Object Storage
+- `ossfs`_ for Alibaba Cloud (Aliyun) Object Storage System (OSS)
+- `s3fs`_ for Amazon S3 and other compatible stores
+- `wandbfs`_ to access Wandb run data (experimental)
+- `webdav4`_ for WebDAV
 
-.. _s3fs: https://s3fs.readthedocs.io/en/latest/
-.. _gcsfs: https://gcsfs.readthedocs.io/en/latest/
-.. _adl: https://github.com/dask/adlfs
 .. _abfs: https://github.com/dask/adlfs
+.. _adl: https://github.com/dask/adlfs
 .. _dropbox: https://github.com/MarineChap/intake_dropbox
-.. _ocifs: https://pypi.org/project/ocifs
-.. _gdrive: https://github.com/fsspec/gdrivefs
-.. _wandbfs: https://github.com/jkulhanek/wandbfs
-.. _ossfs: https://github.com/fsspec/ossfs
-.. _webdav4: https://github.com/skshetry/webdav4
 .. _dvc: https://github.com/iterative/dvc
+.. _gcsfs: https://gcsfs.readthedocs.io/en/latest/
+.. _gdrive: https://github.com/fsspec/gdrivefs
+.. _ocifs: https://pypi.org/project/ocifs
+.. _ossfs: https://github.com/fsspec/ossfs
+.. _s3fs: https://s3fs.readthedocs.io/en/latest/
+.. _wandbfs: https://github.com/jkulhanek/wandbfs
+.. _webdav4: https://github.com/skshetry/webdav4
 
 .. _readbuffering:
 
@@ -229,13 +229,12 @@ Read Buffering
 --------------
 
 .. autosummary::
+   fsspec.caching.BlockCache
+   fsspec.caching.BytesCache
+   fsspec.caching.MMapCache
+   fsspec.caching.ReadAheadCache
 
-  fsspec.caching.ReadAheadCache
-  fsspec.caching.BytesCache
-  fsspec.caching.MMapCache
-  fsspec.caching.BlockCache
-
-.. autoclass:: fsspec.caching.ReadAheadCache
+.. autoclass:: fsspec.caching.BlockCache
    :members:
 
 .. autoclass:: fsspec.caching.BytesCache
@@ -244,7 +243,7 @@ Read Buffering
 .. autoclass:: fsspec.caching.MMapCache
    :members:
 
-.. autoclass:: fsspec.caching.BlockCache
+.. autoclass:: fsspec.caching.ReadAheadCache
    :members:
 
 Utilities

--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -135,15 +135,15 @@ available as the attribute ``.loop``.
 
 .. autosummary::
    fsspec.asyn.AsyncFileSystem
+   fsspec.asyn.get_loop
    fsspec.asyn.sync
    fsspec.asyn.sync_wrapper
-   fsspec.asyn.get_loop
 
 .. autoclass:: fsspec.asyn.AsyncFileSystem
    :members:
 
+.. autofunction:: fsspec.asyn.get_loop
+
 .. autofunction:: fsspec.asyn.sync
 
 .. autofunction:: fsspec.asyn.sync_wrapper
-
-.. autofunction:: fsspec.asyn.get_loop


### PR DESCRIPTION
There are a few lists in the docs, mostly in the API reference. This PR changes the order of the list contents to be alphabetical rather than the order they were added, as I find this easier to scan. But I don't really have a strong view about this.