### PR TITLE
Add abstract tests to wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     maintainer_email="mdurant@anaconda.com",
     license="BSD",
     keywords="file",
-    packages=["fsspec", "fsspec.implementations"],
+    packages=["fsspec", "fsspec.implementations", "fsspec.tests.abstract"],
     python_requires=">=3.8",
     install_requires=open("requirements.txt").read().strip().split("\n"),
     extras_require=extras_require,


### PR DESCRIPTION
This PR adds the `fsspec/tests/abstract` directory and its contents to wheels and hence to conda packages also. This will allow downstream projects such as `s3fs` and `gcsfs` access to the new abstract test harness by installing `fsspec` in the conventional manner rather than having to install it from source in editable mode, which is what is currently required.

I have confirmed that with this change the only extra files added to the wheel are those in the `fsspec/tests/abstract` directory.