### PR TITLE
Create parent directories in get_file

### DIFF
--- a/fsspec/implementations/tests/memory/memory_test.py
+++ b/fsspec/implementations/tests/memory/memory_test.py
@@ -1,5 +1,3 @@
-import pytest
-
 import fsspec.tests.abstract as abstract
 from fsspec.implementations.tests.memory.memory_fixtures import MemoryFixtures
 
@@ -9,21 +7,7 @@ class TestMemoryCopy(abstract.AbstractCopyTests, MemoryFixtures):
 
 
 class TestMemoryGet(abstract.AbstractGetTests, MemoryFixtures):
-    @pytest.mark.skip(reason="Bug: does not auto-create new directory")
-    def test_get_file_to_new_directory(self):
-        pass
-
-    @pytest.mark.skip(reason="Bug: does not auto-create new directory")
-    def test_get_file_to_file_in_new_directory(self):
-        pass
-
-    @pytest.mark.skip(reason="Bug: does not auto-create new directory")
-    def test_get_glob_to_new_directory(self):
-        pass
-
-    @pytest.mark.skip(reason="Bug: does not auto-create new directory")
-    def test_get_list_of_files_to_new_directory(self):
-        pass
+    pass
 
 
 class TestMemoryPut(abstract.AbstractPutTests, MemoryFixtures):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -867,6 +867,8 @@ class AbstractFileSystem(metaclass=_Cached):
             os.makedirs(lpath, exist_ok=True)
             return None
 
+        os.makedirs(self._parent(lpath), exist_ok=True)
+
         with self.open(rpath, "rb", **kwargs) as f1:
             if outfile is None:
                 outfile = open(lpath, "wb")

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -861,13 +861,15 @@ class AbstractFileSystem(metaclass=_Cached):
         self, rpath, lpath, callback=_DEFAULT_CALLBACK, outfile=None, **kwargs
     ):
         """Copy single remote file to local"""
+        from .implementations.local import LocalFileSystem
+
         if isfilelike(lpath):
             outfile = lpath
         elif self.isdir(rpath):
             os.makedirs(lpath, exist_ok=True)
             return None
 
-        os.makedirs(self._parent(lpath), exist_ok=True)
+        LocalFileSystem(auto_mkdir=True).makedirs(self._parent(lpath), exist_ok=True)
 
         with self.open(rpath, "rb", **kwargs) as f1:
             if outfile is None:


### PR DESCRIPTION
This is a fix when calling `get` with a file to get it into a new (i.e. doesn't exist yet) directory we need to create the parent directory to put the file in. The issue was discovered as part of the new `cp/get/put` test harness (https://github.com/fsspec/filesystem_spec/pull/1267). With this fix all `memory` filesystem tests pass whereas before this the 4 "get file/directory/glob into a new directory" tests all failed as the parent directory wasn't auto created.