### PR TITLE
Fix BackgroundBlockCache. Do not clean up the fetch variables if we do not need the block for a current read.

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -661,6 +661,9 @@ class BackgroundBlockCache(BaseCache):
                     self._fetch_block_cached.add_key(
                         self._fetch_future.result(), self._fetch_future_block_number
                     )
+                    # Cleanup the fetch variables. Done with fetching the block.
+                    self._fetch_future_block_number = None
+                    self._fetch_future = None
                 else:
                     # Must join if we need the block for the current fetch
                     must_join = bool(
@@ -674,9 +677,9 @@ class BackgroundBlockCache(BaseCache):
                         fetch_future_block_number = self._fetch_future_block_number
                         fetch_future = self._fetch_future
 
-            # Cleanup the fetch variables. Either done or have a local copy.
-            self._fetch_future_block_number = None
-            self._fetch_future = None
+                        # Cleanup the fetch variables. Have a local copy.
+                        self._fetch_future_block_number = None
+                        self._fetch_future = None
 
         # Need to wait for the future for the current read
         if fetch_future is not None:


### PR DESCRIPTION
Sorry, but it looks like I've introduced a bug when trying to make the cache thread safe if `fetch` is called from different threads.

The current version removes the background fetch future if it does not need the result for the current read. It results in constantly creating new fetch tasks. This PR fixes the issue, such that we clean up background fetch futures, only if we are done or we have a local copy and have to wait for results. If we do not need the result for current read, it will just keep the current future and check if fetching is done on the next call.
