### PR TITLE
Add extra docs about implementations and protocols

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -196,6 +196,8 @@ Built-in Implementations
 .. autoclass:: fsspec.implementations.zip.ZipFileSystem
    :members: __init__
 
+.. _external_implementations:
+
 Other Known Implementations
 ---------------------------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,7 +14,8 @@ file-like objects.
 Some concrete implementations are bundled with ``fsspec`` and others can be installed separately. They
 can be instantiated directly, or the ``registry`` can be used to find them.
 
-Direct instantiation:
+Direct instantiation using the name of the class such as ``LocalFileSystem``, ``ZipFileSystem`` or
+``S3FileSystem``:
 
 .. code-block:: python
 
@@ -30,6 +31,10 @@ Look-up via registry:
 
     fs = fsspec.filesystem('file')
 
+The argument passed here is the protocol name which maps across to the corresponding implementation
+class ``LocalFileSystem``. Other examples are ``zip`` which maps across to ``ZipFileSystem`` and
+``s3`` which maps across to ``S3FileSystem``.
+
 Many filesystems also take extra parameters, some of which may be options - see :doc:`api`, or use
 :func:`fsspec.get_filesystem_class` to get the class object and inspect its docstring.
 
@@ -40,6 +45,14 @@ Many filesystems also take extra parameters, some of which may be options - see 
     fs = fsspec.filesystem('ftp', host=host, port=port, username=user, password=pw)
 
 The list of implemented ``fsspec`` protocols can be retrieved using :func:`fsspec.available_protocols`.
+
+.. note::
+
+   The full list of the available protocols and the implementations that they map across to is
+   divided into two sections:
+
+    - Implementations built into ``fsspec``: :ref:`implementations`
+    - Implementations in separate packages: :ref:`external_implementations`
 
 Use a file-system
 -----------------

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -268,6 +268,16 @@ def open_files(
     -------
     An ``OpenFiles`` instance, which is a list of ``OpenFile`` objects that can
     be used as a single context
+
+    Notes
+    -----
+    For a full list of the available protocols and the implementations that
+    they map across to see the latest online documentation:
+
+    - For implementations built into ``fsspec`` see
+      https://filesystem-spec.readthedocs.io/en/latest/api.html#built-in-implementations
+    - For implementations in separate packages see
+      https://filesystem-spec.readthedocs.io/en/latest/api.html#other-known-implementations
     """
     fs, fs_token, paths = get_fs_token_paths(
         urlpath,
@@ -415,6 +425,16 @@ def open(
     Returns
     -------
     ``OpenFile`` object.
+
+    Notes
+    -----
+    For a full list of the available protocols and the implementations that
+    they map across to see the latest online documentation:
+
+    - For implementations built into ``fsspec`` see
+      https://filesystem-spec.readthedocs.io/en/latest/api.html#built-in-implementations
+    - For implementations in separate packages see
+      https://filesystem-spec.readthedocs.io/en/latest/api.html#other-known-implementations
     """
     return open_files(
         urlpath=[urlpath],


### PR DESCRIPTION
Fixes #1208.

This add links in the docstrings of `fsspec.open` and `fsspec.open_files` to the lists of implementations and their protocols on the docs website. It also expands the usage section with the same information.

We need #1209 fixed before this will build on Read the Docs.

In the medium term we should perhaps consider expanding the docs to include more user-centric information such as a getting started tutorial and and some "How To" guides for common workflows. Then we could show some concrete examples of workflows for simple (e.g. `local` or `zip`) and more complicated (e.g. `s3`) filesystems which will naturally lead on to extra information about the possible extra arguments needed for some of them. We could have a table that explicitly states the string protocol names and the filesystems they map to. This would be inline with the Diátaxis framework (https://diataxis.fr/) which is popular in many Open Source projects.