### PR TITLE
Fix conditional for async file systems

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -305,7 +305,7 @@ class AsyncFileSystem(AbstractFileSystem):
     def __init__(self, *args, asynchronous=False, loop=None, batch_size=None, **kwargs):
         self.asynchronous = asynchronous
         self._pid = os.getpid()
-        if not asynchronous:
+        if asynchronous:
             self._loop = loop or get_loop()
         else:
             self._loop = None


### PR DESCRIPTION
We were noticing the following error when working with the async version of `gcsfs`:

https://github.com/fsspec/filesystem_spec/blob/f511ed2d79e2222fa002a16c5681d2864cf71c3d/fsspec/asyn.py#L80-L81

We believe that's because the `loop` attribute is always set to `None` when `asynchronous=True`. We assume that's a bug and that it should be the other way around.

If you agree, we would appreciate a patch release. 🙏 
