### PR TITLE
expose a preconfigured `dirfs` instance on mapper objects

### DIFF
--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -62,6 +62,7 @@ class FSMap(MutableMapping):
 
     @cached_property
     def dirfs(self):
+        """dirfs instance that can be used with the same keys as the mapper"""
         from .implementations.dirfs import DirFileSystem
 
         return DirFileSystem(path=self._root_key_to_str, fs=self.fs)

--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -2,6 +2,7 @@ import array
 import posixpath
 import warnings
 from collections.abc import MutableMapping
+from functools import cached_property
 
 from .core import url_to_fs
 
@@ -58,6 +59,12 @@ class FSMap(MutableMapping):
                 )
             self.fs.touch(root + "/a")
             self.fs.rm(root + "/a")
+
+    @cached_property
+    def dirfs(self):
+        from .implementations.dirfs import DirFileSystem
+
+        return DirFileSystem(path=self._root_key_to_str, fs=self.fs)
 
     def clear(self):
         """Remove all keys below root - empties out mapping"""

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -214,3 +214,11 @@ def test_fsmap_access_with_suffix(tmp_path):
         _ = m["b/"]
 
     assert m["b/a/"] == b"data"
+
+
+def test_fsmap_dirfs():
+    m = fsspec.get_mapper("memory://")
+
+    fs = m.dirfs
+    assert isinstance(fs, fsspec.implementations.dirfs.DirFileSystem)
+    assert fs.path == m.root


### PR DESCRIPTION
- [x] closes #1269

I'm pretty happy with the way `dirfs` instances help working with mapper objects, but constructing one that uses the same parameters as the mapper is a bit more work than I would wish:

``` python
m = fsspec.get_mapper(url, ...)
dirfs = fsspec.filesystem("dirfs", path=url, fs=m.fs)
dirfs.open(...)
```

As suggested in #1269, this exposes a `dirfs` instance as a cached property, which means that anyone who doesn't need the `dirfs` instance doesn't have to wait the (very) little time it takes to construct one. With that, the above snipped would become:

``` python
m = fsspec.get_mapper(url, ...)
m.dirfs.open(...)
```
I'm not particularly attached to the name of the property, so I'm happy to change that.

Also, I didn't discuss this change before implementing it, so feel free to close if you don't think growing the mapper API makes sense in this case.