### PR TITLE
Support cache mapper that is basename plus fixed number of parent directories

### DIFF
--- a/fsspec/implementations/cache_mapper.py
+++ b/fsspec/implementations/cache_mapper.py
@@ -45,7 +45,7 @@ class BasenameCacheMapper(AbstractCacheMapper):
         self.directory_levels = directory_levels
 
         # Separator for directories when encoded as strings.
-        self._separator = "_^_"
+        self._separator = "_@_"
 
     def __call__(self, path: str) -> str:
         dirname, basename = os.path.split(path)

--- a/fsspec/implementations/cache_mapper.py
+++ b/fsspec/implementations/cache_mapper.py
@@ -48,14 +48,11 @@ class BasenameCacheMapper(AbstractCacheMapper):
         self._separator = "_@_"
 
     def __call__(self, path: str) -> str:
-        dirname, basename = os.path.split(path)
-
-        if self.directory_levels > 0:
-            dirs = dirname.split(os.sep)[-self.directory_levels :]
-            dirs.append(basename)
-            basename = self._separator.join(dirs)
-
-        return basename
+        prefix, *bits = path.rsplit(os.sep, self.directory_levels + 1)
+        if bits:
+            return self._separator.join(bits)
+        else:
+            return prefix  # No separator found, simple filename
 
     def __eq__(self, other: Any) -> bool:
         return super().__eq__(other) and self.directory_levels == other.directory_levels

--- a/fsspec/implementations/cache_mapper.py
+++ b/fsspec/implementations/cache_mapper.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import abc
 import hashlib
-import os
 from typing import TYPE_CHECKING
+
+from fsspec.implementations.local import make_path_posix
 
 if TYPE_CHECKING:
     from typing import Any
@@ -48,7 +49,8 @@ class BasenameCacheMapper(AbstractCacheMapper):
         self._separator = "_@_"
 
     def __call__(self, path: str) -> str:
-        prefix, *bits = path.rsplit(os.sep, self.directory_levels + 1)
+        path = make_path_posix(path)
+        prefix, *bits = path.rsplit("/", self.directory_levels + 1)
         if bits:
             return self._separator.join(bits)
         else:

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -150,7 +150,7 @@ class CachingFileSystem(AbstractFileSystem):
             # acts as a method, since each instance has a difference target
             return self.fs._strip_protocol(type(self)._strip_protocol(path))
 
-        self._strip_protocol = _strip_protocol
+        self._strip_protocol = _strip_protocol  # type: ignore[method-assign]
 
     def _mkcache(self):
         os.makedirs(self.storage[-1], exist_ok=True)

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -8,7 +8,7 @@ import pickle
 import tempfile
 import time
 from shutil import rmtree
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
 from fsspec import AbstractFileSystem, filesystem
 from fsspec.callbacks import _DEFAULT_CALLBACK
@@ -150,7 +150,7 @@ class CachingFileSystem(AbstractFileSystem):
             # acts as a method, since each instance has a difference target
             return self.fs._strip_protocol(type(self)._strip_protocol(path))
 
-        self._strip_protocol = _strip_protocol  # type: ignore[method-assign]
+        self._strip_protocol: Callable = _strip_protocol
 
     def _mkcache(self):
         os.makedirs(self.storage[-1], exist_ok=True)

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -78,7 +78,6 @@ def test_mapper():
         BasenameCacheMapper(-1)
 
     mapper2 = BasenameCacheMapper(1)
-    assert mapper2("somefile") == "somefile"
     assert mapper2("/somefile") == "somefile"
     assert mapper2("/somedir/somefile") == "somedir_@_somefile"
     assert mapper2("/otherdir/somefile") == "otherdir_@_somefile"
@@ -93,7 +92,6 @@ def test_mapper():
     assert hash(BasenameCacheMapper(1)) == hash(mapper2)
 
     mapper3 = BasenameCacheMapper(2)
-    assert mapper3("somefile") == "somefile"
     assert mapper3("/somefile") == "somefile"
     assert mapper3("/somedir/somefile") == "somedir_@_somefile"
     assert mapper3("/otherdir/somefile") == "otherdir_@_somefile"

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -68,12 +68,12 @@ def test_mapper():
         BasenameCacheMapper(-1)
 
     mapper2 = BasenameCacheMapper(1)
-    assert mapper2("/somedir/somefile") == "somedir_^_somefile"
-    assert mapper2("/otherdir/somefile") == "otherdir_^_somefile"
+    assert mapper2("/somedir/somefile") == "somedir_@_somefile"
+    assert mapper2("/otherdir/somefile") == "otherdir_@_somefile"
 
     mapper2 = BasenameCacheMapper(2)
-    assert mapper2("/somedir/somefile") == "_^_somedir_^_somefile"
-    assert mapper2("/otherdir/somefile") == "_^_otherdir_^_somefile"
+    assert mapper2("/somedir/somefile") == "_@_somedir_@_somefile"
+    assert mapper2("/otherdir/somefile") == "_@_otherdir_@_somefile"
 
     assert mapper2 != mapper0
     assert mapper2 != mapper1
@@ -118,7 +118,7 @@ def test_metadata(tmpdir, cache_mapper):
         if cache_mapper.directory_levels == 0:
             assert detail["fn"] == "afile"
         else:
-            assert detail["fn"] == "source_^_afile"
+            assert detail["fn"] == "source_@_afile"
 
 
 def test_constructor_kwargs(tmpdir):

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -40,10 +40,20 @@ def local_filecache():
 
 def test_mapper():
     mapper0 = create_cache_mapper(True)
+    assert mapper0("somefile") == "somefile"
+    assert mapper0("/somefile") == "somefile"
     assert mapper0("/somedir/somefile") == "somefile"
     assert mapper0("/otherdir/somefile") == "somefile"
 
     mapper1 = create_cache_mapper(False)
+    assert (
+        mapper1("somefile")
+        == "dd00b9487898b02555b6a2d90a070586d63f93e80c70aaa60c992fa9e81a72fe"
+    )
+    assert (
+        mapper1("/somefile")
+        == "884c07bc2efe65c60fb9d280a620e7f180488718fb5d97736521b7f9cf5c8b37"
+    )
     assert (
         mapper1("/somedir/somefile")
         == "67a6956e5a5f95231263f03758c1fd9254fdb1c564d311674cec56b0372d2056"
@@ -68,20 +78,36 @@ def test_mapper():
         BasenameCacheMapper(-1)
 
     mapper2 = BasenameCacheMapper(1)
+    assert mapper2("somefile") == "somefile"
+    assert mapper2("/somefile") == "somefile"
     assert mapper2("/somedir/somefile") == "somedir_@_somefile"
     assert mapper2("/otherdir/somefile") == "otherdir_@_somefile"
-
-    mapper2 = BasenameCacheMapper(2)
-    assert mapper2("/somedir/somefile") == "_@_somedir_@_somefile"
-    assert mapper2("/otherdir/somefile") == "_@_otherdir_@_somefile"
+    assert mapper2("/dir1/dir2/dir3/somefile") == "dir3_@_somefile"
 
     assert mapper2 != mapper0
     assert mapper2 != mapper1
-    assert BasenameCacheMapper(2) == mapper2
+    assert BasenameCacheMapper(1) == mapper2
 
     assert hash(mapper2) != hash(mapper0)
     assert hash(mapper2) != hash(mapper1)
-    assert hash(BasenameCacheMapper(2)) == hash(mapper2)
+    assert hash(BasenameCacheMapper(1)) == hash(mapper2)
+
+    mapper3 = BasenameCacheMapper(2)
+    assert mapper3("somefile") == "somefile"
+    assert mapper3("/somefile") == "somefile"
+    assert mapper3("/somedir/somefile") == "somedir_@_somefile"
+    assert mapper3("/otherdir/somefile") == "otherdir_@_somefile"
+    assert mapper3("/dir1/dir2/dir3/somefile") == "dir2_@_dir3_@_somefile"
+
+    assert mapper3 != mapper0
+    assert mapper3 != mapper1
+    assert mapper3 != mapper2
+    assert BasenameCacheMapper(2) == mapper3
+
+    assert hash(mapper3) != hash(mapper0)
+    assert hash(mapper3) != hash(mapper1)
+    assert hash(mapper3) != hash(mapper2)
+    assert hash(BasenameCacheMapper(2)) == hash(mapper3)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This adds support for a cache mapper that is a fixed number of parent directories as well as the basename. This will be useful when using multiple directories containing files with the same names but you still want the cached filenames to be clearly identifiable rather than using hashes.

I have chosen to add a new `directory_levels` attribute to `BasenameCacheMapper` rather than create a new class.

Example use:
```python
from fsspec import filesystem
from fsspec.implementations.cache_mapper import BasenameCacheMapper

fs = filesystem("filecache", target_protocol='file', cache_mapper=BasenameCacheMapper(2))
```

I have made some design decisions for this that are up for discussion:

1. I've kept the `same_names` kwarg to `CachingFileSystem.__init__` for backward compatibility as well as adding the new `cache_mapper` kwarg. You cannot specify both. This seemed a better approach than the alternative of allowing values for `same_names` other than boolean and allows us to easily support other `CacheMapper` classes in the future.
2. For the cached filenames I am not using usual path separators as I wanted to use the same separators on all OSes and avoid any problems in inferring that slashes are indeed directory separators and looking in the wrong place. I am using a somewhat arbitrary string of `_^_` so far but not tied to this.