### PR TITLE
Make support for bz2 compression optional

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -1,5 +1,4 @@
 """Helper functions for a standard streaming compression API"""
-from bz2 import BZ2File
 from zipfile import ZipFile
 
 import fsspec.utils
@@ -68,7 +67,13 @@ def unzip(infile, mode="rb", filename=None, **kwargs):
 
 
 register_compression("zip", unzip, "zip")
-register_compression("bz2", BZ2File, "bz2")
+
+try:
+    from bz2 import BZ2File
+except ImportError:
+    pass
+else:
+    register_compression("bz2", BZ2File, "bz2")
 
 try:  # pragma: no cover
     from isal import igzip


### PR DESCRIPTION
Python may be compiled without bz2 support, in which case import of the standard library module fails with a traceback like:

        …/lib/python3.7/site-packages/fsspec/__init__.py:12: in <module>
            from .compression import available_compressions
        …/lib/python3.7/site-packages/fsspec/compression.py:2: in <module>
            from bz2 import BZ2File
        …/lib/python3.7/bz2.py:19: in <module>
            from _bz2 import BZ2Compressor, BZ2Decompressor
    ModuleNotFoundError: No module named '_bz2'

While rare, it does happen, so make the bz2 registration optional.