### PR TITLE
Correct install GCS example in docs

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -5,4 +5,4 @@ skip = *.css*,.git,build
 # cachable - historically happened
 # falsy - too cute although used only once and could be made strict bool
 # doas - used as argument to some call in WebHDFS
-ignore-words-list = fo,dne,fro,hel,cachable,falsy,doas
+ignore-words-list = fo,dne,fro,hel,cachable,falsy,doas,afile

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,7 +80,7 @@ Installation
    conda install -c conda-forge fsspec
 
 Not all filesystem implementations are available without installing extra
-dependencies. For example to be able to access data in S3, you can use the optional
+dependencies. For example to be able to access data in GCS, you can use the optional
 pip install syntax below, or install the specific package required
 
 .. code-block:: sh


### PR DESCRIPTION
Fixes #936.

Minor docs change to correct the words about installing extra dependencies to match the example code.