### PR TITLE
Fix MemoryFileSystem.touch by just using the default super impl

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -137,10 +137,6 @@ class MemoryFileSystem(AbstractFileSystem):
         else:
             raise FileNotFoundError(path)
 
-    def exists(self, path, **kwargs):
-        path = self._strip_protocol(path)
-        return path in self.store or path in self.pseudo_dirs
-
     def info(self, path, **kwargs):
         path = self._strip_protocol(path)
         if path in self.pseudo_dirs or any(
@@ -191,11 +187,14 @@ class MemoryFileSystem(AbstractFileSystem):
                 return f
             else:
                 raise FileNotFoundError(path)
-        if mode == "wb":
+        elif mode == "wb":
             m = MemoryFile(self, path, kwargs.get("data"))
             if not self._intrans:
                 m.commit()
             return m
+        else:
+            name = self.__class__.__name__
+            raise ValueError(f"unsupported file mode for {name}: {mode!r}")
 
     def cp_file(self, path1, path2, **kwargs):
         path1 = self._strip_protocol(path1)

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -58,6 +58,44 @@ def test_directories(m):
     assert not m.store
 
 
+def test_exists_isdir_isfile(m):
+    m.mkdir("/root")
+    m.touch("/root/a")
+
+    assert m.exists("/root")
+    assert m.isdir("/root")
+    assert not m.isfile("/root")
+
+    assert m.exists("/root/a")
+    assert m.isfile("/root/a")
+    assert not m.isdir("/root/a")
+
+    assert not m.exists("/root/not-exists")
+    assert not m.isfile("/root/not-exists")
+    assert not m.isdir("/root/not-exists")
+
+    m.rm("/root/a")
+    m.rmdir("/root")
+
+    assert not m.exists("/root")
+
+    m.touch("/a/b")
+    assert m.isfile("/a/b")
+
+    assert m.exists("/a")
+    assert m.isdir("/a")
+    assert not m.isfile("/a")
+
+
+def test_touch(m):
+    m.touch("/root/a")
+    with pytest.raises(FileExistsError):
+        m.touch("/root/a/b")
+    with pytest.raises(FileExistsError):
+        m.touch("/root/a/b/c")
+    assert not m.exists("/root/a/b/")
+
+
 def test_mv_recursive(m):
     m.mkdir("src")
     m.touch("src/file.txt")


### PR DESCRIPTION
The current behaviour of `.exists` doesn't do smart checking for directories.

```py
import fsspec
fs, _ = fsspec.core.url_to_fs('memory://')
fs.touch('/a/b')
fs.exists('/a/b')
Out[5]: True
fs.exists('/a')
Out[6]: False
fs.isdir('/a')
Out[7]: True
```

We can simply use the super implementation which just checks `.info` doesn't error. 

Also added some tests :)