### PR TITLE
fsspec.implementations.reference: allow import in python 3.7

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -812,7 +812,8 @@ class DFReferenceFileSystem(AbstractFileSystem):
             if isinstance(inds, int):
                 inds = [inds]
             for i in inds:
-                if x := self.dataframes[pref]["raw"][i]:
+                x = self.dataframes[pref]["raw"][i]
+                if x:
                     thislist.append(x)
                 else:
                     # infer path - cache this?


### PR DESCRIPTION
Hello @martindurant,

I noticed this due to a failing CI test running on python3.7.

```python
tiffslide/tiffslide.py:34: in <module>
    from fsspec.implementations.reference import ReferenceFileSystem
E     File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/fsspec/implementations/reference.py", line 7[97](https://github.com/bayer-science-for-a-better-life/tiffslide/actions/runs/4129073532/jobs/7134279388#step:6:98)
E       if x := self.dataframes[pref]["raw"][i]:
E             ^
E   SyntaxError: invalid syntax
```

This PR should restore fsspec's Python3.7 compatibility.

Cheers,
Andreas 😃 