### PR TITLE
Copy/get/put empty directories correctly

### DIFF
--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -272,6 +272,44 @@ def test_put_directory_recursive(m, tmpdir):
         assert m.find(target) == correct
 
 
+def test_cp_empty_directory(m):
+    # https://github.com/fsspec/filesystem_spec/issues/1198
+    # cp/get/put of empty directory.
+    empty = "/src/empty"
+    m.mkdir(empty)
+
+    target = "/target"
+    m.mkdir(target)
+
+    # cp without slash, target directory exists
+    assert m.isdir(target)
+    m.cp(empty, target)
+    assert m.find(target, withdirs=True) == [target + "/empty"]
+
+    m.rm(target + "/empty", recursive=True)
+
+    # cp with slash, target directory exists
+    assert m.isdir(target)
+    m.cp(empty + "/", target)
+    assert m.find(target, withdirs=True) == []
+
+    m.rm(target, recursive=True)
+
+    # cp without slash, target directory doesn't exist
+    assert not m.isdir(target)
+    m.cp(empty, target)
+    assert m.isdir(target)
+    assert m.find(target, withdirs=True) == []
+
+    m.rm(target, recursive=True)
+
+    # cp with slash, target directory doesn't exist
+    assert not m.isdir(target)
+    m.cp(empty + "/", target)
+    assert m.isdir(target)
+    assert m.find(target, withdirs=True) == []
+
+
 def test_cp_two_files(m):
     src = "/src"
     file0 = src + "/file0"

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -255,23 +255,48 @@ def test_common_prefix(paths, out):
 
 
 @pytest.mark.parametrize(
-    "paths, other, is_dir, expected",
+    "paths, other, is_dir, exists, expected",
     (
-        (["/path1"], "/path2", False, ["/path2"]),
-        (["/path1"], "/path2", True, ["/path2/path1"]),
-        (["/path1"], "/path2", None, ["/path2"]),
-        (["/path1"], "/path2/", True, ["/path2/path1"]),
-        (["/path1"], ["/path2"], True, ["/path2"]),
-        (["/path1", "/path2"], "/path2", True, ["/path2/path1", "/path2/path2"]),
+        (["/path1"], "/path2", False, False, ["/path2"]),
+        (["/path1"], "/path2", True, True, ["/path2/path1"]),
+        (["/path1"], "/path2", None, False, ["/path2"]),
+        (["/path1"], "/path2/", True, True, ["/path2/path1"]),
+        (["/path1"], ["/path2"], True, False, ["/path2"]),
+        (["/path1"], ["/path2"], True, True, ["/path2"]),
+        (["/path1", "/path2"], "/path2", True, False, ["/path2/path1", "/path2/path2"]),
+        (["/path1", "/path2"], "/path2", True, True, ["/path2/path1", "/path2/path2"]),
         (
             ["/more/path1", "/more/path2"],
             "/path2",
             True,
+            False,
             ["/path2/path1", "/path2/path2"],
         ),
         (
             ["/more/path1", "/more/path2"],
             "/path2",
+            True,
+            True,
+            ["/path2/more/path1", "/path2/more/path2"],
+        ),
+        (
+            ["/more/path1", "/more/path2"],
+            "/path2",
+            False,
+            False,
+            ["/path2/path1", "/path2/path2"],
+        ),
+        (
+            ["/more/path1", "/more/path2"],
+            "/path2",
+            False,
+            True,
+            ["/path2/more/path1", "/path2/more/path2"],
+        ),
+        (
+            ["/more/path1", "/more/path2"],
+            "/path2/",
+            None,
             False,
             ["/path2/path1", "/path2/path2"],
         ),
@@ -279,18 +304,27 @@ def test_common_prefix(paths, out):
             ["/more/path1", "/more/path2"],
             "/path2/",
             None,
-            ["/path2/path1", "/path2/path2"],
+            True,
+            ["/path2/more/path1", "/path2/more/path2"],
         ),
         (
             ["/more/path1", "/diff/path2"],
             "/path2/",
             None,
+            False,
+            ["/path2/more/path1", "/path2/diff/path2"],
+        ),
+        (
+            ["/more/path1", "/diff/path2"],
+            "/path2/",
+            None,
+            True,
             ["/path2/more/path1", "/path2/diff/path2"],
         ),
     ),
 )
-def test_other_paths(paths, other, is_dir, expected):
-    assert other_paths(paths, other, is_dir) == expected
+def test_other_paths(paths, other, is_dir, exists, expected):
+    assert other_paths(paths, other, is_dir, exists) == expected
 
 
 def test_log():

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -366,16 +366,10 @@ def other_paths(paths, path2, is_dir=None, exists=False):
     if isinstance(path2, str):
         is_dir = is_dir or path2.endswith("/")
         path2 = path2.rstrip("/")
-        if len(paths) > 1:
-            cp = common_prefix(paths)
-            if exists:
-                cp = cp.rsplit("/", 1)[0]
-            path2 = [p.replace(cp, path2, 1) for p in paths]
-        else:
-            if is_dir:
-                path2 = [path2.rstrip("/") + "/" + paths[0].rsplit("/")[-1]]
-            else:
-                path2 = [path2]
+        cp = common_prefix(paths)
+        if exists:
+            cp = cp.rsplit("/", 1)[0]
+        path2 = [p.replace(cp, path2, 1) for p in paths]
     else:
         assert len(paths) == len(path2)
     return path2


### PR DESCRIPTION
Fixes #1198.

`cp`, `get` and `put` of an empty directory wasn't correctly respecting the presence of a trailing slash.

Fix is located in `other_paths()` so will correct all sync and async uses. There were separate code paths for `len(paths)==1` and `len(paths)>1` source paths, and the handling of the trailing slash using the `exists` arg was already in the `>1` code path so needed to also be in the `==1` code path. This change has allowed me to combine both code paths into one thus making the function simpler.

With this change the new "empty directory" tests pass. The only existing tests that failed as a result of it were two of the `test_other_paths` which I have updated to include the `exists` argument which has been presumably been added since those tests were first created.