### PR TITLE
Change local rm to throw an expressive error

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -164,8 +164,10 @@ class LocalFileSystem(AbstractFileSystem):
 
         for p in path:
             p = self._strip_protocol(p).rstrip("/")
-            if recursive and self.isdir(p):
-
+            if self.isdir(p):
+                if not recursive:
+                    raise ValueError(
+                        "Cannot delete directory, set recursive=True")
                 if osp.abspath(p) == os.getcwd():
                     raise ValueError("Cannot delete current working directory")
                 shutil.rmtree(p)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -166,8 +166,7 @@ class LocalFileSystem(AbstractFileSystem):
             p = self._strip_protocol(p).rstrip("/")
             if self.isdir(p):
                 if not recursive:
-                    raise ValueError(
-                        "Cannot delete directory, set recursive=True")
+                    raise ValueError("Cannot delete directory, set recursive=True")
                 if osp.abspath(p) == os.getcwd():
                     raise ValueError("Cannot delete current working directory")
                 shutil.rmtree(p)

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -751,6 +751,15 @@ def test_delete_cwd(tmpdir):
         os.chdir(cwd)
 
 
+def test_delete_non_recursive_dir_fails(tmpdir):
+    fs = LocalFileSystem()
+    subdir = os.path.join(tmpdir, "testdir")
+    fs.mkdir(subdir)
+    with pytest.raises(ValueError):
+        fs.rm(subdir)
+    fs.rm(subdir, recursive=True)
+
+
 @pytest.mark.parametrize(
     "opener, ext", [(bz2.open, ".bz2"), (gzip.open, ".gz"), (open, "")]
 )


### PR DESCRIPTION
Inform the user when he forgets to add a "recursive" flag to directory path removal.