### PR TITLE
Establish tool.pytest.ini_options in pyproject.toml with pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,10 @@ exclude = '''
   | versioneer.py
 )
 '''
+
+[tool.pytest.ini_options]
+# custom markers, need to be defined to avoid warnings
+markers = [
+    "asyncio",
+    "vcr",
+]


### PR DESCRIPTION
Otherwise running tests for me resulted in the flood on the screen with bunch of warnings like

	❯ python -m pytest -s -v -k test_register_cache
	======================================================================================================================= test session starts =======================================================================================================================
	platform linux -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /home/yoh/venvs/dev3.11/bin/python
	cachedir: .pytest_cache
	rootdir: /home/yoh/proj/misc/filesystem_spec, configfile: pyproject.toml
	plugins: xdist-3.2.1, cov-4.0.0, vcr-1.0.2
	collected 1109 items / 1108 deselected / 3 skipped / 1 selected

	fsspec/tests/test_caches.py::test_register_cache PASSED

	======================================================================================================================== warnings summary =========================================================================================================================
	fsspec/implementations/tests/test_dirfs.py:99
	  /home/yoh/proj/misc/filesystem_spec/fsspec/implementations/tests/test_dirfs.py:99: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
		@pytest.mark.asyncio
	...  many more ...

and AFAIK there is no easy way in pytest to define markers in  code (@jwodder could correct me if I am wrong).

Related unanswered question: https://github.com/pytest-dev/pytest/discussions/9913