### PR TITLE
mv: no-op when paths are the same

### DIFF
--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -79,6 +79,13 @@ def test_mv_recursive(m):
     assert not m.exists("src")
 
 
+def test_mv_same_paths(m):
+    m.mkdir("src")
+    m.touch("src/file.txt")
+    m.mv("src", "src", recursive=True)
+    assert m.exists("src/file.txt")
+
+
 def test_rm_no_psuedo_dir(m):
     m.touch("/dir1/dir2/file")
     m.rm("/dir1", recursive=True)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1033,8 +1033,7 @@ class AbstractFileSystem(metaclass=_Cached):
         """Move file(s) from one location to another"""
         if path1 == path2:
             logger.debug(
-                "%s mv: The source and destination paths are the same, so no files were moved."
-                % (self)
+                "%s mv: The paths are the same, so no files were moved." % (self)
             )
         else:
             self.copy(path1, path2, recursive=recursive, maxdepth=maxdepth)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1032,7 +1032,10 @@ class AbstractFileSystem(metaclass=_Cached):
     def mv(self, path1, path2, recursive=False, maxdepth=None, **kwargs):
         """Move file(s) from one location to another"""
         if path1 == path2:
-            logger.debug("%s mv: The source and destination paths are the same, so no files were moved." % (self))
+            logger.debug(
+                "%s mv: The source and destination paths are the same, so no files were moved."
+                % (self)
+            )
         else:
             self.copy(path1, path2, recursive=recursive, maxdepth=maxdepth)
             self.rm(path1, recursive=recursive)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1031,8 +1031,11 @@ class AbstractFileSystem(metaclass=_Cached):
 
     def mv(self, path1, path2, recursive=False, maxdepth=None, **kwargs):
         """Move file(s) from one location to another"""
-        self.copy(path1, path2, recursive=recursive, maxdepth=maxdepth)
-        self.rm(path1, recursive=recursive)
+        if path1 == path2:
+            logger.debug("%s mv: The source and destination paths are the same, so no files were moved." % (self))
+        else:
+            self.copy(path1, path2, recursive=recursive, maxdepth=maxdepth)
+            self.rm(path1, recursive=recursive)
 
     def rm_file(self, path):
         """Delete a file"""


### PR DESCRIPTION
fixes: https://github.com/fsspec/s3fs/issues/711

**Previous:** If you run `mv('path', 'path')`, the `mv` function will call `cp` and then `rm`, resulting in the removal of the original 'path'.
**Revised:** If you run `mv('path', 'path')`, the `mv` function will not perform any action as the source and destination paths are the same.
