### PR TITLE
Disable clobbering of implementations by default

### DIFF
--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -51,7 +51,13 @@ def process_entries():
             for spec in specs:
                 err_msg = f"Unable to load filesystem from {spec}"
                 register_implementation(
-                    spec.name, spec.value.replace(":", "."), errtxt=err_msg
+                    spec.name,
+                    spec.value.replace(":", "."),
+                    errtxt=err_msg,
+                    # We take our implementations as the ones to overload with if
+                    # for some reason we encounter some, may be the same, already
+                    # registered
+                    clobber=True,
                 )
 
 

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -12,7 +12,7 @@ registry = types.MappingProxyType(_registry)
 default = "file"
 
 
-def register_implementation(name, cls, clobber=True, errtxt=None):
+def register_implementation(name, cls, clobber=False, errtxt=None):
     """Add implementation class to the registry
 
     Parameters

--- a/fsspec/tests/test_registry.py
+++ b/fsspec/tests/test_registry.py
@@ -69,9 +69,12 @@ def test_register_fail(clear_registry):
     with pytest.raises(ImportError):
         get_filesystem_class("test")
 
-    register_implementation("test", "doesntexist.AbstractFileSystem")
     with pytest.raises(ValueError):
         register_implementation("test", "doesntexist.AbstractFileSystem", clobber=False)
+
+    # by default we do not allow clobbering
+    with pytest.raises(ValueError):
+        register_implementation("test", "doesntexist.AbstractFileSystem")
 
     register_implementation(
         "test", "doesntexist.AbstractFileSystem", errtxt="hiho", clobber=True
@@ -82,7 +85,7 @@ def test_register_fail(clear_registry):
     register_implementation("test", AbstractFileSystem)
 
     with pytest.raises(ValueError):
-        register_implementation("test", AbstractFileSystem, clobber=False)
+        register_implementation("test", AbstractFileSystem)
     register_implementation("test", AbstractFileSystem, clobber=True)
 
 


### PR DESCRIPTION
I think nothing good can come out from clobbing by default. The necessity to clobber=True  in process_entries  was not well understood by me, but seems to stem from some artificial situation causing re-import of the fsspec

Follow up to #1227 harmonizing default behavior to have `clobber=False` in both similar functionalities.