### PR TITLE
RF: add a helper add_cache to avoid duplication (.name) and allow for formalized addition of caches

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -777,7 +777,7 @@ def register_cache(cls, clobber=False):
 
     Parameters
     ----------
-    overload: bool, optional
+    clobber: bool, optional
         If overload is set to True (default is False) - allow to overload existing
         entry.
 

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -766,10 +766,13 @@ class BackgroundBlockCache(BaseCache):
             return b"".join(out)
 
 
-caches = {}
+caches = {
+    # one custom case
+    None: BaseCache,
+}
 
 
-def add_cache(cls, overload=False):
+def register_cache(cls, clobber=False):
     """'Register' cache implementation.
 
     Parameters
@@ -783,28 +786,20 @@ def add_cache(cls, overload=False):
     ValueError
     """
     name = cls.name
-    if not overload and name in caches:
+    if not clobber and name in caches:
         raise ValueError(f"Cache with name {name!r} is already known: {caches[name]}")
     caches[name] = cls
-    # custom handling for None
-    if name == "none":
-        if not overload:
-            if None in caches:
-                raise ValueError(f"Cache for None is already known: {caches[None]}")
-        caches[None] = cls
 
 
-[
-    add_cache(c)
-    for c in (
-        BaseCache,
-        MMapCache,
-        BytesCache,
-        ReadAheadCache,
-        BlockCache,
-        FirstChunkCache,
-        AllBytes,
-        KnownPartsOfAFile,
-        BackgroundBlockCache,
-    )
-]
+for c in (
+    BaseCache,
+    MMapCache,
+    BytesCache,
+    ReadAheadCache,
+    BlockCache,
+    FirstChunkCache,
+    AllBytes,
+    KnownPartsOfAFile,
+    BackgroundBlockCache,
+):
+    register_cache(c)

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -778,7 +778,7 @@ def register_cache(cls, clobber=False):
     Parameters
     ----------
     clobber: bool, optional
-        If overload is set to True (default is False) - allow to overload existing
+        If set to True (default is False) - allow to overwrite existing
         entry.
 
     Raises

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -3,7 +3,7 @@ import string
 
 import pytest
 
-from fsspec.caching import BlockCache, FirstChunkCache, caches
+from fsspec.caching import BlockCache, FirstChunkCache, add_cache, caches
 
 
 def test_cache_getitem(Cache_imp):
@@ -138,3 +138,10 @@ def test_background(server, monkeypatch):
     f.read(1)
     time.sleep(0.1)  # second block is loading
     assert len(thread_ids) == 2
+
+
+def test_add_cache():
+    # just test that we have them populated and fail to re-add again unless overload
+    with pytest.raises(ValueError):
+        add_cache(BlockCache)
+    add_cache(BlockCache, overload=True)

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -3,7 +3,7 @@ import string
 
 import pytest
 
-from fsspec.caching import BlockCache, FirstChunkCache, add_cache, caches
+from fsspec.caching import BlockCache, FirstChunkCache, caches, register_cache
 
 
 def test_cache_getitem(Cache_imp):
@@ -140,8 +140,8 @@ def test_background(server, monkeypatch):
     assert len(thread_ids) == 2
 
 
-def test_add_cache():
+def test_register_cache():
     # just test that we have them populated and fail to re-add again unless overload
     with pytest.raises(ValueError):
-        add_cache(BlockCache)
-    add_cache(BlockCache, overload=True)
+        register_cache(BlockCache)
+    register_cache(BlockCache, clobber=True)


### PR DESCRIPTION
Aiming to possibly to expand with another cache without (initially) contributing to fsspec, thought to define helper.