### PR TITLE
IOError → OSError

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -165,7 +165,7 @@ else:
         resource = None
         ResourceError = OSError
     else:
-        ResourceError = getattr(resource, "error", IOError)
+        ResourceError = getattr(resource, "error", OSError)
 
 _DEFAULT_BATCH_SIZE = 128
 _NOFILES_DEFAULT_BATCH_SIZE = 1280
@@ -614,7 +614,7 @@ class AsyncFileSystem(AbstractFileSystem):
     async def _isdir(self, path):
         try:
             return (await self._info(path))["type"] == "directory"
-        except IOError:
+        except OSError:
             return False
 
     async def _size(self, path):
@@ -651,7 +651,7 @@ class AsyncFileSystem(AbstractFileSystem):
         detail = kwargs.pop("detail", False)
         try:
             listing = await self._ls(path, detail=True, **kwargs)
-        except (FileNotFoundError, IOError):
+        except (FileNotFoundError, OSError):
             if detail:
                 yield path, {}, {}
             else:

--- a/fsspec/fuse.py
+++ b/fsspec/fuse.py
@@ -119,7 +119,7 @@ class FUSEr(Operations):
         fn = "".join([self.root, path.lstrip("/")])
         try:
             self.fs.rm(fn, False)
-        except (IOError, FileNotFoundError):
+        except (OSError, FileNotFoundError):
             raise FuseOSError(EIO)
 
     def release(self, path, fh):

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -401,7 +401,7 @@ class CachingFileSystem(AbstractFileSystem):
             logger.debug("going to save")
             self.save_cache()
             logger.debug("saved")
-        except (IOError, OSError):
+        except OSError:
             logger.debug("Cache saving failed while closing file")
         except NameError:
             logger.debug("Cache save failed due to interpreter shutdown")

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -108,7 +108,7 @@ class LocalFileSystem(AbstractFileSystem):
             try:
                 out2 = os.stat(path, follow_symlinks=True)
                 result["size"] = out2.st_size
-            except IOError:
+            except OSError:
                 result["size"] = 0
         return result
 

--- a/fsspec/implementations/tests/test_archive.py
+++ b/fsspec/implementations/tests/test_archive.py
@@ -32,7 +32,7 @@ def tempzip(data=None):
     finally:
         try:
             os.remove(f)
-        except (IOError, OSError):
+        except OSError:
             pass
 
 
@@ -52,7 +52,7 @@ def temparchive(data=None):
     finally:
         try:
             os.remove(f)
-        except (IOError, OSError):
+        except OSError:
             pass
 
 
@@ -87,7 +87,7 @@ def temptar(data=None, mode="w", suffix=".tar"):
     finally:
         try:
             os.remove(fn)
-        except (IOError, OSError):
+        except OSError:
             pass
 
 
@@ -110,7 +110,7 @@ def temptargz(data=None, mode="w", suffix=".tar.gz"):
         finally:
             try:
                 os.remove(fn)
-            except (IOError, OSError):
+            except OSError:
                 pass
 
 
@@ -133,7 +133,7 @@ def temptarbz2(data=None, mode="w", suffix=".tar.bz2"):
         finally:
             try:
                 os.remove(fn)
-            except (IOError, OSError):
+            except OSError:
                 pass
 
 
@@ -156,7 +156,7 @@ def temptarxz(data=None, mode="w", suffix=".tar.xz"):
         finally:
             try:
                 os.remove(fn)
-            except (IOError, OSError):
+            except OSError:
                 pass
 
 

--- a/fsspec/implementations/tests/test_arrow.py
+++ b/fsspec/implementations/tests/test_arrow.py
@@ -239,5 +239,5 @@ def test_seekable(fs, remote_dir):
             assert file.read() == data
 
     with fs.open(remote_dir + "/a.txt", "rb", seekable=False) as file:
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             file.seek(5)

--- a/fsspec/implementations/tests/test_jupyter.py
+++ b/fsspec/implementations/tests/test_jupyter.py
@@ -28,7 +28,7 @@ def jupyter(tmpdir):
                 r = requests.get("http://localhost:5566/?token=blah")
                 r.raise_for_status()
                 break
-            except (requests.exceptions.BaseHTTPError, IOError):
+            except (requests.exceptions.BaseHTTPError, OSError):
                 time.sleep(0.1)
                 timeout -= 0.1
                 if timeout < 0:

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -73,7 +73,7 @@ def filetexts(d, open=open, mode="t"):
             if os.path.exists(filename):
                 try:
                     os.remove(filename)
-                except (IOError, OSError):
+                except OSError:
                     pass
     finally:
         os.chdir(odir)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -412,7 +412,7 @@ class AbstractFileSystem(metaclass=_Cached):
         detail = kwargs.pop("detail", False)
         try:
             listing = self.ls(path, detail=True, **kwargs)
-        except (FileNotFoundError, IOError):
+        except (FileNotFoundError, OSError):
             if detail:
                 return path, {}, {}
             return path, [], []
@@ -687,7 +687,7 @@ class AbstractFileSystem(metaclass=_Cached):
         """Is this entry directory-like?"""
         try:
             return self.info(path)["type"] == "directory"
-        except IOError:
+        except OSError:
             return False
 
     def isfile(self, path):

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -29,7 +29,7 @@ def tempzip(data={}):
     finally:
         try:
             os.remove(f)
-        except (IOError, OSError):
+        except OSError:
             pass
 
 


### PR DESCRIPTION
Starting from Python 3.3, `IOError` is an alias of `OSError`:
https://docs.python.org/3/library/exceptions.html#IOError