### PR TITLE
Handle local file URI without authority

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -214,7 +214,7 @@ class LocalFileSystem(AbstractFileSystem):
         path = stringify_path(path)
         if path.startswith("file://"):
             path = path[7:]
-        elif path.startswith("file:/"):
+        elif path.startswith("file:"):
             path = path[5:]
         return make_path_posix(path).rstrip("/") or cls.root_marker
 

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -214,6 +214,8 @@ class LocalFileSystem(AbstractFileSystem):
         path = stringify_path(path)
         if path.startswith("file://"):
             path = path[7:]
+        elif path.startswith("file:/"):
+            path = path[5:]
         return make_path_posix(path).rstrip("/") or cls.root_marker
 
     def _isfilestore(self):

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -631,7 +631,8 @@ def test_strip_protocol_expanduser():
 def test_strip_protocol_no_authority():
     path = "file:\\foo\\bar" if WIN else "file:/foo/bar"
     stripped = LocalFileSystem._strip_protocol(path)
-    assert stripped == "/foo/bar"
+    assert "file:" not in stripped
+    assert stripped.endswith("/foo/bar")
 
 
 def test_mkdir_twice_faile(tmpdir):

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -628,6 +628,12 @@ def test_strip_protocol_expanduser():
     assert not LocalFileSystem._strip_protocol("./").endswith("/")
 
 
+def test_strip_protocol_no_authority():
+    path = "file:\\foo\\bar" if WIN else "file:/foo/bar"
+    stripped = LocalFileSystem._strip_protocol(path)
+    assert stripped == "/foo/bar"
+
+
 def test_mkdir_twice_faile(tmpdir):
     fn = os.path.join(tmpdir, "test")
     fs = fsspec.filesystem("file")


### PR DESCRIPTION
The `fsspec` Local implementation currently doesn't handle file URIs that skip the authority properly, as per https://www.rfc-editor.org/rfc/rfc8089#appendix-A - ref: https://github.com/fsspec/universal_pathlib/issues/81

(The pytest CI seems to hang on my fork, not certain why)