### PR TITLE
Setup a minimal mypy config

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,6 +68,22 @@ jobs:
       - uses: actions/setup-python@main
       - uses: pre-commit/action@main
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup conda
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: ci/environment-typecheck.yml
+
+      - name: mypy
+        shell: bash -l {0}
+        run: |
+          mypy fsspec
+
   downstream:
     name: downstream
     runs-on: ubuntu-latest

--- a/ci/environment-typecheck.yml
+++ b/ci/environment-typecheck.yml
@@ -1,0 +1,13 @@
+name: test_env
+channels:
+  - conda-forge
+dependencies:
+  - mypy=1.3
+  - pyarrow
+  - python=3.8
+  - pip
+  - pip:
+    - types-paramiko
+    - types-requests
+    - types-tqdm
+    - types-ujson

--- a/fsspec/_version.py
+++ b/fsspec/_version.py
@@ -51,7 +51,6 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY = {}
 HANDLERS = {}
 
 

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -9,7 +9,7 @@ import re
 import threading
 from contextlib import contextmanager
 from glob import has_magic
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 from .callbacks import _DEFAULT_CALLBACK
 from .exceptions import FSTimeoutError
@@ -154,13 +154,18 @@ def get_loop():
     return loop[0]
 
 
-try:
+if TYPE_CHECKING:
     import resource
-except ImportError:
-    resource = None
-    ResourceError = OSError
+
+    ResourceError = resource.error
 else:
-    ResourceError = getattr(resource, "error", IOError)
+    try:
+        import resource
+    except ImportError:
+        resource = None
+        ResourceError = OSError
+    else:
+        ResourceError = getattr(resource, "error", IOError)
 
 _DEFAULT_BATCH_SIZE = 128
 _NOFILES_DEFAULT_BATCH_SIZE = 1280

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -2,8 +2,9 @@ import configparser
 import json
 import os
 import warnings
+from typing import Any, Dict
 
-conf = {}
+conf: Dict[str, Dict[str, Any]] = {}
 default_conf_dir = os.path.join(os.path.expanduser("~"), ".config/fsspec")
 conf_dir = os.environ.get("FSSPEC_CONFIG_DIR", default_conf_dir)
 

--- a/fsspec/config.py
+++ b/fsspec/config.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import configparser
 import json
 import os
 import warnings
-from typing import Any, Dict
+from typing import Any
 
-conf: Dict[str, Dict[str, Any]] = {}
+conf: dict[str, dict[str, Any]] = {}
 default_conf_dir = os.path.join(os.path.expanduser("~"), ".config/fsspec")
 conf_dir = os.environ.get("FSSPEC_CONFIG_DIR", default_conf_dir)
 

--- a/fsspec/gui.py
+++ b/fsspec/gui.py
@@ -3,6 +3,7 @@ import contextlib
 import logging
 import os
 import re
+from typing import ClassVar, Sequence
 
 import panel as pn
 
@@ -25,9 +26,11 @@ class SigSlot(object):
     By default, all signals emit a DEBUG logging statement.
     """
 
-    signals = []  # names of signals that this class may emit
-    # each of which must be set by _register for any new instance
-    slots = []  # names of actions that this class may respond to
+    # names of signals that this class may emit each of which must be
+    # set by _register for any new instance
+    signals: ClassVar[Sequence[str]] = []
+    # names of actions that this class may respond to
+    slots: ClassVar[Sequence[str]] = []
 
     # each of which must be a method name
 

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import hashlib
 import inspect
@@ -7,7 +9,7 @@ import pickle
 import tempfile
 import time
 from shutil import rmtree
-from typing import ClassVar, Tuple, Union
+from typing import ClassVar
 
 from fsspec import AbstractFileSystem, filesystem
 from fsspec.callbacks import _DEFAULT_CALLBACK
@@ -40,7 +42,7 @@ class CachingFileSystem(AbstractFileSystem):
       allowed, for testing
     """
 
-    protocol: ClassVar[Union[str, Tuple[str, ...]]] = ("blockcache", "cached")
+    protocol: ClassVar[str | tuple[str, ...]] = ("blockcache", "cached")
 
     def __init__(
         self,

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -7,6 +7,7 @@ import pickle
 import tempfile
 import time
 from shutil import rmtree
+from typing import ClassVar, Tuple, Union
 
 from fsspec import AbstractFileSystem, filesystem
 from fsspec.callbacks import _DEFAULT_CALLBACK
@@ -39,7 +40,7 @@ class CachingFileSystem(AbstractFileSystem):
       allowed, for testing
     """
 
-    protocol = ("blockcache", "cached")
+    protocol: ClassVar[Union[str, Tuple[str, ...]]] = ("blockcache", "cached")
 
     def __init__(
         self,

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -1,10 +1,10 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, annotations, division, print_function
 
 import logging
 from datetime import datetime
 from errno import ENOTEMPTY
 from io import BytesIO
-from typing import Any, ClassVar, Dict
+from typing import Any, ClassVar
 
 from fsspec import AbstractFileSystem
 
@@ -18,7 +18,7 @@ class MemoryFileSystem(AbstractFileSystem):
     in memory filesystem.
     """
 
-    store: ClassVar[Dict[str, Any]] = {}  # global, do not overwrite!
+    store: ClassVar[dict[str, Any]] = {}  # global, do not overwrite!
     pseudo_dirs = [""]  # global, do not overwrite!
     protocol = "memory"
     root_marker = "/"

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 from errno import ENOTEMPTY
 from io import BytesIO
+from typing import Any, ClassVar, Dict
 
 from fsspec import AbstractFileSystem
 
@@ -17,7 +18,7 @@ class MemoryFileSystem(AbstractFileSystem):
     in memory filesystem.
     """
 
-    store = {}  # global, do not overwrite!
+    store: ClassVar[Dict[str, Any]] = {}  # global, do not overwrite!
     pseudo_dirs = [""]  # global, do not overwrite!
     protocol = "memory"
     root_marker = "/"

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -6,13 +6,15 @@ import logging
 import math
 import os
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
 import fsspec.core
 
 try:
     import ujson as json
 except ImportError:
-    import json
+    if not TYPE_CHECKING:
+        import json
 
 from ..asyn import AsyncFileSystem
 from ..callbacks import _DEFAULT_CALLBACK
@@ -803,11 +805,11 @@ class ReferenceFileSystem(AsyncFileSystem):
                     urls.append(u)
                     starts.append(s)
                     ends.append(e)
-                except FileNotFoundError as e:
+                except FileNotFoundError as err:
                     if on_error == "raise":
                         raise
                     if on_error != "omit":
-                        out[p] = e
+                        out[p] = err
 
             # process references into form for merging
             urls2 = []
@@ -924,7 +926,6 @@ class ReferenceFileSystem(AsyncFileSystem):
         self.references.update(self._process_gen(references.get("gen", [])))
 
     def _process_templates(self, tmp):
-
         self.templates = {}
         if self.template_overrides is not None:
             tmp.update(self.template_overrides)
@@ -939,7 +940,6 @@ class ReferenceFileSystem(AsyncFileSystem):
                 self.templates[k] = v
 
     def _process_gen(self, gens):
-
         out = {}
         for gen in gens:
             dimension = {

--- a/fsspec/implementations/tar.py
+++ b/fsspec/implementations/tar.py
@@ -81,7 +81,7 @@ class TarFileSystem(AbstractArchiveFileSystem):
 
         self._fo_ref = fo
         self.fo = fo  # the whole instance is a context
-        self.tar: tarfile.TarFile = tarfile.TarFile(fileobj=self.fo)
+        self.tar = tarfile.TarFile(fileobj=self.fo)
         self.dir_cache = None
 
         self.index_store = index_store

--- a/fsspec/implementations/tests/test_tar.py
+++ b/fsspec/implementations/tests/test_tar.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import os
 import shutil
 import tarfile
 import tempfile
 from io import BytesIO
 from pathlib import Path
-from typing import Dict
 
 import pytest
 
@@ -210,7 +211,7 @@ def test_ls_with_folders(compression: str, tmp_path: Path):
     but make sure that the reading filesystem is still able to resolve the
     intermediate folders, like the ZipFileSystem.
     """
-    tar_data: Dict[str, bytes] = {
+    tar_data: dict[str, bytes] = {
         "a.pdf": b"Hello A!",
         "b/c.pdf": b"Hello C!",
         "d/e/f.pdf": b"Hello F!",

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import importlib
 import types
 import warnings
-from typing import Dict, Type
 
 __all__ = ["registry", "get_filesystem_class", "default"]
 
 # internal, mutable
-_registry: Dict[str, Type] = {}
+_registry: dict[str, type] = {}
 
 # external, immutable
 registry = types.MappingProxyType(_registry)

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -1,11 +1,12 @@
 import importlib
 import types
 import warnings
+from typing import Dict, Type
 
 __all__ = ["registry", "get_filesystem_class", "default"]
 
 # internal, mutable
-_registry = {}
+_registry: Dict[str, Type] = {}
 
 # external, immutable
 registry = types.MappingProxyType(_registry)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -7,6 +7,7 @@ import weakref
 from errno import ESPIPE
 from glob import has_magic
 from hashlib import sha256
+from typing import ClassVar, Tuple, Union
 
 from .callbacks import _DEFAULT_CALLBACK
 from .config import apply_config, conf
@@ -101,7 +102,7 @@ class AbstractFileSystem(metaclass=_Cached):
     _cached = False
     blocksize = 2**22
     sep = "/"
-    protocol = "abstract"
+    protocol: ClassVar[Union[str, Tuple[str, ...]]] = "abstract"
     _latest = None
     async_impl = False
     mirror_sync_methods = False

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import logging
 import os
@@ -7,7 +9,7 @@ import weakref
 from errno import ESPIPE
 from glob import has_magic
 from hashlib import sha256
-from typing import ClassVar, Tuple, Union
+from typing import ClassVar
 
 from .callbacks import _DEFAULT_CALLBACK
 from .config import apply_config, conf
@@ -102,7 +104,7 @@ class AbstractFileSystem(metaclass=_Cached):
     _cached = False
     blocksize = 2**22
     sep = "/"
-    protocol: ClassVar[Union[str, Tuple[str, ...]]] = "abstract"
+    protocol: ClassVar[str | tuple[str, ...]] = "abstract"
     _latest = None
     async_impl = False
     mirror_sync_methods = False

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import math
 import os
@@ -8,7 +10,6 @@ from contextlib import contextmanager
 from functools import partial
 from hashlib import md5
 from importlib.metadata import version
-from typing import Dict
 from urllib.parse import urlsplit
 
 DEFAULT_BLOCK_SIZE = 5 * 2**20
@@ -111,7 +112,7 @@ def update_storage_options(options, inherited=None):
 
 
 # Compression extensions registered via fsspec.compression.register_compression
-compressions: Dict[str, str] = {}
+compressions: dict[str, str] = {}
 
 
 def infer_compression(filename):

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from functools import partial
 from hashlib import md5
 from importlib.metadata import version
+from typing import Dict
 from urllib.parse import urlsplit
 
 DEFAULT_BLOCK_SIZE = 5 * 2**20
@@ -110,7 +111,7 @@ def update_storage_options(options, inherited=None):
 
 
 # Compression extensions registered via fsspec.compression.register_compression
-compressions = {}
+compressions: Dict[str, str] = {}
 
 
 def infer_compression(filename):

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,18 @@ skip=
     docs/source/conf.py
     versioneer.py
     fsspec/_version
+
+[mypy]
+follow_imports = normal
+ignore_missing_imports = True
+enable_error_code = ignore-without-code,truthy-bool,truthy-iterable,unused-awaitable
+
+disallow_untyped_decorators = True
+strict_equality = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True
+
+
+# don't bother type-checking test_*.py or conftest.py files
+exclude = (test_.*|conftest)\.py$


### PR DESCRIPTION
This is a first step to https://github.com/fsspec/filesystem_spec/issues/625: we setups a new CI step with `mypy` and do the minimal amount of work to get it passing.

Note that by default `mypy` does not type-check any function that doesn't already have type annotations in the function signature, so for now this isn't really type-checking any function internals. Still, I think having the CI setup will be a good first step.