### PR TITLE
raise lower bound to python>=3.8

### DIFF
--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -1,11 +1,4 @@
-try:
-    from importlib.metadata import entry_points
-except ImportError:  # python < 3.8
-    try:
-        from importlib_metadata import entry_points
-    except ImportError:
-        entry_points = None
-
+from importlib.metadata import entry_points
 
 from . import _version, caching
 from .callbacks import Callback

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -6,7 +6,6 @@ import io
 import numbers
 import os
 import re
-import sys
 import threading
 from contextlib import contextmanager
 from glob import has_magic
@@ -122,11 +121,7 @@ def sync_wrapper(func, obj=None):
 def _selector_policy():
     original_policy = asyncio.get_event_loop_policy()
     try:
-        if (
-            sys.version_info >= (3, 8)
-            and os.name == "nt"
-            and hasattr(asyncio, "WindowsSelectorEventLoopPolicy")
-        ):
+        if os.name == "nt" and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
         yield

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from fsspec.asyn import AsyncFileSystem
@@ -21,9 +19,6 @@ def make_fs(mocker):
         }
 
         if async_impl:
-            if asynchronous and sys.version_info < (3, 8):
-                pytest.skip("no AsyncMock before Python 3.8")
-
             attrs["asynchronous"] = asynchronous
             cls = AsyncFileSystem
         else:

--- a/fsspec/tests/test_registry.py
+++ b/fsspec/tests/test_registry.py
@@ -1,4 +1,5 @@
 import sys
+from importlib.metadata import EntryPoint
 from unittest.mock import create_autospec, patch
 
 import pytest
@@ -12,11 +13,6 @@ from fsspec.registry import (
     registry,
 )
 from fsspec.spec import AbstractFileSystem
-
-try:
-    from importlib.metadata import EntryPoint
-except ImportError:  # python < 3.8
-    from importlib_metadata import EntryPoint
 
 
 @pytest.fixture()
@@ -94,10 +90,7 @@ def test_entry_points_registered_on_import(clear_registry, clean_imports):
     mock_ep = create_autospec(EntryPoint, module="fsspec.spec.AbstractFileSystem")
     mock_ep.name = "test"  # this can't be set in the constructor...
     mock_ep.value = "fsspec.spec.AbstractFileSystem"
-    if sys.version_info < (3, 8):
-        import_location = "importlib_metadata.entry_points"
-    else:
-        import_location = "importlib.metadata.entry_points"
+    import_location = "importlib.metadata.entry_points"
     with patch(import_location, return_value={"fsspec.specs": [mock_ep]}):
         assert "test" not in registry
         import fsspec  # noqa
@@ -110,10 +103,7 @@ def test_filesystem_warning_arrow_hdfs_deprecated(clear_registry, clean_imports)
     mock_ep = create_autospec(EntryPoint, module="fsspec.spec.AbstractFileSystem")
     mock_ep.name = "arrow_hdfs"  # this can't be set in the constructor...
     mock_ep.value = "fsspec.spec.AbstractFileSystem"
-    if sys.version_info < (3, 8):
-        import_location = "importlib_metadata.entry_points"
-    else:
-        import_location = "importlib.metadata.entry_points"
+    import_location = "importlib.metadata.entry_points"
     with patch(import_location, return_value={"fsspec.specs": [mock_ep]}):
         import fsspec  # noqa
 

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -7,6 +7,7 @@ import sys
 from contextlib import contextmanager
 from functools import partial
 from hashlib import md5
+from importlib.metadata import version
 from urllib.parse import urlsplit
 
 DEFAULT_BLOCK_SIZE = 5 * 2**20
@@ -422,20 +423,10 @@ def get_package_version_without_import(name):
         mod = sys.modules[name]
         if hasattr(mod, "__version__"):
             return mod.__version__
-    if sys.version_info >= (3, 8):
-        try:
-            import importlib.metadata
-
-            return importlib.metadata.distribution(name).version
-        except:  # noqa: E722
-            pass
-    else:
-        try:
-            import importlib_metadata
-
-            return importlib_metadata.distribution(name).version
-        except:  # noqa: E722
-            pass
+    try:
+        return version(name)
+    except:  # noqa: E722
+        pass
     try:
         import importlib
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ setup(
     python_requires=">=3.7",
     install_requires=open("requirements.txt").read().strip().split("\n"),
     extras_require={
-        "entrypoints": ["importlib_metadata ; python_version < '3.8' "],
+        "entrypoints": [],
         "abfs": ["adlfs"],
         "adl": ["adlfs"],
         "dask": ["dask", "distributed"],


### PR DESCRIPTION
Addresses #1165 by bumping minor python version to 3.8 and removes now obsolete checks/workarounds for `python < 3.8`

The only version with minor compatibility issues with python 3.7 is `2023.1.0` which would require this patch: https://github.com/ap--/filesystem_spec/commit/256378afa3bbf350602d553632bda146d39e1008
Not sure if it's worth the effort to release a fixed version `2023.1.1` to pypi though.