### PR TITLE
Complete sync and async copy/get/put tests

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -13,6 +13,12 @@ from typing import Iterable
 
 from .callbacks import _DEFAULT_CALLBACK
 from .exceptions import FSTimeoutError
+from .implementations.local import (
+    LocalFileSystem,
+    make_path_posix,
+    trailing_sep,
+    trailing_sep_maybe_asterisk,
+)
 from .spec import AbstractBufferedFile, AbstractFileSystem
 from .utils import is_exception, other_paths
 
@@ -331,8 +337,6 @@ class AsyncFileSystem(AbstractFileSystem):
         batch_size=None,
         **kwargs,
     ):
-        from .implementations.local import trailing_sep, trailing_sep_maybe_asterisk
-
         if on_error is None and recursive:
             on_error = "ignore"
         elif on_error is None:
@@ -492,13 +496,6 @@ class AsyncFileSystem(AbstractFileSystem):
         constructor, or for all instances by setting the "gather_batch_size" key
         in ``fsspec.config.conf``, falling back to 1/8th of the system limit .
         """
-        from .implementations.local import (
-            LocalFileSystem,
-            make_path_posix,
-            trailing_sep,
-            trailing_sep_maybe_asterisk,
-        )
-
         source_is_str = isinstance(lpath, str)
         if source_is_str:
             lpath = make_path_posix(lpath)
@@ -565,13 +562,6 @@ class AsyncFileSystem(AbstractFileSystem):
         constructor, or for all instances by setting the "gather_batch_size" key
         in ``fsspec.config.conf``, falling back to 1/8th of the system limit .
         """
-        from .implementations.local import (
-            LocalFileSystem,
-            make_path_posix,
-            trailing_sep,
-            trailing_sep_maybe_asterisk,
-        )
-
         source_is_str = isinstance(rpath, str)
         # First check for rpath trailing slash as _strip_protocol removes it.
         source_not_trailing_sep = source_is_str and not trailing_sep_maybe_asterisk(

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -331,20 +331,30 @@ class AsyncFileSystem(AbstractFileSystem):
         batch_size=None,
         **kwargs,
     ):
+        from .implementations.local import trailing_sep, trailing_sep_maybe_asterisk
+
         if on_error is None and recursive:
             on_error = "ignore"
         elif on_error is None:
             on_error = "raise"
 
+        source_is_str = isinstance(path1, str)
         paths = await self._expand_path(path1, maxdepth=maxdepth, recursive=recursive)
+        if source_is_str and (not recursive or maxdepth is not None):
+            # Non-recursive glob does not copy directories
+            paths = [p for p in paths if not (trailing_sep(p) or await self._isdir(p))]
+            if not paths:
+                return
+
         isdir = isinstance(path2, str) and (
-            path2.endswith("/") or await self._isdir(path2)
+            trailing_sep(path2) or await self._isdir(path2)
         )
         path2 = other_paths(
             paths,
             path2,
-            exists=isdir and isinstance(path1, str) and not path1.endswith("/"),
+            exists=isdir and source_is_str and not trailing_sep_maybe_asterisk(path1),
             is_dir=isdir,
+            flatten=not source_is_str,
         )
         batch_size = batch_size or self.batch_size
         coros = [self._cp_file(p1, p2, **kwargs) for p1, p2 in zip(paths, path2)]
@@ -466,6 +476,7 @@ class AsyncFileSystem(AbstractFileSystem):
         recursive=False,
         callback=_DEFAULT_CALLBACK,
         batch_size=None,
+        maxdepth=None,
         **kwargs,
     ):
         """Copy file(s) from local.
@@ -481,21 +492,34 @@ class AsyncFileSystem(AbstractFileSystem):
         constructor, or for all instances by setting the "gather_batch_size" key
         in ``fsspec.config.conf``, falling back to 1/8th of the system limit .
         """
-        from .implementations.local import LocalFileSystem, make_path_posix
+        from .implementations.local import (
+            LocalFileSystem,
+            make_path_posix,
+            trailing_sep,
+            trailing_sep_maybe_asterisk,
+        )
 
-        rpath = self._strip_protocol(rpath)
-        if isinstance(lpath, str):
+        source_is_str = isinstance(lpath, str)
+        if source_is_str:
             lpath = make_path_posix(lpath)
         fs = LocalFileSystem()
-        lpaths = fs.expand_path(lpath, recursive=recursive)
+        lpaths = fs.expand_path(lpath, recursive=recursive, maxdepth=maxdepth)
+        if source_is_str and (not recursive or maxdepth is not None):
+            # Non-recursive glob does not copy directories
+            lpaths = [p for p in lpaths if not (trailing_sep(p) or fs.isdir(p))]
+            if not lpaths:
+                return
+
         isdir = isinstance(rpath, str) and (
-            rpath.endswith("/") or await self._isdir(rpath)
+            trailing_sep(rpath) or await self._isdir(rpath)
         )
+        rpath = self._strip_protocol(rpath)
         rpaths = other_paths(
             lpaths,
             rpath,
-            exists=isdir and isinstance(lpath, str) and not lpath.endswith("/"),
+            exists=isdir and source_is_str and not trailing_sep_maybe_asterisk(lpath),
             is_dir=isdir,
+            flatten=not source_is_str,
         )
 
         is_dir = {l: os.path.isdir(l) for l in lpaths}
@@ -519,7 +543,13 @@ class AsyncFileSystem(AbstractFileSystem):
         raise NotImplementedError
 
     async def _get(
-        self, rpath, lpath, recursive=False, callback=_DEFAULT_CALLBACK, **kwargs
+        self,
+        rpath,
+        lpath,
+        recursive=False,
+        callback=_DEFAULT_CALLBACK,
+        maxdepth=None,
+        **kwargs,
     ):
         """Copy file(s) to local.
 
@@ -535,21 +565,38 @@ class AsyncFileSystem(AbstractFileSystem):
         constructor, or for all instances by setting the "gather_batch_size" key
         in ``fsspec.config.conf``, falling back to 1/8th of the system limit .
         """
-        from fsspec.implementations.local import LocalFileSystem, make_path_posix
+        from .implementations.local import (
+            LocalFileSystem,
+            make_path_posix,
+            trailing_sep,
+            trailing_sep_maybe_asterisk,
+        )
 
+        source_is_str = isinstance(rpath, str)
         # First check for rpath trailing slash as _strip_protocol removes it.
-        rpath_trailing_slash = isinstance(rpath, str) and rpath.endswith("/")
+        source_not_trailing_sep = source_is_str and not trailing_sep_maybe_asterisk(
+            rpath
+        )
         rpath = self._strip_protocol(rpath)
-        lpath = make_path_posix(lpath)
         rpaths = await self._expand_path(rpath, recursive=recursive)
+        if source_is_str and (not recursive or maxdepth is not None):
+            # Non-recursive glob does not copy directories
+            rpaths = [
+                p for p in rpaths if not (trailing_sep(p) or await self._isdir(p))
+            ]
+            if not rpaths:
+                return
+
+        lpath = make_path_posix(lpath)
         isdir = isinstance(lpath, str) and (
-            lpath.endswith("/") or LocalFileSystem().isdir(lpath)
+            trailing_sep(lpath) or LocalFileSystem().isdir(lpath)
         )
         lpaths = other_paths(
             rpaths,
             lpath,
-            exists=isdir and not rpath_trailing_slash,
+            exists=isdir and source_not_trailing_sep,
             is_dir=isdir,
+            flatten=not source_is_str,
         )
         [os.makedirs(os.path.dirname(lp), exist_ok=True) for lp in lpaths]
         batch_size = kwargs.pop("batch_size", self.batch_size)
@@ -766,9 +813,16 @@ class AsyncFileSystem(AbstractFileSystem):
                     bit = set(await self._glob(p))
                     out |= bit
                     if recursive:
+                        # glob call above expanded one depth so if maxdepth is defined
+                        # then decrement it in expand_path call below. If it is zero
+                        # after decrementing then avoid expand_path call.
+                        if maxdepth is not None and maxdepth <= 1:
+                            continue
                         out |= set(
                             await self._expand_path(
-                                list(bit), recursive=recursive, maxdepth=maxdepth
+                                list(bit),
+                                recursive=recursive,
+                                maxdepth=maxdepth - 1 if maxdepth is not None else None,
                             )
                         )
                     continue
@@ -778,8 +832,6 @@ class AsyncFileSystem(AbstractFileSystem):
                 if p not in out and (recursive is False or (await self._exists(p))):
                     # should only check once, for the root
                     out.add(p)
-            # reduce depth on each recursion level unless None or 0
-            maxdepth = maxdepth if not maxdepth else maxdepth - 1
         if not out:
             raise FileNotFoundError(path)
         return list(sorted(out))

--- a/fsspec/implementations/tests/local/local_fixtures.py
+++ b/fsspec/implementations/tests/local/local_fixtures.py
@@ -5,7 +5,7 @@ from fsspec.tests.abstract import AbstractFixtures
 
 
 class LocalFixtures(AbstractFixtures):
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def fs(self):
         return LocalFileSystem(auto_mkdir=True)
 

--- a/fsspec/implementations/tests/local/local_fixtures.py
+++ b/fsspec/implementations/tests/local/local_fixtures.py
@@ -5,12 +5,10 @@ from fsspec.tests.abstract import AbstractFixtures
 
 
 class LocalFixtures(AbstractFixtures):
-    @staticmethod
     @pytest.fixture
-    def fs():
+    def fs(self):
         return LocalFileSystem(auto_mkdir=True)
 
-    @staticmethod
     @pytest.fixture
-    def fs_path(tmpdir):
+    def fs_path(self, tmpdir):
         return str(tmpdir)

--- a/fsspec/implementations/tests/memory/memory_fixtures.py
+++ b/fsspec/implementations/tests/memory/memory_fixtures.py
@@ -5,7 +5,7 @@ from fsspec.tests.abstract import AbstractFixtures
 
 
 class MemoryFixtures(AbstractFixtures):
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def fs(self):
         m = filesystem("memory")
         m.store.clear()

--- a/fsspec/implementations/tests/memory/memory_fixtures.py
+++ b/fsspec/implementations/tests/memory/memory_fixtures.py
@@ -5,9 +5,8 @@ from fsspec.tests.abstract import AbstractFixtures
 
 
 class MemoryFixtures(AbstractFixtures):
-    @staticmethod
     @pytest.fixture
-    def fs():
+    def fs(self):
         m = filesystem("memory")
         m.store.clear()
         m.pseudo_dirs.clear()
@@ -19,12 +18,10 @@ class MemoryFixtures(AbstractFixtures):
             m.pseudo_dirs.clear()
             m.pseudo_dirs.append("")
 
-    @staticmethod
     @pytest.fixture
-    def fs_join():
+    def fs_join(self):
         return lambda *args: "/".join(args)
 
-    @staticmethod
     @pytest.fixture
-    def fs_path():
+    def fs_path(self):
         return ""

--- a/fsspec/implementations/tests/memory/memory_test.py
+++ b/fsspec/implementations/tests/memory/memory_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 import fsspec.tests.abstract as abstract
 from fsspec.implementations.tests.memory.memory_fixtures import MemoryFixtures
 
@@ -7,7 +9,21 @@ class TestMemoryCopy(abstract.AbstractCopyTests, MemoryFixtures):
 
 
 class TestMemoryGet(abstract.AbstractGetTests, MemoryFixtures):
-    pass
+    @pytest.mark.skip(reason="Bug: does not auto-create new directory")
+    def test_get_file_to_new_directory(self):
+        pass
+
+    @pytest.mark.skip(reason="Bug: does not auto-create new directory")
+    def test_get_file_to_file_in_new_directory(self):
+        pass
+
+    @pytest.mark.skip(reason="Bug: does not auto-create new directory")
+    def test_get_glob_to_new_directory(self):
+        pass
+
+    @pytest.mark.skip(reason="Bug: does not auto-create new directory")
+    def test_get_list_of_files_to_new_directory(self):
+        pass
 
 
 class TestMemoryPut(abstract.AbstractPutTests, MemoryFixtures):

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -23,19 +23,6 @@ def test_strip(m):
     assert m._strip_protocol("/b/c/") == "/b/c"
 
 
-def test_put_single(m, tmpdir):
-    fn = os.path.join(str(tmpdir), "dir")
-    os.mkdir(fn)
-    open(os.path.join(fn, "abc"), "w").write("text")
-    m.put(fn, "/test")  # no-op, no files
-    assert m.isdir("/test")
-    assert not m.exists("/test/abc")
-    assert not m.exists("/test/dir")
-    m.put(fn, "/test", recursive=True)
-    assert m.isdir("/test/dir")
-    assert m.cat("/test/dir/abc") == b"text"
-
-
 def test_ls(m):
     m.mkdir("/dir")
     m.mkdir("/dir/dir1")

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -197,7 +197,7 @@ known_implementations = {
     "box": {
         "class": "boxfs.BoxFileSystem",
         "err": "Please install boxfs to access BoxFileSystem",
-    }
+    },
 }
 
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -976,10 +976,10 @@ class AbstractFileSystem(metaclass=_Cached):
             trailing_sep_maybe_asterisk,
         )
 
-        if isinstance(lpath, str):
+        source_is_str = isinstance(lpath, str)
+        if source_is_str:
             lpath = make_path_posix(lpath)
         fs = LocalFileSystem()
-        source_is_str = isinstance(lpath, str)
         lpaths = fs.expand_path(lpath, recursive=recursive, maxdepth=maxdepth)
         if source_is_str and (not recursive or maxdepth is not None):
             # Non-recursive glob does not copy directories

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -983,16 +983,16 @@ class AbstractFileSystem(metaclass=_Cached):
         lpaths = fs.expand_path(lpath, recursive=recursive, maxdepth=maxdepth)
         if source_is_str and (not recursive or maxdepth is not None):
             # Non-recursive glob does not copy directories
-            lpaths = [p for p in lpaths if not (trailing_sep(p) or self.isdir(p))]
+            lpaths = [p for p in lpaths if not (trailing_sep(p) or fs.isdir(p))]
             if not lpaths:
                 return
 
+        isdir = isinstance(rpath, str) and (trailing_sep(rpath) or self.isdir(rpath))
         rpath = (
             self._strip_protocol(rpath)
             if isinstance(rpath, str)
             else [self._strip_protocol(p) for p in rpath]
         )
-        isdir = isinstance(rpath, str) and (trailing_sep(rpath) or self.isdir(rpath))
         rpaths = other_paths(
             lpaths,
             rpath,

--- a/fsspec/tests/abstract/__init__.py
+++ b/fsspec/tests/abstract/__init__.py
@@ -20,13 +20,13 @@ class AbstractFixtures:
         return os.path.join
 
     @pytest.fixture
-    def fs_scenario_cp(self, fs, fs_join, fs_path):
+    def fs_bulk_operations_scenario_0(self, fs, fs_join, fs_path):
         """
         Scenario on remote filesystem that is used for many cp/get/put tests.
 
         Cleans up at the end of each test it which it is used.
         """
-        source = self._scenario_cp(fs, fs_join, fs_path)
+        source = self._bulk_operations_scenario_0(fs, fs_join, fs_path)
         yield source
         fs.rm(source, recursive=True)
 
@@ -79,17 +79,17 @@ class AbstractFixtures:
         return True
 
     @pytest.fixture
-    def local_scenario_cp(self, local_fs, local_join, local_path):
+    def local_bulk_operations_scenario_0(self, local_fs, local_join, local_path):
         """
         Scenario on local filesystem that is used for many cp/get/put tests.
 
         Cleans up at the end of each test it which it is used.
         """
-        source = self._scenario_cp(local_fs, local_join, local_path)
+        source = self._bulk_operations_scenario_0(local_fs, local_join, local_path)
         yield source
         local_fs.rm(source, recursive=True)
 
-    def _scenario_cp(self, some_fs, some_join, some_path):
+    def _bulk_operations_scenario_0(self, some_fs, some_join, some_path):
         """
         Scenario that is used for many cp/get/put tests. Creates the following
         directory and file structure:

--- a/fsspec/tests/abstract/__init__.py
+++ b/fsspec/tests/abstract/__init__.py
@@ -21,10 +21,28 @@ class AbstractFixtures:
 
     @pytest.fixture
     def fs_scenario_cp(self, fs, fs_join, fs_path):
-        """Scenario on remote filesystem that is used for many cp/get/put tests."""
-        return self.scenario_cp(fs, fs_join, fs_path)
+        """
+        Scenario on remote filesystem that is used for many cp/get/put tests.
+
+        Cleans up at the end of each test it which it is used.
+        """
+        source = self._scenario_cp(fs, fs_join, fs_path)
+        yield source
+        fs.rm(source, recursive=True)
 
     @pytest.fixture
+    def fs_target(self, fs, fs_join, fs_path):
+        """
+        Return name of remote directory that does not yet exist to copy into.
+
+        Cleans up at the end of each test it which it is used.
+        """
+        target = fs_join(fs_path, "target")
+        yield target
+        if fs.exists(target):
+            fs.rm(target, recursive=True)
+
+    @pytest.fixture(scope="class")
     def local_fs(self):
         # Maybe need an option for auto_mkdir=False?  This is only relevant
         # for certain implementations.
@@ -42,6 +60,18 @@ class AbstractFixtures:
     def local_path(self, tmpdir):
         return tmpdir
 
+    @pytest.fixture
+    def local_target(self, local_fs, local_join, local_path):
+        """
+        Return name of local directory that does not yet exist to copy into.
+
+        Cleans up at the end of each test it which it is used.
+        """
+        target = local_join(local_path, "target")
+        yield target
+        if local_fs.exists(target):
+            local_fs.rm(target, recursive=True)
+
     def supports_empty_directories(self):
         """
         Return whether this implementation supports empty directories.
@@ -50,10 +80,16 @@ class AbstractFixtures:
 
     @pytest.fixture
     def local_scenario_cp(self, local_fs, local_join, local_path):
-        """Scenario on local filesystem that is used for many cp/get/put tests."""
-        return self.scenario_cp(local_fs, local_join, local_path)
+        """
+        Scenario on local filesystem that is used for many cp/get/put tests.
 
-    def scenario_cp(self, some_fs, some_join, some_path):
+        Cleans up at the end of each test it which it is used.
+        """
+        source = self._scenario_cp(local_fs, local_join, local_path)
+        yield source
+        local_fs.rm(source, recursive=True)
+
+    def _scenario_cp(self, some_fs, some_join, some_path):
         """
         Scenario that is used for many cp/get/put tests. Creates the following
         directory and file structure:

--- a/fsspec/tests/abstract/__init__.py
+++ b/fsspec/tests/abstract/__init__.py
@@ -20,31 +20,10 @@ class AbstractFixtures:
         """
         return os.path.join
 
-    @staticmethod
     @pytest.fixture
-    def fs_scenario_cp(fs, fs_join, fs_path):
-        """
-        Scenario on remote filesystem that is used for many cp/get/put tests.
-
-        📁 source
-        ├── 📄 file1
-        ├── 📄 file2
-        └── 📁 subdir
-            ├── 📄 subfile1
-            ├── 📄 subfile2
-            └── 📁 nesteddir
-                └── 📄 nestedfile
-        """
-        source = fs_join(fs_path, "source")
-        subdir = fs_join(source, "subdir")
-        nesteddir = fs_join(subdir, "nesteddir")
-        fs.makedirs(nesteddir)
-        fs.touch(fs_join(source, "file1"))
-        fs.touch(fs_join(source, "file2"))
-        fs.touch(fs_join(subdir, "subfile1"))
-        fs.touch(fs_join(subdir, "subfile2"))
-        fs.touch(fs_join(nesteddir, "nestedfile"))
-        return source
+    def fs_scenario_cp(self, fs, fs_join, fs_path):
+        """Scenario on remote filesystem that is used for many cp/get/put tests."""
+        return self.scenario_cp(fs, fs_join, fs_path)
 
     @staticmethod
     @pytest.fixture
@@ -72,3 +51,33 @@ class AbstractFixtures:
         Return whether this implementation supports empty directories.
         """
         return True
+
+    @pytest.fixture
+    def local_scenario_cp(self, local_fs, local_join, local_path):
+        """Scenario on local filesystem that is used for many cp/get/put tests."""
+        return self.scenario_cp(local_fs, local_join, local_path)
+
+    def scenario_cp(self, some_fs, some_join, some_path):
+        """
+        Scenario that is used for many cp/get/put tests. Creates the following
+        directory and file structure:
+
+        📁 source
+        ├── 📄 file1
+        ├── 📄 file2
+        └── 📁 subdir
+            ├── 📄 subfile1
+            ├── 📄 subfile2
+            └── 📁 nesteddir
+                └── 📄 nestedfile
+        """
+        source = some_join(some_path, "source")
+        subdir = some_join(source, "subdir")
+        nesteddir = some_join(subdir, "nesteddir")
+        some_fs.makedirs(nesteddir)
+        some_fs.touch(some_join(source, "file1"))
+        some_fs.touch(some_join(source, "file2"))
+        some_fs.touch(some_join(subdir, "subfile1"))
+        some_fs.touch(some_join(subdir, "subfile2"))
+        some_fs.touch(some_join(nesteddir, "nestedfile"))
+        return source

--- a/fsspec/tests/abstract/__init__.py
+++ b/fsspec/tests/abstract/__init__.py
@@ -9,9 +9,8 @@ from fsspec.tests.abstract.put import AbstractPutTests  # noqa
 
 
 class AbstractFixtures:
-    @staticmethod
     @pytest.fixture
-    def fs_join():
+    def fs_join(self):
         """
         Return a function that joins its arguments together into a path.
 
@@ -25,25 +24,22 @@ class AbstractFixtures:
         """Scenario on remote filesystem that is used for many cp/get/put tests."""
         return self.scenario_cp(fs, fs_join, fs_path)
 
-    @staticmethod
     @pytest.fixture
-    def local_fs():
+    def local_fs(self):
         # Maybe need an option for auto_mkdir=False?  This is only relevant
         # for certain implementations.
         return LocalFileSystem(auto_mkdir=True)
 
-    @staticmethod
     @pytest.fixture
-    def local_join():
+    def local_join(self):
         """
         Return a function that joins its arguments together into a path, on
         the local filesystem.
         """
         return os.path.join
 
-    @staticmethod
     @pytest.fixture
-    def local_path(tmpdir):
+    def local_path(self, tmpdir):
         return tmpdir
 
     def supports_empty_directories(self):

--- a/fsspec/tests/abstract/copy.py
+++ b/fsspec/tests/abstract/copy.py
@@ -1,11 +1,11 @@
 class AbstractCopyTests:
     def test_copy_file_to_existing_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp
+        self, fs, fs_join, fs_scenario_cp, fs_target
     ):
         # Copy scenario 1a
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
         if not self.supports_empty_directories():
             # Force target directory to exist by adding a dummy file
@@ -36,11 +36,11 @@ class AbstractCopyTests:
         fs.cp(fs_join(source, "subdir", "subfile1"), target + "/")
         assert fs.isfile(target_subfile1)
 
-    def test_copy_file_to_new_directory(self, fs, fs_join, fs_path, fs_scenario_cp):
+    def test_copy_file_to_new_directory(self, fs, fs_join, fs_scenario_cp, fs_target):
         # Copy scenario 1b
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
 
         fs.cp(
@@ -51,24 +51,24 @@ class AbstractCopyTests:
         assert fs.isfile(fs_join(target, "newdir", "subfile1"))
 
     def test_copy_file_to_file_in_existing_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp
+        self, fs, fs_join, fs_scenario_cp, fs_target
     ):
         # Copy scenario 1c
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
 
         fs.cp(fs_join(source, "subdir", "subfile1"), fs_join(target, "newfile"))
         assert fs.isfile(fs_join(target, "newfile"))
 
     def test_copy_file_to_file_in_new_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp
+        self, fs, fs_join, fs_scenario_cp, fs_target
     ):
         # Copy scenario 1d
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
 
         fs.cp(
@@ -78,12 +78,12 @@ class AbstractCopyTests:
         assert fs.isfile(fs_join(target, "newdir", "newfile"))
 
     def test_copy_directory_to_existing_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp
+        self, fs, fs_join, fs_scenario_cp, fs_target
     ):
         # Copy scenario 1e
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
         if not self.supports_empty_directories():
             # Force target directory to exist by adding a dummy file
@@ -140,12 +140,12 @@ class AbstractCopyTests:
             assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
     def test_copy_directory_to_new_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp
+        self, fs, fs_join, fs_scenario_cp, fs_target
     ):
         # Copy scenario 1f
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
 
         for source_slash, target_slash in zip([False, True], [False, True]):
@@ -170,7 +170,7 @@ class AbstractCopyTests:
             assert not fs.exists(fs_join(target, "subdir"))
 
             fs.rm(fs_join(target, "newdir"), recursive=True)
-            assert fs.ls(target) == []
+            assert not fs.exists(fs_join(target, "newdir"))
 
             # Limit recursive by maxdepth
             fs.cp(s, t, recursive=True, maxdepth=1)
@@ -181,15 +181,15 @@ class AbstractCopyTests:
             assert not fs.exists(fs_join(target, "subdir"))
 
             fs.rm(fs_join(target, "newdir"), recursive=True)
-            assert fs.ls(target) == []
+            assert not fs.exists(fs_join(target, "newdir"))
 
     def test_copy_glob_to_existing_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp
+        self, fs, fs_join, fs_scenario_cp, fs_target
     ):
         # Copy scenario 1g
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
 
         for target_slash in [False, True]:
@@ -227,11 +227,11 @@ class AbstractCopyTests:
             fs.rm(fs.ls(target, detail=False), recursive=True)
             assert fs.ls(target) == []
 
-    def test_copy_glob_to_new_directory(self, fs, fs_join, fs_path, fs_scenario_cp):
+    def test_copy_glob_to_new_directory(self, fs, fs_join, fs_scenario_cp, fs_target):
         # Copy scenario 1h
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
 
         for target_slash in [False, True]:
@@ -250,7 +250,7 @@ class AbstractCopyTests:
             assert not fs.exists(fs_join(target, "newdir", "subdir"))
 
             fs.rm(fs_join(target, "newdir"), recursive=True)
-            assert fs.ls(target) == []
+            assert not fs.exists(fs_join(target, "newdir"))
 
             # With recursive
             fs.cp(fs_join(source, "subdir", "*"), t, recursive=True)
@@ -263,7 +263,7 @@ class AbstractCopyTests:
             assert not fs.exists(fs_join(target, "newdir", "subdir"))
 
             fs.rm(fs_join(target, "newdir"), recursive=True)
-            assert fs.ls(target) == []
+            assert not fs.exists(fs_join(target, "newdir"))
 
             # Limit recursive by maxdepth
             fs.cp(fs_join(source, "subdir", "*"), t, recursive=True, maxdepth=1)
@@ -275,16 +275,21 @@ class AbstractCopyTests:
             assert not fs.exists(fs_join(target, "newdir", "subdir"))
 
             fs.rm(fs.ls(target, detail=False), recursive=True)
-            assert fs.ls(target) == []
+            assert not fs.exists(fs_join(target, "newdir"))
 
     def test_copy_list_of_files_to_existing_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp
+        self, fs, fs_join, fs_scenario_cp, fs_target
     ):
         # Copy scenario 2a
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
+        if not self.supports_empty_directories():
+            # Force target directory to exist by adding a dummy file
+            dummy = fs_join(target, "dummy")
+            fs.touch(dummy)
+        assert fs.isdir(target)
 
         source_files = [
             fs_join(source, "file1"),
@@ -301,15 +306,15 @@ class AbstractCopyTests:
             assert fs.isfile(fs_join(target, "subfile1"))
 
             fs.rm(fs.find(target))
-            assert fs.ls(target) == []
+            assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
     def test_copy_list_of_files_to_new_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp
+        self, fs, fs_join, fs_scenario_cp, fs_target
     ):
         # Copy scenario 2b
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         fs.mkdir(target)
 
         source_files = [
@@ -324,12 +329,12 @@ class AbstractCopyTests:
         assert fs.isfile(fs_join(target, "newdir", "file2"))
         assert fs.isfile(fs_join(target, "newdir", "subfile1"))
 
-    def test_copy_two_files_new_directory(self, fs, fs_join, fs_path, fs_scenario_cp):
+    def test_copy_two_files_new_directory(self, fs, fs_join, fs_scenario_cp, fs_target):
         # This is a duplicate of test_copy_list_of_files_to_new_directory and
         # can eventually be removed.
         source = fs_scenario_cp
 
-        target = fs_join(fs_path, "target")
+        target = fs_target
         assert not fs.exists(target)
         fs.cp([fs_join(source, "file1"), fs_join(source, "file2")], target)
 

--- a/fsspec/tests/abstract/copy.py
+++ b/fsspec/tests/abstract/copy.py
@@ -8,6 +8,7 @@ class AbstractCopyTests:
         target = fs_join(fs_path, "target")
         fs.mkdir(target)
         if not self.supports_empty_directories():
+            # Force target directory to exist by adding a dummy file
             fs.touch(fs_join(target, "dummy"))
         assert fs.isdir(target)
 
@@ -84,6 +85,11 @@ class AbstractCopyTests:
 
         target = fs_join(fs_path, "target")
         fs.mkdir(target)
+        if not self.supports_empty_directories():
+            # Force target directory to exist by adding a dummy file
+            dummy = fs_join(target, "dummy")
+            fs.touch(dummy)
+        assert fs.isdir(target)
 
         for source_slash, target_slash in zip([False, True], [False, True]):
             s = fs_join(source, "subdir")
@@ -93,7 +99,7 @@ class AbstractCopyTests:
 
             # Without recursive does nothing
             fs.cp(s, t)
-            assert fs.ls(target) == []
+            assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
             # With recursive
             fs.cp(s, t, recursive=True)
@@ -113,7 +119,7 @@ class AbstractCopyTests:
                 assert fs.isfile(fs_join(target, "subdir", "nesteddir", "nestedfile"))
 
                 fs.rm(fs_join(target, "subdir"), recursive=True)
-            assert fs.ls(target) == []
+            assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
             # Limit recursive by maxdepth
             fs.cp(s, t, recursive=True, maxdepth=1)
@@ -131,7 +137,7 @@ class AbstractCopyTests:
                 assert not fs.exists(fs_join(target, "subdir", "nesteddir"))
 
                 fs.rm(fs_join(target, "subdir"), recursive=True)
-            assert fs.ls(target) == []
+            assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
     def test_copy_directory_to_new_directory(
         self, fs, fs_join, fs_path, fs_scenario_cp

--- a/fsspec/tests/abstract/copy.py
+++ b/fsspec/tests/abstract/copy.py
@@ -1,9 +1,9 @@
 class AbstractCopyTests:
     def test_copy_file_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, fs_target
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
     ):
         # Copy scenario 1a
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -36,9 +36,11 @@ class AbstractCopyTests:
         fs.cp(fs_join(source, "subdir", "subfile1"), target + "/")
         assert fs.isfile(target_subfile1)
 
-    def test_copy_file_to_new_directory(self, fs, fs_join, fs_scenario_cp, fs_target):
+    def test_copy_file_to_new_directory(
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
+    ):
         # Copy scenario 1b
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -51,10 +53,10 @@ class AbstractCopyTests:
         assert fs.isfile(fs_join(target, "newdir", "subfile1"))
 
     def test_copy_file_to_file_in_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, fs_target
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
     ):
         # Copy scenario 1c
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -63,10 +65,10 @@ class AbstractCopyTests:
         assert fs.isfile(fs_join(target, "newfile"))
 
     def test_copy_file_to_file_in_new_directory(
-        self, fs, fs_join, fs_scenario_cp, fs_target
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
     ):
         # Copy scenario 1d
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -78,10 +80,10 @@ class AbstractCopyTests:
         assert fs.isfile(fs_join(target, "newdir", "newfile"))
 
     def test_copy_directory_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, fs_target
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
     ):
         # Copy scenario 1e
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -140,10 +142,10 @@ class AbstractCopyTests:
             assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
     def test_copy_directory_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, fs_target
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
     ):
         # Copy scenario 1f
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -184,10 +186,10 @@ class AbstractCopyTests:
             assert not fs.exists(fs_join(target, "newdir"))
 
     def test_copy_glob_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, fs_target
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
     ):
         # Copy scenario 1g
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -227,9 +229,11 @@ class AbstractCopyTests:
             fs.rm(fs.ls(target, detail=False), recursive=True)
             assert fs.ls(target) == []
 
-    def test_copy_glob_to_new_directory(self, fs, fs_join, fs_scenario_cp, fs_target):
+    def test_copy_glob_to_new_directory(
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
+    ):
         # Copy scenario 1h
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -278,10 +282,10 @@ class AbstractCopyTests:
             assert not fs.exists(fs_join(target, "newdir"))
 
     def test_copy_list_of_files_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, fs_target
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
     ):
         # Copy scenario 2a
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -309,10 +313,10 @@ class AbstractCopyTests:
             assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
     def test_copy_list_of_files_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, fs_target
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
     ):
         # Copy scenario 2b
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -329,10 +333,12 @@ class AbstractCopyTests:
         assert fs.isfile(fs_join(target, "newdir", "file2"))
         assert fs.isfile(fs_join(target, "newdir", "subfile1"))
 
-    def test_copy_two_files_new_directory(self, fs, fs_join, fs_scenario_cp, fs_target):
+    def test_copy_two_files_new_directory(
+        self, fs, fs_join, fs_bulk_operations_scenario_0, fs_target
+    ):
         # This is a duplicate of test_copy_list_of_files_to_new_directory and
         # can eventually be removed.
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = fs_target
         assert not fs.exists(target)

--- a/fsspec/tests/abstract/get.py
+++ b/fsspec/tests/abstract/get.py
@@ -1,11 +1,11 @@
 class AbstractGetTests:
     def test_get_file_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 1a
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
         assert local_fs.isdir(target)
 
@@ -34,12 +34,12 @@ class AbstractGetTests:
         assert local_fs.isfile(target_subfile1)
 
     def test_get_file_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 1b
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
 
         fs.get(
@@ -51,24 +51,24 @@ class AbstractGetTests:
         assert local_fs.isfile(local_join(target, "newdir", "subfile1"))
 
     def test_get_file_to_file_in_existing_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_path, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 1c
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
 
         fs.get(fs_join(source, "subdir", "subfile1"), local_join(target, "newfile"))
         assert local_fs.isfile(local_join(target, "newfile"))
 
     def test_get_file_to_file_in_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 1d
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
 
         fs.get(
@@ -79,12 +79,12 @@ class AbstractGetTests:
         assert local_fs.isfile(local_join(target, "newdir", "newfile"))
 
     def test_get_directory_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 1e
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
 
         for source_slash, target_slash in zip([False, True], [False, True]):
@@ -130,12 +130,12 @@ class AbstractGetTests:
             # ERROR: maxdepth ignored here
 
     def test_get_directory_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 1f
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
 
         for source_slash, target_slash in zip([False, True], [False, True]):
@@ -168,12 +168,12 @@ class AbstractGetTests:
             # ERROR: maxdepth ignored here
 
     def test_get_glob_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 1g
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
 
         # for target_slash in [False, True]:
@@ -192,12 +192,12 @@ class AbstractGetTests:
             # Limit by maxdepth
 
     def test_get_glob_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 1h
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
 
         for target_slash in [False, True]:
@@ -233,12 +233,12 @@ class AbstractGetTests:
             # ERROR: this is not correct
 
     def test_get_list_of_files_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 2a
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
 
         source_files = [
@@ -259,12 +259,12 @@ class AbstractGetTests:
             assert local_fs.ls(target) == []
 
     def test_get_list_of_files_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
     ):
         # Copy scenario 2b
         source = fs_scenario_cp
 
-        target = local_join(local_path, "target")
+        target = local_target
         local_fs.mkdir(target)
 
         source_files = [
@@ -280,7 +280,7 @@ class AbstractGetTests:
         assert local_fs.isfile(local_join(target, "newdir", "subfile1"))
 
     def test_get_directory_recursive(
-        self, fs, fs_join, fs_path, local_fs, local_join, local_path
+        self, fs, fs_join, fs_path, local_fs, local_join, local_target
     ):
         # https://github.com/fsspec/filesystem_spec/issues/1062
         # Recursive cp/get/put of source directory into non-existent target directory.
@@ -289,7 +289,7 @@ class AbstractGetTests:
         fs.mkdir(src)
         fs.touch(src_file)
 
-        target = local_join(local_path, "target")
+        target = local_target
 
         # get without slash
         assert not local_fs.exists(target)

--- a/fsspec/tests/abstract/get.py
+++ b/fsspec/tests/abstract/get.py
@@ -7,8 +7,6 @@ class AbstractGetTests:
 
         target = local_join(local_path, "target")
         local_fs.mkdir(target)
-        if not self.supports_empty_directories():
-            local_fs.touch(local_join(target, "dummy"))
         assert local_fs.isdir(target)
 
         target_file2 = local_join(target, "file2")

--- a/fsspec/tests/abstract/get.py
+++ b/fsspec/tests/abstract/get.py
@@ -1,9 +1,15 @@
 class AbstractGetTests:
     def test_get_file_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 1a
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)
@@ -34,10 +40,16 @@ class AbstractGetTests:
         assert local_fs.isfile(target_subfile1)
 
     def test_get_file_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 1b
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)
@@ -51,10 +63,17 @@ class AbstractGetTests:
         assert local_fs.isfile(local_join(target, "newdir", "subfile1"))
 
     def test_get_file_to_file_in_existing_directory(
-        self, fs, fs_join, fs_path, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_path,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 1c
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)
@@ -63,10 +82,16 @@ class AbstractGetTests:
         assert local_fs.isfile(local_join(target, "newfile"))
 
     def test_get_file_to_file_in_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 1d
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)
@@ -79,10 +104,16 @@ class AbstractGetTests:
         assert local_fs.isfile(local_join(target, "newdir", "newfile"))
 
     def test_get_directory_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 1e
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)
@@ -130,10 +161,16 @@ class AbstractGetTests:
             # ERROR: maxdepth ignored here
 
     def test_get_directory_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 1f
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)
@@ -168,10 +205,16 @@ class AbstractGetTests:
             # ERROR: maxdepth ignored here
 
     def test_get_glob_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 1g
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)
@@ -192,10 +235,16 @@ class AbstractGetTests:
             # Limit by maxdepth
 
     def test_get_glob_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 1h
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)
@@ -233,10 +282,16 @@ class AbstractGetTests:
             # ERROR: this is not correct
 
     def test_get_list_of_files_to_existing_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 2a
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)
@@ -259,10 +314,16 @@ class AbstractGetTests:
             assert local_fs.ls(target) == []
 
     def test_get_list_of_files_to_new_directory(
-        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_target
+        self,
+        fs,
+        fs_join,
+        fs_bulk_operations_scenario_0,
+        local_fs,
+        local_join,
+        local_target,
     ):
         # Copy scenario 2b
-        source = fs_scenario_cp
+        source = fs_bulk_operations_scenario_0
 
         target = local_target
         local_fs.mkdir(target)

--- a/fsspec/tests/abstract/get.py
+++ b/fsspec/tests/abstract/get.py
@@ -1,4 +1,286 @@
 class AbstractGetTests:
+    def test_get_file_to_existing_directory(
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 1a
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+        if not self.supports_empty_directories():
+            local_fs.touch(local_join(target, "dummy"))
+        assert local_fs.isdir(target)
+
+        target_file2 = local_join(target, "file2")
+        target_subfile1 = local_join(target, "subfile1")
+
+        # Copy from source directory
+        fs.get(fs_join(source, "file2"), target)
+        assert local_fs.isfile(target_file2)
+
+        # Copy from sub directory
+        fs.get(fs_join(source, "subdir", "subfile1"), target)
+        assert local_fs.isfile(target_subfile1)
+
+        # Remove copied files
+        local_fs.rm([target_file2, target_subfile1])
+        assert not local_fs.exists(target_file2)
+        assert not local_fs.exists(target_subfile1)
+
+        # Repeat with trailing slash on target
+        fs.get(fs_join(source, "file2"), target + "/")
+        assert local_fs.isdir(target)
+        assert local_fs.isfile(target_file2)
+
+        fs.get(fs_join(source, "subdir", "subfile1"), target + "/")
+        assert local_fs.isfile(target_subfile1)
+
+    def test_get_file_to_new_directory(
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 1b
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+
+        fs.get(
+            fs_join(source, "subdir", "subfile1"), local_join(target, "newdir/")
+        )  # Note trailing slash
+
+        assert local_fs.isdir(target)
+        assert local_fs.isdir(local_join(target, "newdir"))
+        assert local_fs.isfile(local_join(target, "newdir", "subfile1"))
+
+    def test_get_file_to_file_in_existing_directory(
+        self, fs, fs_join, fs_path, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 1c
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+
+        fs.get(fs_join(source, "subdir", "subfile1"), local_join(target, "newfile"))
+        assert local_fs.isfile(local_join(target, "newfile"))
+
+    def test_get_file_to_file_in_new_directory(
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 1d
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+
+        fs.get(
+            fs_join(source, "subdir", "subfile1"),
+            local_join(target, "newdir", "newfile"),
+        )
+        assert local_fs.isdir(local_join(target, "newdir"))
+        assert local_fs.isfile(local_join(target, "newdir", "newfile"))
+
+    def test_get_directory_to_existing_directory(
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 1e
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+
+        for source_slash, target_slash in zip([False, True], [False, True]):
+            s = fs_join(source, "subdir")
+            if source_slash:
+                s += "/"
+            t = target + "/" if target_slash else target
+
+            # Without recursive does nothing
+            # ERROR: erroneously creates new directory
+            # fs.get(s, t)
+            # assert fs.ls(target) == []
+
+            # With recursive
+            fs.get(s, t, recursive=True)
+            if source_slash:
+                assert local_fs.isfile(local_join(target, "subfile1"))
+                assert local_fs.isfile(local_join(target, "subfile2"))
+                assert local_fs.isdir(local_join(target, "nesteddir"))
+                assert local_fs.isfile(local_join(target, "nesteddir", "nestedfile"))
+
+                local_fs.rm(
+                    [
+                        local_join(target, "subfile1"),
+                        local_join(target, "subfile2"),
+                        local_join(target, "nesteddir"),
+                    ],
+                    recursive=True,
+                )
+            else:
+                assert local_fs.isdir(local_join(target, "subdir"))
+                assert local_fs.isfile(local_join(target, "subdir", "subfile1"))
+                assert local_fs.isfile(local_join(target, "subdir", "subfile2"))
+                assert local_fs.isdir(local_join(target, "subdir", "nesteddir"))
+                assert local_fs.isfile(
+                    local_join(target, "subdir", "nesteddir", "nestedfile")
+                )
+
+                local_fs.rm(local_join(target, "subdir"), recursive=True)
+            assert local_fs.ls(target) == []
+
+            # Limit by maxdepth
+            # ERROR: maxdepth ignored here
+
+    def test_get_directory_to_new_directory(
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 1f
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+
+        for source_slash, target_slash in zip([False, True], [False, True]):
+            s = fs_join(source, "subdir")
+            if source_slash:
+                s += "/"
+            t = local_join(target, "newdir")
+            if target_slash:
+                t += "/"
+
+            # Without recursive does nothing
+            # ERROR: erroneously creates new directory
+            # fs.get(s, t)
+            # assert fs.ls(target) == []
+
+            # With recursive
+            fs.get(s, t, recursive=True)
+            assert local_fs.isdir(local_join(target, "newdir"))
+            assert local_fs.isfile(local_join(target, "newdir", "subfile1"))
+            assert local_fs.isfile(local_join(target, "newdir", "subfile2"))
+            assert local_fs.isdir(local_join(target, "newdir", "nesteddir"))
+            assert local_fs.isfile(
+                local_join(target, "newdir", "nesteddir", "nestedfile")
+            )
+
+            local_fs.rm(local_join(target, "newdir"), recursive=True)
+            assert local_fs.ls(target) == []
+
+            # Limit by maxdepth
+            # ERROR: maxdepth ignored here
+
+    def test_get_glob_to_existing_directory(
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 1g
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+
+        # for target_slash in [False, True]:
+        for target_slash in [False]:
+            t = target + "/" if target_slash else target
+
+            # Without recursive
+            fs.get(fs_join(source, "subdir", "*"), t)
+            assert local_fs.isfile(local_join(target, "subfile1"))
+            assert local_fs.isfile(local_join(target, "subfile2"))
+            # assert not local_fs.isdir(local_join(target, "nesteddir"))  # ERROR
+            assert not local_fs.isdir(local_join(target, "subdir"))
+
+            # With recursive
+
+            # Limit by maxdepth
+
+    def test_get_glob_to_new_directory(
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 1h
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+
+        for target_slash in [False, True]:
+            t = fs_join(target, "newdir")
+            if target_slash:
+                t += "/"
+
+            # Without recursive
+            fs.get(fs_join(source, "subdir", "*"), t)
+            assert local_fs.isdir(local_join(target, "newdir"))
+            assert local_fs.isfile(local_join(target, "newdir", "subfile1"))
+            assert local_fs.isfile(local_join(target, "newdir", "subfile2"))
+            # ERROR - do not copy empty directory
+            # assert not local_fs.exists(local_join(target, "newdir", "nesteddir"))
+
+            local_fs.rm(local_join(target, "newdir"), recursive=True)
+            assert local_fs.ls(target) == []
+
+            # With recursive
+            fs.get(fs_join(source, "subdir", "*"), t, recursive=True)
+            assert local_fs.isdir(local_join(target, "newdir"))
+            assert local_fs.isfile(local_join(target, "newdir", "subfile1"))
+            assert local_fs.isfile(local_join(target, "newdir", "subfile2"))
+            assert local_fs.isdir(local_join(target, "newdir", "nesteddir"))
+            assert local_fs.isfile(
+                local_join(target, "newdir", "nesteddir", "nestedfile")
+            )
+
+            local_fs.rm(local_join(target, "newdir"), recursive=True)
+            assert local_fs.ls(target) == []
+
+            # Limit by maxdepth
+            # ERROR: this is not correct
+
+    def test_get_list_of_files_to_existing_directory(
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 2a
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+
+        source_files = [
+            fs_join(source, "file1"),
+            fs_join(source, "file2"),
+            fs_join(source, "subdir", "subfile1"),
+        ]
+
+        for target_slash in [False, True]:
+            t = target + "/" if target_slash else target
+
+            fs.get(source_files, t)
+            assert local_fs.isfile(local_join(target, "file1"))
+            assert local_fs.isfile(local_join(target, "file2"))
+            assert local_fs.isfile(local_join(target, "subfile1"))
+
+            local_fs.rm(local_fs.find(target))
+            assert local_fs.ls(target) == []
+
+    def test_get_list_of_files_to_new_directory(
+        self, fs, fs_join, fs_scenario_cp, local_fs, local_join, local_path
+    ):
+        # Copy scenario 2b
+        source = fs_scenario_cp
+
+        target = local_join(local_path, "target")
+        local_fs.mkdir(target)
+
+        source_files = [
+            fs_join(source, "file1"),
+            fs_join(source, "file2"),
+            fs_join(source, "subdir", "subfile1"),
+        ]
+
+        fs.get(source_files, local_join(target, "newdir") + "/")  # Note trailing slash
+        assert local_fs.isdir(local_join(target, "newdir"))
+        assert local_fs.isfile(local_join(target, "newdir", "file1"))
+        assert local_fs.isfile(local_join(target, "newdir", "file2"))
+        assert local_fs.isfile(local_join(target, "newdir", "subfile1"))
+
     def test_get_directory_recursive(
         self, fs, fs_join, fs_path, local_fs, local_join, local_path
     ):

--- a/fsspec/tests/abstract/put.py
+++ b/fsspec/tests/abstract/put.py
@@ -5,10 +5,10 @@ class AbstractPutTests:
         fs_join,
         fs_target,
         local_join,
-        local_scenario_cp,
+        local_bulk_operations_scenario_0,
     ):
         # Copy scenario 1a
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -42,10 +42,10 @@ class AbstractPutTests:
         assert fs.isfile(target_subfile1)
 
     def test_put_file_to_new_directory(
-        self, fs, fs_join, fs_target, local_join, local_scenario_cp
+        self, fs, fs_join, fs_target, local_join, local_bulk_operations_scenario_0
     ):
         # Copy scenario 1b
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -58,10 +58,10 @@ class AbstractPutTests:
         assert fs.isfile(fs_join(target, "newdir", "subfile1"))
 
     def test_put_file_to_file_in_existing_directory(
-        self, fs, fs_join, fs_target, local_join, local_scenario_cp
+        self, fs, fs_join, fs_target, local_join, local_bulk_operations_scenario_0
     ):
         # Copy scenario 1c
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -70,10 +70,10 @@ class AbstractPutTests:
         assert fs.isfile(fs_join(target, "newfile"))
 
     def test_put_file_to_file_in_new_directory(
-        self, fs, fs_join, fs_target, local_join, local_scenario_cp
+        self, fs, fs_join, fs_target, local_join, local_bulk_operations_scenario_0
     ):
         # Copy scenario 1d
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -86,10 +86,10 @@ class AbstractPutTests:
         assert fs.isfile(fs_join(target, "newdir", "newfile"))
 
     def test_put_directory_to_existing_directory(
-        self, fs, fs_join, fs_target, local_scenario_cp
+        self, fs, fs_join, fs_target, local_bulk_operations_scenario_0
     ):
         # Copy scenario 1e
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -148,10 +148,10 @@ class AbstractPutTests:
             assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
     def test_put_directory_to_new_directory(
-        self, fs, fs_join, fs_target, local_scenario_cp
+        self, fs, fs_join, fs_target, local_bulk_operations_scenario_0
     ):
         # Copy scenario 1f
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -197,10 +197,10 @@ class AbstractPutTests:
             assert not fs.exists(fs_join(target, "newdir"))
 
     def test_put_glob_to_existing_directory(
-        self, fs, fs_join, fs_target, local_join, local_scenario_cp
+        self, fs, fs_join, fs_target, local_join, local_bulk_operations_scenario_0
     ):
         # Copy scenario 1g
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -246,10 +246,10 @@ class AbstractPutTests:
             assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
     def test_put_glob_to_new_directory(
-        self, fs, fs_join, fs_target, local_join, local_scenario_cp
+        self, fs, fs_join, fs_target, local_join, local_bulk_operations_scenario_0
     ):
         # Copy scenario 1h
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -303,10 +303,16 @@ class AbstractPutTests:
             assert not fs.exists(fs_join(target, "newdir"))
 
     def test_put_list_of_files_to_existing_directory(
-        self, fs, fs_join, fs_target, local_join, local_scenario_cp, fs_path
+        self,
+        fs,
+        fs_join,
+        fs_target,
+        local_join,
+        local_bulk_operations_scenario_0,
+        fs_path,
     ):
         # Copy scenario 2a
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)
@@ -334,10 +340,10 @@ class AbstractPutTests:
             assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
     def test_put_list_of_files_to_new_directory(
-        self, fs, fs_join, fs_target, local_join, local_scenario_cp
+        self, fs, fs_join, fs_target, local_join, local_bulk_operations_scenario_0
     ):
         # Copy scenario 2b
-        source = local_scenario_cp
+        source = local_bulk_operations_scenario_0
 
         target = fs_target
         fs.mkdir(target)

--- a/fsspec/tests/abstract/put.py
+++ b/fsspec/tests/abstract/put.py
@@ -13,6 +13,7 @@ class AbstractPutTests:
         target = fs_join(fs_path, "target")
         fs.mkdir(target)
         if not self.supports_empty_directories():
+            # Force target directory to exist by adding a dummy file
             fs.touch(fs_join(target, "dummy"))
         assert fs.isdir(target)
 
@@ -92,6 +93,11 @@ class AbstractPutTests:
 
         target = fs_join(fs_path, "target")
         fs.mkdir(target)
+        if not self.supports_empty_directories():
+            # Force target directory to exist by adding a dummy file
+            dummy = fs_join(target, "dummy")
+            fs.touch(dummy)
+        assert fs.isdir(target)
 
         for source_slash, target_slash in zip([False, True], [False, True]):
             s = fs_join(source, "subdir")
@@ -101,7 +107,7 @@ class AbstractPutTests:
 
             # Without recursive does nothing
             fs.put(s, t)
-            assert fs.ls(target) == []
+            assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
             # With recursive
             fs.put(s, t, recursive=True)
@@ -121,7 +127,7 @@ class AbstractPutTests:
                 assert fs.isfile(fs_join(target, "subdir", "nesteddir", "nestedfile"))
 
                 fs.rm(fs_join(target, "subdir"), recursive=True)
-            assert fs.ls(target) == []
+            assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
             # Limit recursive by maxdepth
             fs.put(s, t, recursive=True, maxdepth=1)
@@ -139,7 +145,7 @@ class AbstractPutTests:
                 assert not fs.exists(fs_join(target, "subdir", "nesteddir"))
 
                 fs.rm(fs_join(target, "subdir"), recursive=True)
-            assert fs.ls(target) == []
+            assert fs.ls(target) == [] if self.supports_empty_directories() else [dummy]
 
     def test_put_directory_to_new_directory(
         self, fs, fs_join, fs_path, local_scenario_cp

--- a/fsspec/tests/abstract/put.py
+++ b/fsspec/tests/abstract/put.py
@@ -1,4 +1,333 @@
 class AbstractPutTests:
+    def test_put_file_to_existing_directory(
+        self,
+        fs,
+        fs_join,
+        fs_path,
+        local_scenario_cp,
+        local_join,
+    ):
+        # Copy scenario 1a
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+        if not self.supports_empty_directories():
+            fs.touch(fs_join(target, "dummy"))
+        assert fs.isdir(target)
+
+        target_file2 = fs_join(target, "file2")
+        target_subfile1 = fs_join(target, "subfile1")
+
+        # Copy from source directory
+        fs.put(local_join(source, "file2"), target)
+        assert fs.isfile(target_file2)
+
+        # Copy from sub directory
+        fs.put(local_join(source, "subdir", "subfile1"), target)
+        assert fs.isfile(target_subfile1)
+
+        # Remove copied files
+        fs.rm([target_file2, target_subfile1])
+        assert not fs.exists(target_file2)
+        assert not fs.exists(target_subfile1)
+
+        # Repeat with trailing slash on target
+        fs.put(local_join(source, "file2"), target + "/")
+        assert fs.isdir(target)
+        assert fs.isfile(target_file2)
+
+        fs.put(local_join(source, "subdir", "subfile1"), target + "/")
+        assert fs.isfile(target_subfile1)
+
+    def test_put_file_to_new_directory(
+        self, fs, fs_join, fs_path, local_scenario_cp, local_join
+    ):
+        # Copy scenario 1b
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+
+        fs.put(
+            local_join(source, "subdir", "subfile1"), fs_join(target, "newdir/")
+        )  # Note trailing slash
+        assert fs.isdir(target)
+        assert fs.isdir(fs_join(target, "newdir"))
+        assert fs.isfile(fs_join(target, "newdir", "subfile1"))
+
+    def test_put_file_to_file_in_existing_directory(
+        self, fs, fs_join, fs_path, local_scenario_cp, local_join
+    ):
+        # Copy scenario 1c
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+
+        fs.put(local_join(source, "subdir", "subfile1"), fs_join(target, "newfile"))
+        assert fs.isfile(fs_join(target, "newfile"))
+
+    def test_put_file_to_file_in_new_directory(
+        self, fs, fs_join, fs_path, local_scenario_cp, local_join
+    ):
+        # Copy scenario 1d
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+
+        fs.put(
+            local_join(source, "subdir", "subfile1"),
+            fs_join(target, "newdir", "newfile"),
+        )
+        assert fs.isdir(fs_join(target, "newdir"))
+        assert fs.isfile(fs_join(target, "newdir", "newfile"))
+
+    def test_put_directory_to_existing_directory(
+        self, fs, fs_join, fs_path, local_scenario_cp
+    ):
+        # Copy scenario 1e
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+
+        for source_slash, target_slash in zip([False, True], [False, True]):
+            s = fs_join(source, "subdir")
+            if source_slash:
+                s += "/"
+            t = target + "/" if target_slash else target
+
+            # Without recursive does nothing
+            fs.put(s, t)
+            assert fs.ls(target) == []
+
+            # With recursive
+            fs.put(s, t, recursive=True)
+            if source_slash:
+                assert fs.isfile(fs_join(target, "subfile1"))
+                assert fs.isfile(fs_join(target, "subfile2"))
+                assert fs.isdir(fs_join(target, "nesteddir"))
+                assert fs.isfile(fs_join(target, "nesteddir", "nestedfile"))
+                assert not fs.exists(fs_join(target, "subdir"))
+
+                fs.rm(fs.ls(target, detail=False), recursive=True)
+            else:
+                assert fs.isdir(fs_join(target, "subdir"))
+                assert fs.isfile(fs_join(target, "subdir", "subfile1"))
+                assert fs.isfile(fs_join(target, "subdir", "subfile2"))
+                assert fs.isdir(fs_join(target, "subdir", "nesteddir"))
+                assert fs.isfile(fs_join(target, "subdir", "nesteddir", "nestedfile"))
+
+                fs.rm(fs_join(target, "subdir"), recursive=True)
+            assert fs.ls(target) == []
+
+            # Limit recursive by maxdepth
+            fs.put(s, t, recursive=True, maxdepth=1)
+            if source_slash:
+                assert fs.isfile(fs_join(target, "subfile1"))
+                assert fs.isfile(fs_join(target, "subfile2"))
+                assert not fs.exists(fs_join(target, "nesteddir"))
+                assert not fs.exists(fs_join(target, "subdir"))
+
+                fs.rm(fs.ls(target, detail=False), recursive=True)
+            else:
+                assert fs.isdir(fs_join(target, "subdir"))
+                assert fs.isfile(fs_join(target, "subdir", "subfile1"))
+                assert fs.isfile(fs_join(target, "subdir", "subfile2"))
+                assert not fs.exists(fs_join(target, "subdir", "nesteddir"))
+
+                fs.rm(fs_join(target, "subdir"), recursive=True)
+            assert fs.ls(target) == []
+
+    def test_put_directory_to_new_directory(
+        self, fs, fs_join, fs_path, local_scenario_cp
+    ):
+        # Copy scenario 1f
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+
+        for source_slash, target_slash in zip([False, True], [False, True]):
+            s = fs_join(source, "subdir")
+            if source_slash:
+                s += "/"
+            t = fs_join(target, "newdir")
+            if target_slash:
+                t += "/"
+
+            # Without recursive does nothing
+            fs.put(s, t)
+            assert fs.ls(target) == []
+
+            # With recursive
+            fs.put(s, t, recursive=True)
+            assert fs.isdir(fs_join(target, "newdir"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile1"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile2"))
+            assert fs.isdir(fs_join(target, "newdir", "nesteddir"))
+            assert fs.isfile(fs_join(target, "newdir", "nesteddir", "nestedfile"))
+            assert not fs.exists(fs_join(target, "subdir"))
+
+            fs.rm(fs_join(target, "newdir"), recursive=True)
+            assert fs.ls(target) == []
+
+            # Limit recursive by maxdepth
+            fs.put(s, t, recursive=True, maxdepth=1)
+            assert fs.isdir(fs_join(target, "newdir"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile1"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile2"))
+            assert not fs.exists(fs_join(target, "newdir", "nesteddir"))
+            assert not fs.exists(fs_join(target, "subdir"))
+
+            fs.rm(fs_join(target, "newdir"), recursive=True)
+            assert fs.ls(target) == []
+
+    def test_put_glob_to_existing_directory(
+        self, fs, fs_join, fs_path, local_scenario_cp, local_join
+    ):
+        # Copy scenario 1g
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+
+        for target_slash in [False, True]:
+            t = target + "/" if target_slash else target
+
+            # Without recursive
+            fs.put(local_join(source, "subdir", "*"), t)
+            assert fs.isfile(fs_join(target, "subfile1"))
+            assert fs.isfile(fs_join(target, "subfile2"))
+            assert not fs.isdir(fs_join(target, "nesteddir"))
+            assert not fs.exists(fs_join(target, "nesteddir", "nestedfile"))
+            assert not fs.exists(fs_join(target, "subdir"))
+
+            fs.rm(fs.ls(target, detail=False), recursive=True)
+            assert fs.ls(target) == []
+
+            # With recursive
+            fs.put(local_join(source, "subdir", "*"), t, recursive=True)
+            assert fs.isfile(fs_join(target, "subfile1"))
+            assert fs.isfile(fs_join(target, "subfile2"))
+            assert fs.isdir(fs_join(target, "nesteddir"))
+            assert fs.isfile(fs_join(target, "nesteddir", "nestedfile"))
+            assert not fs.exists(fs_join(target, "subdir"))
+
+            fs.rm(fs.ls(target, detail=False), recursive=True)
+            assert fs.ls(target) == []
+
+            # Limit recursive by maxdepth
+            fs.put(local_join(source, "subdir", "*"), t, recursive=True, maxdepth=1)
+            assert fs.isfile(fs_join(target, "subfile1"))
+            assert fs.isfile(fs_join(target, "subfile2"))
+            assert not fs.exists(fs_join(target, "nesteddir"))
+            assert not fs.exists(fs_join(target, "subdir"))
+
+            fs.rm(fs.ls(target, detail=False), recursive=True)
+            assert fs.ls(target) == []
+
+    def test_put_glob_to_new_directory(
+        self, fs, fs_join, fs_path, local_scenario_cp, local_join
+    ):
+        # Copy scenario 1h
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+
+        for target_slash in [False, True]:
+            t = fs_join(target, "newdir")
+            if target_slash:
+                t += "/"
+
+            # Without recursive
+            fs.put(local_join(source, "subdir", "*"), t)
+            assert fs.isdir(fs_join(target, "newdir"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile1"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile2"))
+            assert not fs.exists(fs_join(target, "newdir", "nesteddir"))
+            assert not fs.exists(fs_join(target, "newdir", "nesteddir", "nestedfile"))
+            assert not fs.exists(fs_join(target, "subdir"))
+            assert not fs.exists(fs_join(target, "newdir", "subdir"))
+
+            fs.rm(fs_join(target, "newdir"), recursive=True)
+            assert fs.ls(target) == []
+
+            # With recursive
+            fs.put(local_join(source, "subdir", "*"), t, recursive=True)
+            assert fs.isdir(fs_join(target, "newdir"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile1"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile2"))
+            assert fs.isdir(fs_join(target, "newdir", "nesteddir"))
+            assert fs.isfile(fs_join(target, "newdir", "nesteddir", "nestedfile"))
+            assert not fs.exists(fs_join(target, "subdir"))
+            assert not fs.exists(fs_join(target, "newdir", "subdir"))
+
+            fs.rm(fs_join(target, "newdir"), recursive=True)
+            assert fs.ls(target) == []
+
+            # Limit recursive by maxdepth
+            fs.put(local_join(source, "subdir", "*"), t, recursive=True, maxdepth=1)
+            assert fs.isdir(fs_join(target, "newdir"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile1"))
+            assert fs.isfile(fs_join(target, "newdir", "subfile2"))
+            assert not fs.exists(fs_join(target, "newdir", "nesteddir"))
+            assert not fs.exists(fs_join(target, "subdir"))
+            assert not fs.exists(fs_join(target, "newdir", "subdir"))
+
+            fs.rm(fs.ls(target, detail=False), recursive=True)
+            assert fs.ls(target) == []
+
+    def test_put_list_of_files_to_existing_directory(
+        self, fs, fs_join, fs_path, local_scenario_cp, local_join
+    ):
+        # Copy scenario 2a
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+
+        source_files = [
+            local_join(source, "file1"),
+            local_join(source, "file2"),
+            local_join(source, "subdir", "subfile1"),
+        ]
+
+        for target_slash in [False, True]:
+            t = target + "/" if target_slash else target
+
+            fs.put(source_files, t)
+            assert fs.isfile(fs_join(target, "file1"))
+            assert fs.isfile(fs_join(target, "file2"))
+            assert fs.isfile(fs_join(target, "subfile1"))
+
+            fs.rm(fs.find(target))
+            assert fs.ls(target) == []
+
+    def test_put_list_of_files_to_new_directory(
+        self, fs, fs_join, fs_path, local_scenario_cp, local_join
+    ):
+        # Copy scenario 2b
+        source = local_scenario_cp
+
+        target = fs_join(fs_path, "target")
+        fs.mkdir(target)
+
+        source_files = [
+            local_join(source, "file1"),
+            local_join(source, "file2"),
+            local_join(source, "subdir", "subfile1"),
+        ]
+
+        fs.put(source_files, fs_join(target, "newdir") + "/")  # Note trailing slash
+        assert fs.isdir(fs_join(target, "newdir"))
+        assert fs.isfile(fs_join(target, "newdir", "file1"))
+        assert fs.isfile(fs_join(target, "newdir", "file2"))
+        assert fs.isfile(fs_join(target, "newdir", "subfile1"))
+
     def test_put_directory_recursive(
         self, fs, fs_join, fs_path, local_fs, local_join, local_path
     ):


### PR DESCRIPTION
This adds a full set of `AbstractGetTests` and `AbstractPutTests` that are equivalent to the existing `AbstractCopyTests`, and ports the recent changes from synchronous copy/get/put code (#1250, #1254, #1255, #1259) to async. This completes the top 10 most common cp/get/put use cases documented by #713.

The abstract test suite all passes locally for me using `local` and `memory` filesystems (the latter skips 4 tests, see below) and also `s3fs` (using the branch that is fsspec/s3fs#713).

Noteworthy implementation details:

- Filesystem scope for tests is per test class, so there is one setup-and-teardown combination for each of the `AbstractCopyTests`, `AbstractGetTests` and `AbstractPutTests`. This doesn't make any real difference for `local` and `memory` tests, but makes the `s3fs` tests much faster than individual test scope. The scope could be made once per test session, but that would involve a bit of a refactor so is not planned yet.
- Setting up the `source` and `target` directories for these tests uses fixtures that automatically clean up after themselves at the end of each test, ensuring that the filesystem is empty ready for the next test.

Work to do in future PRs soon:

- Four of the `memory` `get` tests are skipped as currently there is a bespoke code path that does not auto create a local directory when required. Needs a fix to `MemoryFileSystem`.
- I haven't fully dealt with all combinations of trailing slashes on `source` and `target` directories yet.
- `gcsfs` doesn't pass all the new tests yet.

I propose the following order of operations:

1. Review and merge this when CI happy.
2. I'll update fsspec/s3fs#713 to check that `s3fs` is happy with the new changes, then review and merge of that PR.
3. A new release of `fsspec` is advisable then, as one of my recent PRs broke `async` `get` in some situations and this is fixed in this PR.
4. I'll fix the above 3 "future PRs" issues.

Longer term there are other improvements that are not urgent:

1. Cover some of the less-common `cp/get/put` use cases.
2. Test more of implementations that ship in `fsspec`.
3. Document how to use the abstract test harness in downstream projects.
5. Move tests from original test scripts to the new abstract test classes.