### PR TITLE
Allow pruning dirnames in a topdown walk to improve speed on large filesystems

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -623,7 +623,7 @@ class AsyncFileSystem(AbstractFileSystem):
             name = pathname.rsplit("/", 1)[-1]
             if info["type"] == "directory" and pathname != path:
                 # do not include "self" path
-                full_dirs[pathname] = info
+                full_dirs[name] = pathname
                 dirs[name] = info
             elif pathname == path:
                 # file-like with same name as give path
@@ -641,8 +641,10 @@ class AsyncFileSystem(AbstractFileSystem):
             if maxdepth < 1:
                 return
 
-        for d in full_dirs:
-            async for _ in self._walk(d, maxdepth=maxdepth, detail=detail, **kwargs):
+        for d in dirs:
+            async for _ in self._walk(
+                full_dirs[d], maxdepth=maxdepth, detail=detail, **kwargs
+            ):
                 yield _
 
     async def _glob(self, path, **kwargs):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -375,6 +375,10 @@ class AbstractFileSystem(metaclass=_Cached):
         List all files, recursing into subdirectories; output is iterator-style,
         like ``os.walk()``. For a simple list of files, ``find()`` is available.
 
+        When topdown is True, the caller can modify the dirs list in-place,
+        and walk() will only recurse into the subdirectories whose names remain in dirs.
+        Modifying dirs when topdown is False has no effect.
+
         Note that the "files" outputted will include anything that is not
         a directory, such as links.
 
@@ -413,7 +417,7 @@ class AbstractFileSystem(metaclass=_Cached):
             name = pathname.rsplit("/", 1)[-1]
             if info["type"] == "directory" and pathname != path:
                 # do not include "self" path
-                full_dirs[pathname] = info
+                full_dirs[name] = pathname
                 dirs[name] = info
             elif pathname == path:
                 # file-like with same name as give path
@@ -436,9 +440,9 @@ class AbstractFileSystem(metaclass=_Cached):
                     yield path, dirs, files
                 return
 
-        for d in full_dirs:
+        for d in dirs:
             yield from self.walk(
-                d, maxdepth=maxdepth, detail=detail, topdown=topdown, **kwargs
+                full_dirs[d], maxdepth=maxdepth, detail=detail, topdown=topdown, **kwargs
             )
 
         if not topdown:

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -428,3 +428,20 @@ def test_walk(m):
         list(m.walk(dir0, maxdepth=0, topdown=True))
     with pytest.raises(ValueError):
         list(m.walk(dir0, maxdepth=0, topdown=False))
+
+    # purne dir2
+    def _walk(*args, **kwargs):
+        for path, dirs, files in m.walk(*args, **kwargs):
+            yield (path, dirs.copy(), files)
+            if "dir2" in dirs:
+                dirs.remove("dir2")
+
+    assert list(_walk(dir0, topdown=True)) == [
+        (dir0, ["dir1"], ["file1"]),
+        (dir1, ["dir2"], ["file2"]),
+    ]
+    assert list(_walk(dir0, topdown=False)) == [
+        (dir2, [], ["file3"]),
+        (dir1, ["dir2"], ["file2"]),
+        (dir0, ["dir1"], ["file1"]),
+    ]


### PR DESCRIPTION
Solving #1223 

Allowing modifying `dirnames` in order to improve browsing large filesystems:

[os.walk](https://docs.python.org/3/library/os.html#os.walk)
```
When topdown is True, the caller can modify the dirnames list in-place (perhaps using del or slice assignment),
and walk() will only recurse into the subdirectories whose names remain in dirnames;
this can be used to prune the search, impose a specific order of visiting, or even to inform walk()
about directories the caller creates or renames before it resumes walk() again.
```

Related issue: [Add topdown kwarg to AbstractFileSystem.walk()](https://github.com/fsspec/filesystem_spec/pull/1081)