### PR TITLE
Add encoding support for FTPFileSystem.

### DIFF
--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -24,7 +24,7 @@ class FTPFileSystem(AbstractFileSystem):
         block_size=None,
         tempdir=None,
         timeout=30,
-        encoding='utf-8',
+        encoding="utf-8",
         **kwargs,
     ):
         """

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -24,6 +24,7 @@ class FTPFileSystem(AbstractFileSystem):
         block_size=None,
         tempdir=None,
         timeout=30,
+        encoding='utf-8',
         **kwargs,
     ):
         """
@@ -51,6 +52,8 @@ class FTPFileSystem(AbstractFileSystem):
             Directory on remote to put temporary files when in a transaction
         timeout: int
             Timeout of the ftp connection in seconds
+        encoding: str
+            Encoding to use for file names in FTP connection
         """
         super(FTPFileSystem, self).__init__(**kwargs)
         self.host = host
@@ -58,6 +61,7 @@ class FTPFileSystem(AbstractFileSystem):
         self.tempdir = tempdir or "/tmp"
         self.cred = username, password, acct
         self.timeout = timeout
+        self.encoding = encoding
         if block_size is not None:
             self.blocksize = block_size
         else:
@@ -66,6 +70,7 @@ class FTPFileSystem(AbstractFileSystem):
 
     def _connect(self):
         self.ftp = FTP(timeout=self.timeout)
+        self.ftp.encoding = self.encoding
         self.ftp.connect(self.host, self.port)
         self.ftp.login(*self.cred)
 


### PR DESCRIPTION
I have an error when connect to a FTP server which use `gbk` as codepage.

Usage:
```
>>> ftp = fsspec.filesystem(protocol='ftp', host='10.20.30.40', port=21, username='xxx', password='yyy')
```

Error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\ProgramData\Anaconda3\envs\exp\lib\site-packages\fsspec\registry.py", line 261, in filesystem
  File "D:\ProgramData\Anaconda3\envs\exp\lib\site-packages\fsspec\spec.py", line 76, in __call__
    obj = super().__call__(*args, **kwargs)
  File "D:\ProgramData\Anaconda3\envs\exp\lib\site-packages\fsspec\implementations\ftp.py", line 65, in __init__
    self._connect()
  File "D:\ProgramData\Anaconda3\envs\exp\lib\site-packages\fsspec\implementations\ftp.py", line 69, in _connect
    self.ftp.connect(self.host, self.port)
  File "D:\ProgramData\Anaconda3\envs\exp\lib\ftplib.py", line 162, in connect
    self.welcome = self.getresp()
  File "D:\ProgramData\Anaconda3\envs\exp\lib\ftplib.py", line 244, in getresp
    resp = self.getmultiline()
  File "D:\ProgramData\Anaconda3\envs\exp\lib\ftplib.py", line 230, in getmultiline
    line = self.getline()
  File "D:\ProgramData\Anaconda3\envs\exp\lib\ftplib.py", line 212, in getline
    line = self.file.readline(self.maxline + 1)
  File "D:\ProgramData\Anaconda3\envs\exp\lib\codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbb in position 14: invalid start byte
```

I think this PR could fix it.