### PR TITLE
Add CacheMapper to map from remote URL to local cached basename

### DIFF
--- a/fsspec/implementations/cache_mapper.py
+++ b/fsspec/implementations/cache_mapper.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import abc
+import hashlib
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class AbstractCacheMapper(abc.ABC):
+    """Abstract super-class for mappers from remote URLs to local cached
+    basenames.
+    """
+
+    @abc.abstractmethod
+    def __call__(self, path: str) -> str:
+        ...
+
+    def __eq__(self, other: Any) -> bool:
+        # Identity only depends on class. When derived classes have attributes
+        # they will need to be included.
+        return isinstance(other, type(self))
+
+    def __hash__(self) -> int:
+        # Identity only depends on class. When derived classes have attributes
+        # they will need to be included.
+        return hash(type(self))
+
+
+class BasenameCacheMapper(AbstractCacheMapper):
+    """Cache mapper that uses the basename of the remote URL.
+
+    Different paths with the same basename will therefore have the same cached
+    basename.
+    """
+
+    def __call__(self, path: str) -> str:
+        return os.path.basename(path)
+
+
+class HashCacheMapper(AbstractCacheMapper):
+    """Cache mapper that uses a hash of the remote URL."""
+
+    def __call__(self, path: str) -> str:
+        return hashlib.sha256(path.encode()).hexdigest()
+
+
+def create_cache_mapper(same_names: bool) -> AbstractCacheMapper:
+    """Factory method to create cache mapper for backward compatibility with
+    ``CachingFileSystem`` constructor using ``same_names`` kwarg.
+    """
+    if same_names:
+        return BasenameCacheMapper()
+    else:
+        return HashCacheMapper()

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -253,10 +253,11 @@ class CachingFileSystem(AbstractFileSystem):
 
         for path, detail in self.cached_files[-1].copy().items():
             if time.time() - detail["time"] > expiry_time:
-                fn = getattr(detail, "fn", "")
+                fn = detail.get("fn", "")
                 if not fn:
-                    # fn should always be set, but be defensive here.
-                    fn = self._mapper(detail["original"])
+                    raise RuntimeError(
+                        f"Cache metadata does not contain 'fn' for {path}"
+                    )
                 fn = os.path.join(self.storage[-1], fn)
                 if os.path.exists(fn):
                     os.remove(fn)

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -10,6 +10,7 @@ from fsspec.compression import compr
 from fsspec.exceptions import BlocksizeMismatchError
 from fsspec.implementations.cache_mapper import create_cache_mapper
 from fsspec.implementations.cached import CachingFileSystem, LocalTempFile
+from fsspec.implementations.local import make_path_posix
 
 from .test_ftp import FTPFileSystem
 
@@ -70,18 +71,20 @@ def test_metadata(tmpdir, same_names):
         cache_storage=os.path.join(tmpdir, "cache"),
         same_names=same_names,
     )
+
     with fs.open(afile, "rb") as f:
         assert f.read(5) == b"test"
 
-    detail = fs.cached_files[0][afile]
+    afile_posix = make_path_posix(afile)
+    detail = fs.cached_files[0][afile_posix]
     assert sorted(detail.keys()) == ["blocks", "fn", "original", "time", "uid"]
     assert isinstance(detail["blocks"], bool)
     assert isinstance(detail["fn"], str)
     assert isinstance(detail["time"], float)
     assert isinstance(detail["uid"], str)
 
-    assert detail["original"] == afile
-    assert detail["fn"] == fs._mapper(afile)
+    assert detail["original"] == afile_posix
+    assert detail["fn"] == fs._mapper(afile_posix)
     if same_names:
         assert detail["fn"] == "afile"
 

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -308,6 +308,7 @@ def test_chained_equivalent():
     #  since the parameters don't quite match. Also, the url understood by the two
     #  of s are not the same (path gets munged a bit differently)
     assert of.fs == of2.fs
+    assert hash(of.fs) == hash(of2.fs)
     assert of.open().read() == of2.open().read()
 
 


### PR DESCRIPTION
This is the start of work to make the caching system more configurable by splitting up different areas of responsibility of `CachingFileSystem` into separate class hierarchies that will eventually be pluggable.

It starts here by separating out the mapping from remote URL to local cached basename into a new class hierarchy based on `AbstractCacheMapper`. There is no change in functionality here, the two concrete derived classes cover the `same_names=True` and `same_names=False` options of `CachingFileSystem`. It will easy in future to add new `CacheMapper` classes or to modify the existing ones with extra attributes, e.g. number of directories to consider as well as the basename.

Implementation details:

1. `CacheMapper` is the best name I can think of but I am happy to change it if someone has a better idea.
2. `CachingFileSystem` no longer stores the `same_names` attribute, it is just used to create the `CacheMapper` which is stored. Removal of the `same_names` attribute could be considered an API change as it was technically public.
3. I have kept the `CachingFileSystem.hash_name` function even though it now defers to the `CacheMapper`. This is just for backwards compatibility in case downstream libraries are using it. The local `fsspec` tests all pass if it is removed.

In future, to support more pluggable options we will need to be able to pass `CacheMapper` instances to the `CachingFileSystem` constructor, but we will probably also have to keep the `same_names` arg for backward compatibility.

(Edited: typo)