### PR TITLE
bugfix: await on size, assuming it can be an async function

### DIFF
--- a/fsspec/generic.py
+++ b/fsspec/generic.py
@@ -280,9 +280,12 @@ class GenericFileSystem(AsyncFileSystem):
                 if hasattr(fs2, "open_async")
                 else fs2.open(url2, "wb", **kw)
             )
-            while f1.size is None or f2.tell() < f1.size:
+            while (
+                await maybe_await(f1.size) is None 
+                or f2.tell() < await maybe_await(f1.size)
+            ):
                 data = await maybe_await(f1.read(blocksize))
-                if f1.size is None and not data:
+                if await maybe_await(f1.size) is None and not data:
                     break
                 await maybe_await(f2.write(data))
                 callback.absolute_update(f2.tell())


### PR DESCRIPTION
Checking `size` may require a call to the async `_info` function. On line 277, `_cp_file` checks if `f1.size` is async (`callback.set_size(await maybe_await(f1.size))`), but then later it simply references `f1.size` which fails if this function is async. As such, this PR corrects the code to ensure `f1.size` references are wrapped in `await maybe_await()`.