### PR TITLE
set location by webhdfs server

### DIFF
--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -420,7 +420,9 @@ class WebHDFile(AbstractBufferedFile):
                 location, headers={"content-type": "application/octet-stream"}
             )
             out2.raise_for_status()
-        self.location = location.replace("CREATE", "APPEND")
+            # after creating empty file, change location to append to
+            out2 = self.fs._call("APPEND", "POST", self.path, redirect=False, **kwargs)
+            self.location = self.fs._apply_proxy(out2.headers["Location"])
 
     def _fetch_range(self, start, end):
         start = max(start, 0)


### PR DESCRIPTION
The location has query parameters when using WebHDFS.
[The query parameters is encrypted by apache knox](https://knox.apache.org/books/knox-2-0-0/user-guide.html#WebHDFS+URL+Mapping).
Therefore, the location should not be manipulated like `location.replace("CREATE", "APPEND")`.
The webhdfs location should be refered by WebHDFS server.
