### PR TITLE
Writable lazy references dict

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -369,7 +369,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
                 self.np.product(self._get_chunk_sizes(field)) // self.record_size
             )  # ??
             for record in range(n_chunks):
-                if (field, record) in self._items:
+                if self._items.get((record, field)):
                     self.write(
                         field,
                         record,

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -69,31 +69,6 @@ class RefsItemsView(collections.abc.ItemsView):
         return zip(self._mapping.keys(), self._mapping.values())
 
 
-class CountedReferenceSubSet(dict):
-    def __init__(self, target_url=None, target_options=None, full_size=None):
-        self.target_url = target_url
-        self.target_options = target_options
-        self.count = 0
-        self.full_size = full_size
-        super().__init__()
-
-    def __setitem__(self, key, value):
-        import pandas as pd
-
-        if self.full_size is None:
-            raise ValueError("already written")
-        super().__setitem__(key, value)
-        self.count += 1
-        if self.count == self.full_size:
-            # TODO: this probably doesn't make the right frame; maybe start with numpy
-            #  arrays and fill them in?
-            df = pd.DataFrame(self)
-            # TODO: dict encoding and other options here
-            df.to_parquet(self.target_url, storage_options=self.target_options)
-            self.clear()
-            self.full_size = None  # prevents further setting
-
-
 class LazyReferenceMapper(collections.abc.MutableMapping):
     """Interface to read parquet store as if it were a standard kerchunk
     references dict."""

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -302,7 +302,6 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         return self._load_one_key(key)
 
     def __setitem__(self, key, value):
-        print("set", key, value)
         if "/" in key and not self._is_meta(key):
             field, chunk = key.split("/")
             record, _, _ = self._key_to_record(key)
@@ -322,7 +321,6 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         return key.startswith(".z") or "/.z" in key
 
     def __delitem__(self, key):
-        print("delete", key)
         if key in self._items:
             del self._items[key]
         elif key in self.zmetadata:
@@ -474,8 +472,9 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
     def __iter__(self):
         # Caveat: Note that this generates all expected keys, but does not
         # account for reference keys that are missing.
-        yield from self.zmetadata
-        yield from self._items
+        metas = set(self.zmetadata)
+        metas.update(self._items)
+        yield from sorted(metas)
         for field in self.listdir():
             yield from self._keys_in_field(field)
 

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -410,7 +410,8 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         df.to_parquet(
             fn,
             engine="fastparquet",
-            storage_options=storage_options,
+            storage_options=storage_options
+            or getattr(self.fs, "storage_options", None),
             compression="zstd",
             index=False,
             stats=False,

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -340,10 +340,9 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
     def flush(self, base_url=None, storage_options=None):
         # done when all writing finishes
         for field in self.listdir():
-            n_chunks = (
-                self.np.product(self._get_chunk_sizes(field)) // self.record_size
-            )  # ??
-            for record in range(n_chunks):
+            nchunks = self.np.product(self._get_chunk_sizes(field))
+            nrecs = int(self.np.ceil(nchunks / self.record_size))
+            for record in range(nrecs):
                 if self._items.get((record, field)):
                     self.write(
                         field,


### PR DESCRIPTION
@agoodm : this is an attempt o start in principle one way to tackle combining references to parquet. The idea is, that kerchunk.MultiarrToZarr can have a LazyRefernceMapper instead of a dict for its `out` attribute, and that this will reuse some of the key-location logic to fill dicts. When a dict is full, it gets written to parquet and saved; else the calling code calls flush() when finished to write whatever has been accumulated and not cleared. 

(Perhaps it's possible to have a mapper which references both unchanged original chunks of references and updated sections simultaneously, to allow for "append"-like logic; at this point it feels like the set of parquet files we are pointing to could themselves live in a reference file-system...)