### PR TITLE
Allow numpy-like inputs to async cat/ranges

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -3,12 +3,14 @@ import asyncio.events
 import functools
 import inspect
 import io
+import numbers
 import os
 import re
 import sys
 import threading
 from contextlib import contextmanager
 from glob import has_magic
+from typing import Iterable
 
 from .callbacks import _DEFAULT_CALLBACK
 from .exceptions import FSTimeoutError
@@ -393,7 +395,7 @@ class AsyncFileSystem(AbstractFileSystem):
                     end = size + end
             elif end is None:
                 end = ""
-            if isinstance(end, int):
+            if isinstance(end, numbers.Integral):
                 end -= 1  # bytes range is inclusive
         return "bytes=%s-%s" % (start, end)
 
@@ -442,9 +444,9 @@ class AsyncFileSystem(AbstractFileSystem):
             raise NotImplementedError
         if not isinstance(paths, list):
             raise TypeError
-        if not isinstance(starts, list):
+        if not isinstance(starts, Iterable):
             starts = [starts] * len(paths)
-        if not isinstance(ends, list):
+        if not isinstance(ends, Iterable):
             ends = [starts] * len(paths)
         if len(starts) != len(paths) or len(ends) != len(paths):
             raise ValueError

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -329,6 +329,15 @@ def test_cat_file_range(server):
     assert h.cat(urla, end=-10) == data[:-10]
 
 
+def test_cat_file_range_numpy(server):
+    np = pytest.importorskip("numpy")
+    h = fsspec.filesystem("http", headers={"give_length": "true", "head_ok": "true "})
+    urla = server + "/index/realfile"
+    assert h.cat(urla, start=np.int8(1), end=np.int8(10)) == data[1:10]
+    out = h.cat_ranges([urla, urla], starts=np.array([1, 5]), ends=np.array([10, 15]))
+    assert out == [data[1:10], data[5:15]]
+
+
 def test_mcat_cache(server):
     urla = server + "/index/realfile"
     urlb = server + "/index/otherfile"


### PR DESCRIPTION
Fixes https://github.com/fsspec/kerchunk/issues/294

cc @hakon-matland-adsk