### PR TITLE
Implement maxdepth for recursive cp/get/put

### DIFF
--- a/docs/source/copying.rst
+++ b/docs/source/copying.rst
@@ -119,11 +119,6 @@ Forward slashes are used for directory separators throughout.
 
 .. dropdown:: 1e. Directory to existing directory
 
-    .. warning::
-
-       ``maxdepth`` is not yet implemented for copying functions
-       (`issue 1231 <https://github.com/fsspec/filesystem_spec/issues/1231>`_).
-
     .. code-block:: python
 
         cp("source/subdir/", "target/", recursive=True)
@@ -168,12 +163,21 @@ Forward slashes are used for directory separators throughout.
                 └── 📁 nesteddir
                     └── 📄 nestedfile
 
+    Again the depth of recursion can be controlled using the ``maxdepth`` keyword argument, for
+    example:
+
+    .. code-block:: python
+
+        cp("source/subdir", "target/", recursive=True, maxdepth=1)
+
+    results in::
+
+       📁 target
+        └── 📁 subdir
+            ├── 📄 subfile1
+            └── 📄 subfile2
+
 .. dropdown:: 1f. Directory to new directory
-
-    .. warning::
-
-       ``maxdepth`` is not yet implemented for copying functions
-       (`issue 1231 <https://github.com/fsspec/filesystem_spec/issues/1231>`_).
 
     .. code-block:: python
 
@@ -192,7 +196,18 @@ Forward slashes are used for directory separators throughout.
     They are recommended to explicitly indicate both are directories.
 
     The ``recursive=True`` keyword argument is required otherwise the call does nothing. The depth
-    of recursion can be controlled using the ``maxdepth`` keyword argument.
+    of recursion can be controlled using the ``maxdepth`` keyword argument, for example:
+
+    .. code-block:: python
+
+        cp("source/subdir/", "target/newdir/", recursive=True, maxdepth=1)
+
+    results in::
+
+       📁 target
+        └── 📁 newdir
+            ├── 📄 subfile1
+            └── 📄 subfile2
 
 .. dropdown:: 1g. Glob to existing directory
 
@@ -222,10 +237,20 @@ Forward slashes are used for directory separators throughout.
             └── 📁 nesteddir
                 └── 📄 nestedfile
 
-    The depth of recursion can be controlled by the ``maxdepth`` keyword argument.
-
     The trailing slash on ``"target/"`` is optional but recommended as it explicitly indicates that
     the target is a directory.
+
+    The depth of recursion can be controlled by the ``maxdepth`` keyword argument, for example:
+
+    .. code-block:: python
+
+        cp("source/subdir/*", "target/", recursive=True, maxdepth=1)
+
+    results in::
+
+       📁 target
+        ├── 📄 subfile1
+        └── 📄 subfile2
 
 .. dropdown:: 1h. Glob to new directory
 
@@ -257,10 +282,21 @@ Forward slashes are used for directory separators throughout.
                 └── 📁 nesteddir
                     └── 📄 nestedfile
 
-    The depth of recursion can be controlled by the ``maxdepth`` keyword argument.
-
     The trailing slash on the ``target`` is optional but recommended as it explicitly indicates that
     it is a directory.
+
+    The depth of recursion can be controlled by the ``maxdepth`` keyword argument, for example:
+
+    .. code-block:: python
+
+        cp("source/subdir/*", "target/newdir/", recursive=True, maxdepth=1)
+
+    results in::
+
+        📁 target
+        └── 📁 newdir
+            ├── 📄 subfile1
+            └── 📄 subfile2
 
     These calls fail if the ``target`` file system is not capable of creating the directory, for
     example if it is write-only or if ``auto_mkdir=False``. There is no command line equivalent of

--- a/fsspec/tests/abstract/copy.py
+++ b/fsspec/tests/abstract/copy.py
@@ -102,15 +102,9 @@ class AbstractCopyTests:
                 assert fs.isfile(fs_join(target, "subfile2"))
                 assert fs.isdir(fs_join(target, "nesteddir"))
                 assert fs.isfile(fs_join(target, "nesteddir", "nestedfile"))
+                assert not fs.exists(fs_join(target, "subdir"))
 
-                fs.rm(
-                    [
-                        fs_join(target, "subfile1"),
-                        fs_join(target, "subfile2"),
-                        fs_join(target, "nesteddir"),
-                    ],
-                    recursive=True,
-                )
+                fs.rm(fs.ls(target, detail=False), recursive=True)
             else:
                 assert fs.isdir(fs_join(target, "subdir"))
                 assert fs.isfile(fs_join(target, "subdir", "subfile1"))
@@ -121,8 +115,23 @@ class AbstractCopyTests:
                 fs.rm(fs_join(target, "subdir"), recursive=True)
             assert fs.ls(target) == []
 
-            # Limit by maxdepth
-            # ERROR: maxdepth ignored here
+            # Limit recursive by maxdepth
+            fs.cp(s, t, recursive=True, maxdepth=1)
+            if source_slash:
+                assert fs.isfile(fs_join(target, "subfile1"))
+                assert fs.isfile(fs_join(target, "subfile2"))
+                assert not fs.exists(fs_join(target, "nesteddir"))
+                assert not fs.exists(fs_join(target, "subdir"))
+
+                fs.rm(fs.ls(target, detail=False), recursive=True)
+            else:
+                assert fs.isdir(fs_join(target, "subdir"))
+                assert fs.isfile(fs_join(target, "subdir", "subfile1"))
+                assert fs.isfile(fs_join(target, "subdir", "subfile2"))
+                assert not fs.exists(fs_join(target, "subdir", "nesteddir"))
+
+                fs.rm(fs_join(target, "subdir"), recursive=True)
+            assert fs.ls(target) == []
 
     def test_copy_directory_to_new_directory(
         self, fs, fs_join, fs_path, fs_scenario_cp
@@ -152,12 +161,21 @@ class AbstractCopyTests:
             assert fs.isfile(fs_join(target, "newdir", "subfile2"))
             assert fs.isdir(fs_join(target, "newdir", "nesteddir"))
             assert fs.isfile(fs_join(target, "newdir", "nesteddir", "nestedfile"))
+            assert not fs.exists(fs_join(target, "subdir"))
 
             fs.rm(fs_join(target, "newdir"), recursive=True)
             assert fs.ls(target) == []
 
-            # Limit by maxdepth
-            # ERROR: maxdepth ignored here
+            # Limit recursive by maxdepth
+            fs.cp(s, t, recursive=True, maxdepth=1)
+            assert fs.isdir(fs_join(target, "newdir"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile1"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile2"))
+            assert not fs.exists(fs_join(target, "newdir", "nesteddir"))
+            assert not fs.exists(fs_join(target, "subdir"))
+
+            fs.rm(fs_join(target, "newdir"), recursive=True)
+            assert fs.ls(target) == []
 
     def test_copy_glob_to_existing_directory(
         self, fs, fs_join, fs_path, fs_scenario_cp
@@ -193,8 +211,15 @@ class AbstractCopyTests:
             fs.rm(fs.ls(target, detail=False), recursive=True)
             assert fs.ls(target) == []
 
-            # Limit by maxdepth
-            # ERROR: maxdepth ignored here
+            # Limit recursive by maxdepth
+            fs.cp(fs_join(source, "subdir", "*"), t, recursive=True, maxdepth=1)
+            assert fs.isfile(fs_join(target, "subfile1"))
+            assert fs.isfile(fs_join(target, "subfile2"))
+            assert not fs.exists(fs_join(target, "nesteddir"))
+            assert not fs.exists(fs_join(target, "subdir"))
+
+            fs.rm(fs.ls(target, detail=False), recursive=True)
+            assert fs.ls(target) == []
 
     def test_copy_glob_to_new_directory(self, fs, fs_join, fs_path, fs_scenario_cp):
         # Copy scenario 1h
@@ -234,8 +259,17 @@ class AbstractCopyTests:
             fs.rm(fs_join(target, "newdir"), recursive=True)
             assert fs.ls(target) == []
 
-            # Limit by maxdepth
-            # ERROR: this is not correct
+            # Limit recursive by maxdepth
+            fs.cp(fs_join(source, "subdir", "*"), t, recursive=True, maxdepth=1)
+            assert fs.isdir(fs_join(target, "newdir"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile1"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile2"))
+            assert not fs.exists(fs_join(target, "newdir", "nesteddir"))
+            assert not fs.exists(fs_join(target, "subdir"))
+            assert not fs.exists(fs_join(target, "newdir", "subdir"))
+
+            fs.rm(fs.ls(target, detail=False), recursive=True)
+            assert fs.ls(target) == []
 
     def test_copy_list_of_files_to_existing_directory(
         self, fs, fs_join, fs_path, fs_scenario_cp


### PR DESCRIPTION
Fixes #1231.

I have explicitly added the `maxdepth` as an argument to `cp`, `get` and `put` as it is already explicit in `expand_path`, `find` and `glob`. But the alternative of leaving it within the `kwargs` and using `get` to read it from there would be fine too.