### PR TITLE
Adding support for onerror parameter in walk

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -641,7 +641,7 @@ class AsyncFileSystem(AbstractFileSystem):
     async def _ls(self, path, detail=True, **kwargs):
         raise NotImplementedError
 
-    async def _walk(self, path, maxdepth=None, **kwargs):
+    async def _walk(self, path, maxdepth=None, onerror=None, **kwargs):
         if maxdepth is not None and maxdepth < 1:
             raise ValueError("maxdepth must be at least 1")
 
@@ -653,7 +653,9 @@ class AsyncFileSystem(AbstractFileSystem):
         detail = kwargs.pop("detail", False)
         try:
             listing = await self._ls(path, detail=True, **kwargs)
-        except (FileNotFoundError, OSError):
+        except (FileNotFoundError, OSError) as e:
+            if onerror is not None:
+                onerror(e)
             if detail:
                 yield path, {}, {}
             else:

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -641,7 +641,7 @@ class AsyncFileSystem(AbstractFileSystem):
     async def _ls(self, path, detail=True, **kwargs):
         raise NotImplementedError
 
-    async def _walk(self, path, maxdepth=None, onerror=None, **kwargs):
+    async def _walk(self, path, maxdepth=None, on_error="omit", **kwargs):
         if maxdepth is not None and maxdepth < 1:
             raise ValueError("maxdepth must be at least 1")
 
@@ -654,8 +654,10 @@ class AsyncFileSystem(AbstractFileSystem):
         try:
             listing = await self._ls(path, detail=True, **kwargs)
         except (FileNotFoundError, OSError) as e:
-            if onerror is not None:
-                onerror(e)
+            if on_error == "raise":
+                raise
+            elif callable(on_error):
+                on_error(e)
             if detail:
                 yield path, {}, {}
             else:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -372,7 +372,7 @@ class AbstractFileSystem(metaclass=_Cached):
         except KeyError:
             pass
 
-    def walk(self, path, maxdepth=None, topdown=True, onerror=None, **kwargs):
+    def walk(self, path, maxdepth=None, topdown=True, on_error="omit", **kwargs):
         """Return all files belows path
 
         List all files, recursing into subdirectories; output is iterator-style,
@@ -385,11 +385,6 @@ class AbstractFileSystem(metaclass=_Cached):
         or even to inform walk() about directories the caller creates or renames before
         it resumes walk() again.
         Modifying dirnames when topdown is False has no effect. (see os.walk)
-
-        If optional argument onerror is specified, it should be a function;
-        it will be called with one argument, an OSError instance.
-        It can report the error to continue with the walk,
-        or raise the exception to abort the walk.
 
         Note that the "files" outputted will include anything that is not
         a directory, such as links.
@@ -404,6 +399,10 @@ class AbstractFileSystem(metaclass=_Cached):
         topdown: bool (True)
             Whether to walk the directory tree from the top downwards or from
             the bottom upwards.
+        on_error: "omit", "raise", a collable
+            if omit (default), path with exception will simply be empty;
+            If raise, an underlying exception will be raised;
+            if callable, it will be called with a single OSError instance as argument
         kwargs: passed to ``ls``
         """
         if maxdepth is not None and maxdepth < 1:
@@ -418,8 +417,10 @@ class AbstractFileSystem(metaclass=_Cached):
         try:
             listing = self.ls(path, detail=True, **kwargs)
         except (FileNotFoundError, OSError) as e:
-            if onerror is not None:
-                onerror(e)
+            if on_error == "raise":
+                raise
+            elif callable(on_error):
+                on_error(e)
             if detail:
                 return path, {}, {}
             return path, [], []

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -4,6 +4,7 @@ import contextlib
 import os
 import pickle
 import tempfile
+from unittest.mock import Mock
 
 import pytest
 
@@ -479,3 +480,20 @@ def test_walk(m):
         (dir12, [], ["file121"]),
         (dir1, ["dir11", "dir12"], ["file11"]),
     ]
+
+    # onerror skip by default
+    assert list(m.walk("do_not_exist")) == []
+    # onerror skip function
+    mock = Mock()
+    assert list(m.walk("do_not_exist", onerror=mock.onerror)) == []
+    mock.onerror.assert_called()
+    assert mock.onerror.call_args.kwargs == {}
+    assert len(mock.onerror.call_args.args) == 1
+    assert isinstance(mock.onerror.call_args.args[0], FileNotFoundError)
+    # onerror re-raise function
+    with pytest.raises(FileNotFoundError):
+
+        def onerror(e):
+            raise e
+
+        list(m.walk("do_not_exist", onerror=onerror))

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -481,19 +481,17 @@ def test_walk(m):
         (dir1, ["dir11", "dir12"], ["file11"]),
     ]
 
-    # onerror skip by default
+    # on_error omit by default
     assert list(m.walk("do_not_exist")) == []
-    # onerror skip function
+    # on_error omit
+    assert list(m.walk("do_not_exist", on_error="omit")) == []
+    # on_error raise
+    with pytest.raises(FileNotFoundError):
+        list(m.walk("do_not_exist", on_error="raise"))
+    # on_error callable function
     mock = Mock()
-    assert list(m.walk("do_not_exist", onerror=mock.onerror)) == []
+    assert list(m.walk("do_not_exist", on_error=mock.onerror)) == []
     mock.onerror.assert_called()
     assert mock.onerror.call_args.kwargs == {}
     assert len(mock.onerror.call_args.args) == 1
     assert isinstance(mock.onerror.call_args.args[0], FileNotFoundError)
-    # onerror re-raise function
-    with pytest.raises(FileNotFoundError):
-
-        def onerror(e):
-            raise e
-
-        list(m.walk("do_not_exist", onerror=onerror))


### PR DESCRIPTION
Fixes #1297, I was not sure how to test the async version since I haven't found any suitable existing test to start with.

The current `walk()` implementation is missing the `onerror` parameter.

[See os.walk](https://docs.python.org/3/library/os.html#os.walk)