### PR TITLE
Fix doc build warning about missing newline after list in docstring

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -332,6 +332,7 @@ class ReferenceFileSystem(AsyncFileSystem):
                 - a dict of protocol:filesystem, where each value is either a filesystem
                   instance, or a dict of kwargs that can be used to create in
                   instance for the given protocol
+
             If this is given, remote_options and remote_protocol are ignored.
         template_overrides : dict
             Swap out any templates in the references file with these - useful for


### PR DESCRIPTION
Latest doc build (https://readthedocs.org/projects/filesystem-spec/builds/19933772/) has a warning:
```
<snip>/reference.py:docstring of fsspec.implementations.reference.ReferenceFileSystem.__init__:44: WARNING: Definition list ends without a blank line; unexpected unindent.
```

This PR removes the warning, although it is a little strange having an extra line of whitespace in a docstring just to keep the doc build happy.

At some point we should revisit the idea of having the RTD build appear in CI so that it is easy to check that the doc build succeeds on each PR. But it is not a high priority of course.