### PR TITLE
Fix doc build warnings

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,7 +23,7 @@ Fixes
 Other
 
 - #1186, make seekable=True default for pyarrow files
-= #1184, 1185, set minimum python version to 3.8
+- #1184, 1185, set minimum python version to 3.8
 
 2023.1.0
 --------

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -371,7 +371,7 @@ Alternatively, you can provide overrides with environment variables of the style
 
 Configuration is determined in the following order, with later items winning:
 
-#.  ini and json files in the config directory (``FSSPEC_CONFIG_DIRECTORY`` or ``$HOME/.config/fsspec/``), sorted
+#. ini and json files in the config directory (``FSSPEC_CONFIG_DIRECTORY`` or ``$HOME/.config/fsspec/``), sorted
    lexically by filename
 #. ``FSSPEC_{protocol}`` environment variables
 #. ``FSSPEC_{protocol}_{kwargname}`` environment variables


### PR DESCRIPTION
This fixes 3 warnings that occur in the docs build:

```
docs/source/changelog.rst:26: WARNING: Bullet list ends without a blank line; unexpected unindent.
docs/source/features.rst:375: WARNING: Enumerated list ends without a blank line; unexpected unindent.
docs/source/features.rst:376: WARNING: Block quote ends without a blank line; unexpected unindent.
```

This should hopefully allow the Read the Docs builds to succeed.