### PR TITLE
Remove unneeded maxdepth manipulation in expand_path

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1025,8 +1025,6 @@ class AbstractFileSystem(metaclass=_Cached):
                 if p not in out and (recursive is False or self.exists(p)):
                     # should only check once, for the root
                     out.add(p)
-            # reduce depth on each recursion level unless None or 0
-            maxdepth = maxdepth if not maxdepth else maxdepth - 1
         if not out:
             raise FileNotFoundError(path)
         return list(sorted(out))

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -208,6 +208,26 @@ def test_expand_path_recursive(test_paths, expected):
         "top_level/second_level",
     ]
 
+    assert test_fs.expand_path("top_level", recursive=True, maxdepth=2) == [
+        "top_level",
+        "top_level/second_level",
+        "top_level/second_level/date=2019-10-01",
+        "top_level/second_level/date=2019-10-02",
+        "top_level/second_level/date=2019-10-04",
+    ]
+
+    assert test_fs.expand_path("top_level", recursive=True, maxdepth=3) == [
+        "top_level",
+        "top_level/second_level",
+        "top_level/second_level/date=2019-10-01",
+        "top_level/second_level/date=2019-10-01/a.parquet",
+        "top_level/second_level/date=2019-10-01/b.parquet",
+        "top_level/second_level/date=2019-10-02",
+        "top_level/second_level/date=2019-10-02/a.parquet",
+        "top_level/second_level/date=2019-10-04",
+        "top_level/second_level/date=2019-10-04/a.parquet",
+    ]
+
     with pytest.raises(ValueError):
         test_fs.expand_path("top_level", recursive=True, maxdepth=0)
     with pytest.raises(ValueError):


### PR DESCRIPTION
There was a line at the end of `expand_path()` that decremented the `maxdepth` although it wasn't used subsequently. I have confirmed that the line is not needed as it is always handled eventually by the call to `self.find()` within the function.

This PR removes the unused line, and adds extra tests of `expand_path()` to confirm that the behaviour is correct when `maxdepth` is changed.