### PR TITLE
Remove deprecated utcnow and utcfromtimestamp

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -196,11 +196,13 @@ class LocalFileSystem(AbstractFileSystem):
 
     def created(self, path):
         info = self.info(path=path)
-        return datetime.datetime.utcfromtimestamp(info["created"])
+        return datetime.datetime.fromtimestamp(
+            info["created"], tz=datetime.timezone.utc
+        )
 
     def modified(self, path):
         info = self.info(path=path)
-        return datetime.datetime.utcfromtimestamp(info["mtime"])
+        return datetime.datetime.fromtimestamp(info["mtime"], tz=datetime.timezone.utc)
 
     @classmethod
     def _parent(cls, path):

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, annotations, division, print_function
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from errno import ENOTEMPTY
 from io import BytesIO
 from typing import Any, ClassVar
@@ -268,8 +268,8 @@ class MemoryFile(BytesIO):
         logger.debug("open file %s", path)
         self.fs = fs
         self.path = path
-        self.created = datetime.utcnow()
-        self.modified = datetime.utcnow()
+        self.created = datetime.now(tz=timezone.utc)
+        self.modified = datetime.now(tz=timezone.utc)
         if data:
             super().__init__(data)
             self.seek(0)
@@ -289,4 +289,4 @@ class MemoryFile(BytesIO):
 
     def commit(self):
         self.fs.store[self.path] = self
-        self.modified = datetime.utcnow()
+        self.modified = datetime.now(tz=timezone.utc)

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -110,8 +110,12 @@ class SFTPFileSystem(AbstractFileSystem):
             "type": t,
             "uid": stat.st_uid,
             "gid": stat.st_gid,
-            "time": datetime.datetime.utcfromtimestamp(stat.st_atime),
-            "mtime": datetime.datetime.utcfromtimestamp(stat.st_mtime),
+            "time": datetime.datetime.fromtimestamp(
+                stat.st_atime, tz=datetime.timezone.utc
+            ),
+            "mtime": datetime.datetime.fromtimestamp(
+                stat.st_mtime, tz=datetime.timezone.utc
+            ),
         }
         if parent_path:
             out["name"] = "/".join([parent_path.rstrip("/"), stat.filename])

--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -177,13 +177,13 @@ class SMBFileSystem(AbstractFileSystem):
         """Return the created timestamp of a file as a datetime.datetime"""
         wpath = _as_unc_path(self.host, path)
         stats = smbclient.stat(wpath, port=self.port)
-        return datetime.datetime.utcfromtimestamp(stats.st_ctime)
+        return datetime.datetime.fromtimestamp(stats.st_ctime, tz=datetime.timezone.utc)
 
     def modified(self, path):
         """Return the modified timestamp of a file as a datetime.datetime"""
         wpath = _as_unc_path(self.host, path)
         stats = smbclient.stat(wpath, port=self.port)
-        return datetime.datetime.utcfromtimestamp(stats.st_mtime)
+        return datetime.datetime.fromtimestamp(stats.st_mtime, tz=datetime.timezone.utc)
 
     def ls(self, path, detail=True, **kwargs):
         unc = _as_unc_path(self.host, path)

--- a/fsspec/implementations/tests/test_common.py
+++ b/fsspec/implementations/tests/test_common.py
@@ -23,10 +23,12 @@ def test_modified(fs: AbstractFileSystem, temp_file):
     try:
         fs.touch(temp_file)
         # created = fs.created(path=temp_file)
-        created = datetime.datetime.utcnow()  # pyarrow only have modified
+        created = datetime.datetime.now(
+            tz=datetime.timezone.utc
+        )  # pyarrow only have modified
         time.sleep(0.05)
         fs.touch(temp_file)
-        modified = fs.modified(path=temp_file).replace(tzinfo=None)
+        modified = fs.modified(path=temp_file)
         assert isinstance(modified, datetime.datetime)
         assert modified > created
     finally:


### PR DESCRIPTION
Fixes #1312.

This replaces the functions `datetime.utcnow` and `datetime.utcfromtimestamp` which are deprecated in Python 3.12. Following the CPython issue (https://github.com/python/cpython/issues/103857) and related article (https://blog.ganssle.io/articles/2019/11/utcnow.html) they are replaced as follows:

`datetime.utcnow()` -> `datetime.now(tz=timezone.utc)` and
`datetime.utcfromtimestamp(x)` -> `datetime.fromtimestamp(x, tz=timezone.utc`)

The following example
```python
import fsspec

mem = fsspec.filesystem("memory")
mem.touch("/file")
print(repr(mem.created("/file")))
```
used to give
```python
datetime.datetime(2023, 7, 21, 10, 38, 3, 924824)
```
whereas after this PR it gives
```python
datetime.datetime(2023, 7, 21, 10, 38, 3, 924824, tzinfo=datetime.timezone.utc)
```
so previously datetimes returned by `fsspec` were timezone-naive whereas now they are timezone aware at UTC. This is more correct than it used to be as such `created` datetimes are derived from UNIX timestamps which are seconds since the epoch at UTC so it is correct to label them as UTC (as in the article linked above) rather than as timezone naive. But some users/libraries may be making assumptions about the timezone which are no longer true.

It would be possible to change this PR to drop the UTC timezone to make such datetimes timezone-naive, which more closely follows the old behaviour but is less correct in the long term, so I prefer the solution here.