### PR TITLE
Setting map value with array should use bytes not bytearray

### DIFF
--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -191,7 +191,7 @@ def maybe_convert(value):
             # The buffer interface doesn't support datetime64/timdelta64 numpy
             # arrays
             value = value.view("int64")
-        value = bytearray(memoryview(value))
+        value = bytes(memoryview(value))
     return value
 
 


### PR DESCRIPTION
It may be a copy, but it behaves better in other places