### PR TITLE
Fix del self.zip giving AttributeError

### DIFF
--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -73,7 +73,7 @@ class ZipFileSystem(AbstractArchiveFileSystem):
     def __del__(self):
         if hasattr(self, "zip"):
             self.close()
-        del self.zip
+            del self.zip
 
     def close(self):
         """Commits any write changes to the file. Done on ``del`` too."""


### PR DESCRIPTION
The deletion of the self.zip should only be performed if that attribute exists. Without this there are errors for example like the following:

```
  Traceback (most recent call last):
    File "/home/runner/work/jsonargparse/jsonargparse/.tox/py-all-extras/lib/python3.8/site-packages/fsspec/implementations/zip.py", line 76, in __del__
      del self.zip
  AttributeError: zip
```

Extracted from https://github.com/omni-us/jsonargparse/actions/runs/4868536023/jobs/8682110610