### PR TITLE
Add boxfs to registry

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -203,6 +203,7 @@ Other Known Implementations
 
 - `abfs`_ for Azure Blob service
 - `adl`_ for Azure DataLake storage
+- `boxfs`_ for access to Box file storage
 - `dropbox`_ for access to dropbox shares
 - `dvc`_ to access DVC/Git repository as a filesystem
 - `gcsfs`_ for Google Cloud Storage
@@ -216,6 +217,7 @@ Other Known Implementations
 
 .. _abfs: https://github.com/dask/adlfs
 .. _adl: https://github.com/dask/adlfs
+.. _boxfs: https://github.com/IBM/boxfs
 .. _dropbox: https://github.com/MarineChap/intake_dropbox
 .. _dvc: https://github.com/iterative/dvc
 .. _gcsfs: https://gcsfs.readthedocs.io/en/latest/

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -194,6 +194,10 @@ known_implementations = {
         + " not referring to root directories",
     },
     "dir": {"class": "fsspec.implementations.dirfs.DirFileSystem"},
+    "box": {
+        "class": "boxfs.BoxFileSystem",
+        "err": "Please install boxfs to access BoxFileSystem",
+    }
 }
 
 


### PR DESCRIPTION
Add [`boxfs`](https://github.com/IBM/boxfs) to registry, allowing users to connect to file storage hosted by box.com