### PR TITLE
Do nothing for non-recursive copy of empty directory

### DIFF
--- a/docs/source/copying.rst
+++ b/docs/source/copying.rst
@@ -121,9 +121,6 @@ Forward slashes are used for directory separators throughout.
 
     .. warning::
 
-       ``recursive=False`` is not correct
-       (`issue 1232 <https://github.com/fsspec/filesystem_spec/issues/1232>`_).
-
        ``maxdepth`` is not yet implemented for copying functions
        (`issue 1231 <https://github.com/fsspec/filesystem_spec/issues/1231>`_).
 
@@ -174,9 +171,6 @@ Forward slashes are used for directory separators throughout.
 .. dropdown:: 1f. Directory to new directory
 
     .. warning::
-
-       ``recursive=False`` is not correct
-       (`issue 1232 <https://github.com/fsspec/filesystem_spec/issues/1232>`_).
 
        ``maxdepth`` is not yet implemented for copying functions
        (`issue 1231 <https://github.com/fsspec/filesystem_spec/issues/1231>`_).

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -281,7 +281,7 @@ def trailing_sep(path):
     # TODO: if all incoming paths were posix-compliant then separator would
     # always be a forward slash, simplifying this function.
     # See https://github.com/fsspec/filesystem_spec/pull/1250
-    return path.endswith(os.sep) or os.altsep and path.endswith(os.altsep)
+    return path.endswith(os.sep) or (os.altsep is not None and path.endswith(os.altsep))
 
 
 def trailing_sep_maybe_asterisk(path):
@@ -294,10 +294,8 @@ def trailing_sep_maybe_asterisk(path):
     # TODO: if all incoming paths were posix-compliant then separator would
     # always be a forward slash, simplifying this function.
     # See https://github.com/fsspec/filesystem_spec/pull/1250
-    return (
-        path.endswith((os.sep, os.sep + "*"))
-        or os.altsep
-        and path.endswith((os.altsep, os.altsep + "*"))
+    return path.endswith((os.sep, os.sep + "*")) or (
+        os.altsep is not None and path.endswith((os.altsep, os.altsep + "*"))
     )
 
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -939,32 +939,24 @@ def test_cp_get_put_empty_directory(tmpdir, funcname):
     # cp/get/put without slash, target directory exists
     assert fs.isdir(target)
     func(empty, target)
-    assert fs.find(target, withdirs=True) == [
-        make_path_posix(os.path.join(target, "empty"))
-    ]
-
-    fs.rm(target + "/empty", recursive=True)
+    assert fs.find(target, withdirs=True) == []
 
     # cp/get/put with slash, target directory exists
     assert fs.isdir(target)
     func(empty + "/", target)
     assert fs.find(target, withdirs=True) == []
 
-    fs.rm(target, recursive=True)
+    fs.rmdir(target)
 
     # cp/get/put without slash, target directory doesn't exist
     assert not fs.isdir(target)
     func(empty, target)
-    assert fs.isdir(target)
-    assert fs.find(target, withdirs=True) == []
-
-    fs.rm(target, recursive=True)
+    assert not fs.isdir(target)
 
     # cp/get/put with slash, target directory doesn't exist
     assert not fs.isdir(target)
     func(empty + "/", target)
-    assert fs.isdir(target)
-    assert fs.find(target, withdirs=True) == []
+    assert not fs.isdir(target)
 
 
 def test_cp_two_files(tmpdir):

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -291,30 +291,24 @@ def test_cp_empty_directory(m):
     # cp without slash, target directory exists
     assert m.isdir(target)
     m.cp(empty, target)
-    assert m.find(target, withdirs=True) == [target + "/empty"]
-
-    m.rm(target + "/empty", recursive=True)
+    assert m.find(target, withdirs=True) == []
 
     # cp with slash, target directory exists
     assert m.isdir(target)
     m.cp(empty + "/", target)
     assert m.find(target, withdirs=True) == []
 
-    m.rm(target, recursive=True)
+    m.rmdir(target)
 
     # cp without slash, target directory doesn't exist
     assert not m.isdir(target)
     m.cp(empty, target)
-    assert m.isdir(target)
-    assert m.find(target, withdirs=True) == []
-
-    m.rm(target, recursive=True)
+    assert not m.isdir(target)
 
     # cp with slash, target directory doesn't exist
     assert not m.isdir(target)
     m.cp(empty + "/", target)
-    assert m.isdir(target)
-    assert m.find(target, withdirs=True) == []
+    assert not m.isdir(target)
 
 
 def test_cp_two_files(m):

--- a/fsspec/tests/abstract/copy.py
+++ b/fsspec/tests/abstract/copy.py
@@ -92,9 +92,8 @@ class AbstractCopyTests:
             t = target + "/" if target_slash else target
 
             # Without recursive does nothing
-            # ERROR: erroneously creates new directory
-            # fs.cp(s, t)
-            # assert fs.ls(target) == []
+            fs.cp(s, t)
+            assert fs.ls(target) == []
 
             # With recursive
             fs.cp(s, t, recursive=True)
@@ -143,9 +142,8 @@ class AbstractCopyTests:
                 t += "/"
 
             # Without recursive does nothing
-            # ERROR: erroneously creates new directory
-            # fs.cp(s, t)
-            # assert fs.ls(target) == []
+            fs.cp(s, t)
+            assert fs.ls(target) == []
 
             # With recursive
             fs.cp(s, t, recursive=True)


### PR DESCRIPTION
Fixes #1232.

This is for a non-recursive copy of an empty directory such as
```python
cp("source/somedir/", "target/", recursive=False)
```
which is now a no-op to agree with command-line copy.

There were two possible approaches. The one I've opted for is to leave `expand_path()` as it is, returning the empty directory, and checking this separately in `cp`, `get` and `put` to identify the "do nothing" scenario and return early.

The other approach would have been to add a new kwarg to `expand_path()` to override the current `withdirs=True`. This would allow an empty return from the function which would have needed extra handling so I considered this a worse solution than the one I have adopted. I am writing this here because I suspect in the long run this solution may be required to support corner cases of `cp` passing a list of individual files and empty directories, which probably nobody is doing but must eventually be supported. Very low priority though.