### PR TITLE
Separate CacheMetadata class for CachingFileSystem

### DIFF
--- a/fsspec/implementations/cache_metadata.py
+++ b/fsspec/implementations/cache_metadata.py
@@ -31,7 +31,7 @@ class CacheMetadata:
         ----------
         storage: list[str]
             Directories containing cached files, must be at least one. Metadata
-            is stored in the last of these directores by convention.
+            is stored in the last of these directories by convention.
         """
         if not storage:
             raise ValueError("CacheMetadata expects at least one storage location")

--- a/fsspec/implementations/cache_metadata.py
+++ b/fsspec/implementations/cache_metadata.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import contextlib
 import os
 import pickle
-import tempfile
 import time
 from typing import TYPE_CHECKING
+
+from fsspec.utils import atomic_write
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, Literal
@@ -204,24 +204,3 @@ class CacheMetadata:
     def update_file(self, path: str, detail: Detail) -> None:
         """Update metadata for specific file in memory, do not save"""
         self.cached_files[-1][path] = detail
-
-
-@contextlib.contextmanager
-def atomic_write(path: str, mode: str = "wb"):
-    """
-    A context manager that opens a temporary file next to `path` and, on exit,
-    replaces `path` with the temporary file, thereby updating `path`
-    atomically.
-    """
-    fd, fn = tempfile.mkstemp(
-        dir=os.path.dirname(path), prefix=os.path.basename(path) + "-"
-    )
-    try:
-        with open(fd, mode) as fp:
-            yield fp
-    except BaseException:
-        with contextlib.suppress(FileNotFoundError):
-            os.unlink(fn)
-        raise
-    else:
-        os.replace(fn, path)

--- a/fsspec/implementations/cache_metadata.py
+++ b/fsspec/implementations/cache_metadata.py
@@ -143,19 +143,25 @@ class CacheMetadata:
         if c["blocks"] is not True and len(c["blocks"]) * f.blocksize >= f.size:
             c["blocks"] = True
 
-    def pop_file(self, path: str) -> None:
+    def pop_file(self, path: str) -> str | None:
+        """Remove metadata of cached file.
+
+        If path is in the cache, return the filename of the cached file,
+        otherwise return ``None``.  Caller is responsible for deleting the
+        cached file.
+        """
         details = self.check_file(path, None)
         if not details:
-            return
+            return None
         _, fn = details
         if fn.startswith(self._storage[-1]):
-            os.remove(fn)
             self.cached_files[-1].pop(path)
             self.save()
         else:
             raise PermissionError(
                 "Can only delete cached file in last, writable cache location"
             )
+        return fn
 
     def save(self) -> None:
         """Save metadata to disk"""

--- a/fsspec/implementations/cache_metadata.py
+++ b/fsspec/implementations/cache_metadata.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import pickle
+import tempfile
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Dict, Iterator, Literal
+
+    from typing_extensions import TypeAlias
+
+    Detail: TypeAlias = Dict[str, Any]
+
+
+class CacheMetadata:
+    """Cache metadata.
+
+    All reading and writing of cache metadata is performed by this class,
+    accessing the cached files and blocks is not.
+
+    Metadata is stored in a single file per storage directory, pickled.
+    """
+
+    def __init__(self, storage: list[str]):
+        """
+
+        Parameters
+        ----------
+        storage: list[str]
+            Directories containing cached files, must be at least one. Metadata
+            is stored in the last of these directores by convention.
+        """
+        if not storage:
+            raise ValueError("CacheMetadata expects at least one storage location")
+
+        self._storage = storage
+        self.cached_files: list[Detail] = [{}]
+
+    def _scan_locations(
+        self, writable_only: bool = False
+    ) -> Iterator[tuple[str, str, bool]]:
+        """Yield locations (filenames) where metadata is stored, and whether
+        writable or not.
+
+        Parameters
+        ----------
+        writable: bool
+            Set to True to only yield writable locations.
+
+        Returns
+        -------
+        Yields (str, str, bool)
+        """
+        n = len(self._storage)
+        for i, storage in enumerate(self._storage):
+            writable = i == n - 1
+            if writable_only and not writable:
+                continue
+            yield os.path.join(storage, "cache"), storage, writable
+
+    def check_file(
+        self, path: str, ignore: Callable[[Detail], bool] | None
+    ) -> Literal[False] | tuple[Detail, str]:
+        """If path is in cache return its details, otherwise return ``False``.
+
+        Takes an optional callback so that the caller can choose to ignore
+        possible matches if, for example, they are too old.
+        """
+        for (fn, base, _), cache in zip(self._scan_locations(), self.cached_files):
+            if path not in cache:
+                continue
+            detail = cache[path].copy()
+            if ignore is not None and ignore(detail):
+                continue
+            fn = os.path.join(base, detail["fn"])
+            if os.path.exists(fn):
+                return detail, fn
+        return False
+
+    def clear_expired(self, expiry_time: int) -> Iterator[str]:
+        """Remove expired metadata from the cache.
+
+        Yields names of files corresponding to expired metadata. Caller is
+        responsible for deleting these files.
+        """
+        for path, detail in self.cached_files[-1].copy().items():
+            if time.time() - detail["time"] > expiry_time:
+                fn = detail.get("fn", "")
+                if not fn:
+                    raise RuntimeError(
+                        f"Cache metadata does not contain 'fn' for {path}"
+                    )
+                fn = os.path.join(self._storage[-1], fn)
+                yield fn
+                self.cached_files[-1].pop(path)
+
+        if self.cached_files[-1]:
+            cache_path = os.path.join(self._storage[-1], "cache")
+            with atomic_write(cache_path) as fc:
+                pickle.dump(self.cached_files[-1], fc)
+
+    def close_file(self, f: Any, path: str) -> None:
+        """Perform side-effect actions when closing a cached file.
+
+        The actual closing of the file is the responsibility of the caller.
+        """
+        # File must be writeble, so in self.cached_files[-1]
+        c = self.cached_files[-1][path]
+        if c["blocks"] is not True and len(c["blocks"]) * f.blocksize >= f.size:
+            c["blocks"] = True
+
+    def empty(self) -> bool:
+        """Return ``True`` if metadata of the writable storage is empty"""
+        return not self.cached_files[-1]
+
+    def load(self) -> None:
+        """Load all metadata from disk and store in ``self.cached_files``"""
+        cached_files = []
+        for fn, _, _ in self._scan_locations():
+            if os.path.exists(fn):
+                with open(fn, "rb") as f:
+                    # TODO: consolidate blocks here
+                    loaded_cached_files = pickle.load(f)
+                    for c in loaded_cached_files.values():
+                        if isinstance(c["blocks"], list):
+                            c["blocks"] = set(c["blocks"])
+                    cached_files.append(loaded_cached_files)
+            else:
+                cached_files.append({})
+        self.cached_files = cached_files or [{}]
+
+    def pop_file(self, path: str) -> None:
+        details = self.check_file(path, None)
+        if not details:
+            return
+        _, fn = details
+        if fn.startswith(self._storage[-1]):
+            os.remove(fn)
+            self.cached_files[-1].pop(path)
+            self.save()
+        else:
+            raise PermissionError(
+                "Can only delete cached file in last, writable cache location"
+            )
+
+    def save(self) -> None:
+        """Save metadata to disk"""
+        for (fn, _, writable), cache in zip(self._scan_locations(), self.cached_files):
+            if not writable:
+                continue
+
+            if os.path.exists(fn):
+                with open(fn, "rb") as f:
+                    cached_files = pickle.load(f)
+                for k, c in cached_files.items():
+                    if k in cache:
+                        if c["blocks"] is True or cache[k]["blocks"] is True:
+                            c["blocks"] = True
+                        else:
+                            # self.cached_files[*][*]["blocks"] must continue to
+                            # point to the same set object so that updates
+                            # performed by MMapCache are propagated back to
+                            # self.cached_files.
+                            blocks = cache[k]["blocks"]
+                            blocks.update(c["blocks"])
+                            c["blocks"] = blocks
+                        c["time"] = max(c["time"], cache[k]["time"])
+                        c["uid"] = cache[k]["uid"]
+
+                # Files can be added to cache after it was written once
+                for k, c in cache.items():
+                    if k not in cached_files:
+                        cached_files[k] = c
+            else:
+                cached_files = cache
+            cache = {k: v.copy() for k, v in cached_files.items()}
+            for c in cache.values():
+                if isinstance(c["blocks"], set):
+                    c["blocks"] = list(c["blocks"])
+            with atomic_write(fn) as f:
+                pickle.dump(cache, f)
+            self.cached_files[-1] = cached_files
+
+    def update_file(self, path: str, detail: Detail) -> None:
+        """Update metadata for specific file in memory, do not save"""
+        self.cached_files[-1][path] = detail
+
+
+@contextlib.contextmanager
+def atomic_write(path: str, mode: str = "wb"):
+    """
+    A context manager that opens a temporary file next to `path` and, on exit,
+    replaces `path` with the temporary file, thereby updating `path`
+    atomically.
+    """
+    fd, fn = tempfile.mkstemp(
+        dir=os.path.dirname(path), prefix=os.path.basename(path) + "-"
+    )
+    try:
+        with open(fd, mode) as fp:
+            yield fp
+    except BaseException:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(fn)
+        raise
+    else:
+        os.replace(fn, path)

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -332,7 +332,7 @@ class CachingFileSystem(AbstractFileSystem):
         if f.closed:
             return
         path = self._strip_protocol(f.path)
-        self._metadata.close_file(f, path)
+        self._metadata.on_close_cached_file(f, path)
         try:
             logger.debug("going to save")
             self.save_cache()

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 import time
 from shutil import rmtree
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
 from fsspec import AbstractFileSystem, filesystem
 from fsspec.callbacks import _DEFAULT_CALLBACK
@@ -20,7 +20,6 @@ from fsspec.utils import infer_compression
 
 if TYPE_CHECKING:
     from fsspec.implementations.cache_mapper import AbstractCacheMapper
-    from fsspec.implementations.cache_metadata import Detail
 
 logger = logging.getLogger("fsspec.cached")
 

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 import time
 from shutil import rmtree
-from typing import TYPE_CHECKING, Any, Callable, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from fsspec import AbstractFileSystem, filesystem
 from fsspec.callbacks import _DEFAULT_CALLBACK
@@ -183,13 +183,7 @@ class CachingFileSystem(AbstractFileSystem):
         """Is path in cache and still valid"""
         path = self._strip_protocol(path)
         self._check_cache()
-
-        def ignore(detail: Detail) -> bool:
-            return (self.check_files and detail["uid"] != self.fs.ukey(path)) or (
-                self.expiry and time.time() - detail["time"] > self.expiry
-            )
-
-        return self._metadata.check_file(path, ignore)
+        return self._metadata.check_file(path, self)
 
     def clear_cache(self):
         """Remove all files and metadata from the cache

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -230,7 +230,9 @@ class CachingFileSystem(AbstractFileSystem):
         raises PermissionError
         """
         path = self._strip_protocol(path)
-        self._metadata.pop_file(path)
+        fn = self._metadata.pop_file(path)
+        if fn is not None:
+            os.remove(fn)
 
     def _open(
         self,

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -213,11 +213,12 @@ class CachingFileSystem(AbstractFileSystem):
 
         self._check_cache()
 
-        for fn in self._metadata.clear_expired(expiry_time):
+        expired_files, writable_cache_empty = self._metadata.clear_expired(expiry_time)
+        for fn in expired_files:
             if os.path.exists(fn):
                 os.remove(fn)
 
-        if self._metadata.empty():
+        if writable_cache_empty:
             rmtree(self.storage[-1])
             self.load_cache()
 

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import contextlib
 import inspect
 import logging
 import os
-import pickle
 import tempfile
 import time
 from shutil import rmtree
@@ -16,11 +14,13 @@ from fsspec.compression import compr
 from fsspec.core import BaseCache, MMapCache
 from fsspec.exceptions import BlocksizeMismatchError
 from fsspec.implementations.cache_mapper import create_cache_mapper
+from fsspec.implementations.cache_metadata import CacheMetadata
 from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import infer_compression
 
 if TYPE_CHECKING:
     from fsspec.implementations.cache_mapper import AbstractCacheMapper
+    from fsspec.implementations.cache_metadata import Detail
 
 logger = logging.getLogger("fsspec.cached")
 
@@ -143,6 +143,7 @@ class CachingFileSystem(AbstractFileSystem):
             if isinstance(target_protocol, str)
             else (fs.protocol if isinstance(fs.protocol, str) else fs.protocol[0])
         )
+        self._metadata = CacheMetadata(self.storage)
         self.load_cache()
         self.fs = fs if fs is not None else filesystem(target_protocol, **self.kwargs)
 
@@ -157,61 +158,14 @@ class CachingFileSystem(AbstractFileSystem):
 
     def load_cache(self):
         """Read set of stored blocks from file"""
-        cached_files = []
-        for storage in self.storage:
-            fn = os.path.join(storage, "cache")
-            if os.path.exists(fn):
-                with open(fn, "rb") as f:
-                    # TODO: consolidate blocks here
-                    loaded_cached_files = pickle.load(f)
-                    for c in loaded_cached_files.values():
-                        if isinstance(c["blocks"], list):
-                            c["blocks"] = set(c["blocks"])
-                    cached_files.append(loaded_cached_files)
-            else:
-                cached_files.append({})
+        self._metadata.load()
         self._mkcache()
-        self.cached_files = cached_files or [{}]
         self.last_cache = time.time()
 
     def save_cache(self):
         """Save set of stored blocks from file"""
-        fn = os.path.join(self.storage[-1], "cache")
-        # TODO: a file lock could be used to ensure file does not change
-        #  between re-read and write; but occasional duplicated reads ok.
-        cache = self.cached_files[-1]
-        if os.path.exists(fn):
-            with open(fn, "rb") as f:
-                cached_files = pickle.load(f)
-            for k, c in cached_files.items():
-                if k in cache:
-                    if c["blocks"] is True or cache[k]["blocks"] is True:
-                        c["blocks"] = True
-                    else:
-                        # self.cached_files[*][*]["blocks"] must continue to
-                        # point to the same set object so that updates
-                        # performed by MMapCache are propagated back to
-                        # self.cached_files.
-                        blocks = cache[k]["blocks"]
-                        blocks.update(c["blocks"])
-                        c["blocks"] = blocks
-                    c["time"] = max(c["time"], cache[k]["time"])
-                    c["uid"] = cache[k]["uid"]
-
-            # Files can be added to cache after it was written once
-            for k, c in cache.items():
-                if k not in cached_files:
-                    cached_files[k] = c
-        else:
-            cached_files = cache
-        cache = {k: v.copy() for k, v in cached_files.items()}
-        for c in cache.values():
-            if isinstance(c["blocks"], set):
-                c["blocks"] = list(c["blocks"])
         self._mkcache()
-        with atomic_write(fn) as f:
-            pickle.dump(cache, f)
-        self.cached_files[-1] = cached_files
+        self._metadata.save()
         self.last_cache = time.time()
 
     def _check_cache(self):
@@ -228,25 +182,17 @@ class CachingFileSystem(AbstractFileSystem):
     def _check_file(self, path):
         """Is path in cache and still valid"""
         path = self._strip_protocol(path)
-
         self._check_cache()
-        for storage, cache in zip(self.storage, self.cached_files):
-            if path not in cache:
-                continue
-            detail = cache[path].copy()
-            if self.check_files:
-                if detail["uid"] != self.fs.ukey(path):
-                    continue
-            if self.expiry:
-                if time.time() - detail["time"] > self.expiry:
-                    continue
-            fn = os.path.join(storage, detail["fn"])
-            if os.path.exists(fn):
-                return detail, fn
-        return False
+
+        def ignore(detail: Detail) -> bool:
+            return (self.check_files and detail["uid"] != self.fs.ukey(path)) or (
+                self.expiry and time.time() - detail["time"] > self.expiry
+            )
+
+        return self._metadata.check_file(path, ignore)
 
     def clear_cache(self):
-        """Remove all files and metadat from the cache
+        """Remove all files and metadata from the cache
 
         In the case of multiple cache locations, this clears only the last one,
         which is assumed to be the read/write one.
@@ -273,23 +219,11 @@ class CachingFileSystem(AbstractFileSystem):
 
         self._check_cache()
 
-        for path, detail in self.cached_files[-1].copy().items():
-            if time.time() - detail["time"] > expiry_time:
-                fn = detail.get("fn", "")
-                if not fn:
-                    raise RuntimeError(
-                        f"Cache metadata does not contain 'fn' for {path}"
-                    )
-                fn = os.path.join(self.storage[-1], fn)
-                if os.path.exists(fn):
-                    os.remove(fn)
-                    self.cached_files[-1].pop(path)
+        for fn in self._metadata.clear_expired(expiry_time):
+            if os.path.exists(fn):
+                os.remove(fn)
 
-        if self.cached_files[-1]:
-            cache_path = os.path.join(self.storage[-1], "cache")
-            with atomic_write(cache_path) as fc:
-                pickle.dump(self.cached_files[-1], fc)
-        else:
+        if self._metadata.empty():
             rmtree(self.storage[-1])
             self.load_cache()
 
@@ -301,19 +235,7 @@ class CachingFileSystem(AbstractFileSystem):
         raises PermissionError
         """
         path = self._strip_protocol(path)
-        details = self._check_file(path)
-        if not details:
-            return
-        _, fn = details
-        if fn.startswith(self.storage[-1]):
-            # is in in writable cache
-            os.remove(fn)
-            self.cached_files[-1].pop(path)
-            self.save_cache()
-        else:
-            raise PermissionError(
-                "Can only delete cached file in last, writable cache location"
-            )
+        self._metadata.pop_file(path)
 
     def _open(
         self,
@@ -370,7 +292,7 @@ class CachingFileSystem(AbstractFileSystem):
                 "time": time.time(),
                 "uid": self.fs.ukey(path),
             }
-            self.cached_files[-1][path] = detail
+            self._metadata.update_file(path, detail)
             logger.debug("Creating local sparse file for %s" % path)
 
         # call target filesystems open
@@ -416,10 +338,7 @@ class CachingFileSystem(AbstractFileSystem):
         if f.closed:
             return
         path = self._strip_protocol(f.path)
-
-        c = self.cached_files[-1][path]
-        if c["blocks"] is not True and len(c["blocks"]) * f.blocksize >= f.size:
-            c["blocks"] = True
+        self._metadata.close_file(f, path)
         try:
             logger.debug("going to save")
             self.save_cache()
@@ -588,9 +507,8 @@ class WholeFileCacheFileSystem(CachingFileSystem):
                 }
                 for path in downpath
             ]
-            self.cached_files[-1].update(
-                {path: detail for path, detail in zip(downpath, newdetail)}
-            )
+            for path, detail in zip(downpath, newdetail):
+                self._metadata.update_file(path, detail)
             self.save_cache()
 
         def firstpart(fn):
@@ -622,7 +540,7 @@ class WholeFileCacheFileSystem(CachingFileSystem):
             "time": time.time(),
             "uid": self.fs.ukey(path),
         }
-        self.cached_files[-1][path] = detail
+        self._metadata.update_file(path, detail)
         logger.debug("Copying %s to local cache" % path)
         return fn
 
@@ -750,7 +668,6 @@ class SimpleCacheFileSystem(WholeFileCacheFileSystem):
         for storage in self.storage:
             if not os.path.exists(storage):
                 os.makedirs(storage, exist_ok=True)
-        self.cached_files = [{}]
 
     def _check_file(self, path):
         self._check_cache()
@@ -859,24 +776,3 @@ class LocalTempFile:
 
     def __getattr__(self, item):
         return getattr(self.fh, item)
-
-
-@contextlib.contextmanager
-def atomic_write(path, mode="wb"):
-    """
-    A context manager that opens a temporary file next to `path` and, on exit,
-    replaces `path` with the temporary file, thereby updating `path`
-    atomically.
-    """
-    fd, fn = tempfile.mkstemp(
-        dir=os.path.dirname(path), prefix=os.path.basename(path) + "-"
-    )
-    try:
-        with open(fd, mode) as fp:
-            yield fp
-    except BaseException:
-        with contextlib.suppress(FileNotFoundError):
-            os.unlink(fn)
-        raise
-    else:
-        os.replace(fn, path)

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -537,14 +537,15 @@ def test_metadata_save_blocked(ftp_writable, caplog):
         raise NameError
 
     try:
-
+        # To simulate an interpreter shutdown we temporarily set an open function in the
+        # cache_metadata module which is used on the next attempt to save metadata.
         with caplog.at_level(logging.DEBUG):
             with fs.open("/one", block_size=20) as f:
-                fsspec.implementations.cached.open = open_raise
+                fsspec.implementations.cache_metadata.open = open_raise
                 f.seek(21)
                 assert f.read(1)
     finally:
-        fsspec.implementations.cached.__dict__.pop("open", None)
+        fsspec.implementations.cache_metadata.__dict__.pop("open", None)
     assert "Cache save failed due to interpreter shutdown" in caplog.text
 
 

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -128,7 +128,7 @@ def test_metadata(tmpdir, cache_mapper):
         assert f.read(5) == b"test"
 
     afile_posix = make_path_posix(afile)
-    detail = fs.cached_files[0][afile_posix]
+    detail = fs._metadata.cached_files[0][afile_posix]
     assert sorted(detail.keys()) == ["blocks", "fn", "original", "time", "uid"]
     assert isinstance(detail["blocks"], bool)
     assert isinstance(detail["fn"], str)
@@ -225,9 +225,9 @@ def test_workflow(ftp_writable, impl):
     with fs.open("/out") as f:
         assert os.listdir(fs.storage[-1])
         assert f.read() == b"test"
-        assert fs.cached_files[-1]["/out"]["blocks"]
+        assert fs._metadata.cached_files[-1]["/out"]["blocks"]
     assert fs.cat("/out") == b"test"
-    assert fs.cached_files[-1]["/out"]["blocks"] is True
+    assert fs._metadata.cached_files[-1]["/out"]["blocks"] is True
 
     with fs.open("/out", "wb") as f:
         f.write(b"changed")
@@ -499,13 +499,13 @@ def test_blockcache_multiinstance(ftp_writable):
         skip_instance_cache=True,
         cache_storage=fs.storage,
     )
-    assert fs2.cached_files  # loaded from metadata for "one"
+    assert fs2._metadata.cached_files  # loaded from metadata for "one"
     with fs2.open("/two", block_size=20) as f:
         assert f.read(1) == b"t"
-    assert "/two" in fs2.cached_files[-1]
+    assert "/two" in fs2._metadata.cached_files[-1]
     fs.save_cache()
-    assert list(fs.cached_files[-1]) == ["/one", "/two"]
-    assert list(fs2.cached_files[-1]) == ["/one", "/two"]
+    assert list(fs._metadata.cached_files[-1]) == ["/one", "/two"]
+    assert list(fs2._metadata.cached_files[-1]) == ["/one", "/two"]
 
 
 def test_metadata_save_blocked(ftp_writable, caplog):
@@ -611,7 +611,7 @@ def test_local_filecache_basic(local_filecache):
     assert "cache" in os.listdir(cache_location)
 
     # the file in the location contains the right data
-    fn = list(fs.cached_files[-1].values())[0]["fn"]  # this is a hash value
+    fn = list(fs._metadata.cached_files[-1].values())[0]["fn"]  # this is a hash value
     assert fn in os.listdir(cache_location)
     with open(os.path.join(cache_location, fn), "rb") as f:
         assert f.read() == data
@@ -656,7 +656,7 @@ def test_local_filecache_gets_from_original_if_cache_deleted(local_filecache):
         assert f.read() == new_data
 
     # the file in the location contains the right data
-    fn = list(fs.cached_files[-1].values())[0]["fn"]  # this is a hash value
+    fn = list(fs._metadata.cached_files[-1].values())[0]["fn"]  # this is a hash value
     assert fn in os.listdir(cache_location)
     with open(os.path.join(cache_location, fn), "rb") as f:
         assert f.read() == new_data
@@ -679,7 +679,9 @@ def test_local_filecache_with_new_cache_location_makes_a_new_copy(local_filecach
         assert f.read() == data
 
     # the file in the location contains the right data
-    fn = list(new_fs.cached_files[-1].values())[0]["fn"]  # this is a hash value
+    fn = list(new_fs._metadata.cached_files[-1].values())[0][
+        "fn"
+    ]  # this is a hash value
     assert fn in os.listdir(old_cache_location)
     assert fn in os.listdir(new_cache_location)
 
@@ -815,7 +817,7 @@ def test_add_file_to_cache_after_save(local_filecache):
     fs.save_cache()
 
     fs.cat(original_file)
-    assert len(fs.cached_files[-1]) == 1
+    assert len(fs._metadata.cached_files[-1]) == 1
 
     fs.save_cache()
 
@@ -825,7 +827,7 @@ def test_add_file_to_cache_after_save(local_filecache):
         cache_storage=cache_location,
         do_not_use_cache_for_this_instance=True,  # cache is masking the issue
     )
-    assert len(fs2.cached_files[-1]) == 1
+    assert len(fs2._metadata.cached_files[-1]) == 1
 
 
 def test_cached_open_close_read(ftp_writable):
@@ -844,7 +846,7 @@ def test_cached_open_close_read(ftp_writable):
     with fs.open("/out_block", block_size=1024) as f:
         assert f.read(1) == b"t"
     # Regression test for <https://github.com/fsspec/filesystem_spec/issues/845>
-    assert fs.cached_files[-1]["/out_block"]["blocks"] == {0}
+    assert fs._metadata.cached_files[-1]["/out_block"]["blocks"] == {0}
 
 
 @pytest.mark.parametrize("impl", ["filecache", "simplecache"])
@@ -1017,7 +1019,7 @@ def test_expiry():
     # get file
     assert fs._check_file(fn0) is False
     assert fs.open(fn0, mode="rb").read() == data
-    start_time = fs.cached_files[-1][fn]["time"]
+    start_time = fs._metadata.cached_files[-1][fn]["time"]
 
     # cache time..
     assert fs.last_cache - start_time < 0.19


### PR DESCRIPTION
This PR moves handling of cache metadata out of the `CachingFileSystem` and into a new class `CacheMetadata`. The idea is for the metadata handling occur in one place so that we can easily modify and/or extend it in future PRs, e.g. to change the storage format or location.

Essentially `cached_files` used to be a property of `CacheMetadata` but is now a property of the new class. Both `CachingFileSystem` and `CacheMetadata` need access to the `storage` locations, so this is shared between them.

There is no functional change here. The only changes to the tests are due to the change in where the private `cached_files` are stored. There is one failing test that I haven't yet fixed, it is `test_metadata_save_blocked` and is something to do with the hot-swapping of the `open` function that I don't fully understand.