### PR TITLE
Bug fixes on AbstractAsyncStreamedFile

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -960,7 +960,7 @@ class AbstractAsyncStreamedFile(AbstractBufferedFile):
                 self.closed = True
                 raise
 
-        if self._upload_chunk(final=force) is not False:
+        if await self._upload_chunk(final=force) is not False:
             self.offset += self.buffer.seek(0, 2)
             self.buffer = io.BytesIO()
 
@@ -974,7 +974,7 @@ class AbstractAsyncStreamedFile(AbstractBufferedFile):
         raise NotImplementedError
 
     async def _initiate_upload(self):
-        raise NotImplementedError
+        pass
 
     async def _upload_chunk(self, final=False):
         raise NotImplementedError

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -193,5 +193,5 @@ async def test_async_streamed_file_write():
 async def test_async_streamed_file_read():
     test_fs = DummyAsyncFS()
     streamed_file = await test_fs.open_async("misc/foo.txt", mode="rb")
-    await streamed_file.read()
+    assert (await streamed_file.read(3)) + (await streamed_file.read()) == b"foo-bar"
     await streamed_file.close()

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import io
 import os
 import time
 
@@ -174,24 +175,45 @@ class DummyAsyncFS(fsspec.asyn.AsyncFileSystem):
 
 
 class DummyAsyncStreamedFile(fsspec.asyn.AbstractAsyncStreamedFile):
+    def __init__(self, fs, path, mode, block_size, autocommit, **kwargs):
+        super().__init__(fs, path, mode, block_size, autocommit, **kwargs)
+        self.temp_buffer = io.BytesIO(b"foo-bar" * 20)
+
     async def _fetch_range(self, start, end):
-        return "foo-bar"[start:end]
+        return self.temp_buffer.read(end - start)
+
+    async def _initiate_upload(self):
+        # Reinitialize for new uploads.
+        self.temp_buffer = io.BytesIO()
 
     async def _upload_chunk(self, final=False):
-        return final
+        self.temp_buffer.write(self.buffer.getbuffer())
+
+    async def get_data(self):
+        return self.temp_buffer.getbuffer().tobytes()
+
+    async def get_data(self):
+        return self.temp_buffer.getbuffer().tobytes()
 
 
 @pytest.mark.asyncio
 async def test_async_streamed_file_write():
     test_fs = DummyAsyncFS()
     streamed_file = await test_fs.open_async("misc/foo.txt", mode="wb")
-    await streamed_file.write("foo-bar".encode("utf8"))
+    inp_data = "foo-bar".encode("utf8") * streamed_file.blocksize * 2
+    await streamed_file.write(inp_data)
+    assert streamed_file.loc == len(inp_data)
     await streamed_file.close()
+    out_data = await streamed_file.get_data()
+    assert out_data.count(b"foo-bar") == streamed_file.blocksize * 2
 
 
 @pytest.mark.asyncio
 async def test_async_streamed_file_read():
     test_fs = DummyAsyncFS()
     streamed_file = await test_fs.open_async("misc/foo.txt", mode="rb")
-    assert (await streamed_file.read(3)) + (await streamed_file.read()) == b"foo-bar"
+    assert (
+        await streamed_file.read(7 * 3) + await streamed_file.read(7 * 18)
+        == b"foo-bar" * 20
+    )
     await streamed_file.close()


### PR DESCRIPTION

`AbstractAsyncStreamedFile`-  `_upload_chunk` from `flush` method is now modified to be awaited. 

Also, `_initiate_upload` method is now made non mandatory to be implemented by Async-backends (same behaviour as `AbstractBufferedFile`).

Fixes #1204