### PR TITLE
bugfix: Strip file protocol when calling LocalFileSystem.rm_file

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -156,7 +156,7 @@ class LocalFileSystem(AbstractFileSystem):
         return os.path.islink(self._strip_protocol(path))
 
     def rm_file(self, path):
-        os.remove(path)
+        os.remove(self._strip_protocol(path))
 
     def rm(self, path, recursive=False, maxdepth=None):
         if not isinstance(path, list):


### PR DESCRIPTION
These changes fix calling `LocalFileSystem.rm_file(self, path)` with paths prefixed with `file://` protocol. The issue with the original code is that it does not call `LocalFileSystem._strip_protocol(self, path)` before passing the path to `os.remove(path)`.