### PR TITLE
Fix reference fs cat path list

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -357,7 +357,8 @@ class ReferenceFileSystem(AsyncFileSystem):
             bytes_out = fs.cat_ranges(new_paths, new_starts, new_ends)
             if len(urls2) == len(bytes_out):
                 # we didn't do any merging
-                for p, b in zip(paths2, bytes_out):
+                for url, b in zip(new_paths, bytes_out):
+                    p = paths2[urls2.index(url)]
                     out[p] = b
             else:
                 # unbundle from merged bytes - simple approach

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -565,3 +565,16 @@ def test_df_multi(m):
     assert fs.cat("a") == b"raw"
     assert fs.cat("b") == data + data[4:8]
     assert fs.cat("d") == data[4:6] + b"hello"[1:3]
+
+
+def test_mapping_getitems(m):
+    m.pipe({"a": b"A", "b": b"B"})
+
+    refs = {
+        "a": ["a"],
+        "b": ["b"],
+    }
+    h = fsspec.filesystem("memory")
+    fs = fsspec.filesystem("reference", fo=refs, fs=h)
+    mapping = fs.get_mapper("")
+    assert mapping.getitems(["b", "a"]) == {"a": b"A", "b": b"B"}


### PR DESCRIPTION
Hello everyone,

here's a potential fix for the issue revealed in zarr-developers/zarr-python#1324

I added a test to check the order of returned data when using `FSMap.getitems`
Without the fix, it errors with

```python
    def test_mapping_getitems(m):
        m.pipe({"a": b"A", "b": b"B"})
    
        refs = {
            "a": ["a"],
            "b": ["b"],
        }
        h = fsspec.filesystem("memory")
        fs = fsspec.filesystem("reference", fo=refs, fs=h)
        mapping = fs.get_mapper("")
>       assert mapping.getitems(["b", "a"]) == {"a": b"A", "b": b"B"}
E       AssertionError: assert {'a': b'B', 'b': b'A'} == {'a': b'A', 'b': b'B'}
E         Differing items:
E         {'b': b'A'} != {'b': b'B'}
E         {'a': b'B'} != {'a': b'A'}
E         Full diff:
E         - {'a': b'A', 'b': b'B'}
E         + {'a': b'B', 'b': b'A'}

```

Regarding the fix: I'm not sure if this should be solved differently, since the non-merging codepath is probably the more common. Also I haven't tested if `DFReferenceFileSystem.cat_ranges` has the same issue...

Cheers,
Andreas 😃 
