### PR TITLE
Skip pyarrow-requiring tests if missing and make posix test run anywhere

### DIFF
--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -482,7 +482,8 @@ def test_make_path_posix():
         )
     assert "/" in make_path_posix("rel\\path")
 
-    assert "." not in make_path_posix("./path")
+    pp = make_path_posix("./path")
+    assert "./" not in pp and ".\\" not in pp
 
 
 def test_linked_files(tmpdir):

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -521,6 +521,7 @@ def test_cat_missing(m):
 
 def test_df_single(m):
     pd = pytest.importorskip("pandas")
+    pytest.importorskip("pyarrow")
     data = b"data0data1data2"
     m.pipe({"data": data})
     df = pd.DataFrame(
@@ -541,6 +542,7 @@ def test_df_single(m):
 
 def test_df_multi(m):
     pd = pytest.importorskip("pandas")
+    pytest.importorskip("pyarrow")
     data = b"data0data1data2"
     m.pipe({"data": data, "data2": b"hello"})
     df = pd.DataFrame(


### PR DESCRIPTION
Fixes https://github.com/fsspec/filesystem_spec/issues/970
Fixes https://github.com/fsspec/filesystem_spec/issues/1161