### PR TITLE
Add Python 3.11 to CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PY: ["3.8", "3.9", "3.10"]
+        PY: ["3.8", "3.9", "3.10", "3.11"]
 
     env:
       CIRUN: true

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     description="File-system specification",
     long_description=long_description,


### PR DESCRIPTION
This PR adds Python 3.11 to CI. Tests all pass locally on macOS using Python 3.11. 

I've also updated the classifiers to indicate 3.11 is supported.

The `versioneer.py` that we vendor only claims support up to Python 3.9 but I haven't experienced any problems with it and left it as it is.