### PR TITLE
Added block cache with pre-loading of the data in the background thread.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -234,6 +234,7 @@ Read Buffering
    fsspec.caching.MMapCache
    fsspec.caching.ReadAheadCache
    fsspec.caching.FirstChunkCache
+   fsspec.caching.BackgroundBlockCache
 
 .. autoclass:: fsspec.caching.BlockCache
    :members:
@@ -248,6 +249,9 @@ Read Buffering
    :members:
 
 .. autoclass:: fsspec.caching.FirstChunkCache
+   :members:
+
+.. autoclass:: fsspec.caching.BackgroundBlockCache
    :members:
 
 Utilities

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -1,10 +1,10 @@
+import collections
 import functools
 import io
 import logging
 import math
 import os
 import warnings
-import collections
 from concurrent.futures import ThreadPoolExecutor
 
 logger = logging.getLogger("fsspec")

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -633,9 +633,7 @@ class BackgroundBlockCache(BaseCache):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        self._fetch_block_cached = BackgroundBlockCache.UpdatableLRU(
-            self._fetch_block, state["maxblocks"]
-        )
+        self._fetch_block_cached = UpdatableLRU(self._fetch_block, state["maxblocks"])
         self._thread_executor = ThreadPoolExecutor(max_workers=1)
         self._fetch_future_block_number = None
         self._fetch_future = None

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -576,7 +576,7 @@ class BackgroundBlockCache(BaseCache):
                 self._cache.popitem(last=False)
 
         def cache_info(self):
-            return CacheInfo(
+            return self.CacheInfo(
                 maxsize=self._max_size,
                 currsize=len(self._cache),
                 hits=self._hits,


### PR DESCRIPTION
Hi everyone,

this PR contains an implementation of BackgroundBlockCache that tries to pre-fetch the next block of data in the background thread before we actually need it for reading. This should reduce the time our main thread spends blocked on IO. 

One example use case for this type of cache is video playback (similar to YouTube). We want to pre-fetch some blocks in front to avoid video "freezing" while we have to load new data.

This implementation passes all the tests and works well for me. The only concern I have is thread-safety of `super()._fetch`. Is it safe to run it from a separate thread?