### PR TITLE
[add] seekable for ArrowFile

### DIFF
--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -200,7 +200,7 @@ class ArrowFSWrapper(AbstractFileSystem):
 
 
 @mirror_from(
-    "stream", ["read", "seek", "tell", "write", "readable", "writable", "close", "size"]
+    "stream", ["read", "seek", "tell", "write", "readable", "writable", "close", "size", "seekable"]
 )
 class ArrowFile(io.IOBase):
     def __init__(self, fs, stream, path, mode, block_size=None, **kwargs):


### PR DESCRIPTION
Fix https://github.com/fsspec/filesystem_spec/issues/1153

ref:
https://arrow.apache.org/docs/python/generated/pyarrow.fs.HadoopFileSystem.html#pyarrow.fs.HadoopFileSystem
- `open_*_streams` and `open_input_file` of `pyarrow.fs.HadoopFileSystem` return `pyarrow.NativeFile`.
- `pyarrow.NativeFile` supports `seekable`.
