### PR TITLE
Correct capitalization of XetHub

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,7 +52,7 @@ The following libraries use ``fsspec`` internally for path and file handling:
 #. `Kedro`_, a Python framework for reproducible,
    maintainable and modular data science code
 #. `pyxet`_, a Python library for mounting and
-   accessing very large datasets from Xethub
+   accessing very large datasets from XetHub
 
 ``fsspec`` filesystems are also supported by:
 


### PR DESCRIPTION
Sorry -- a nitpicky PR that fixes the capitalization of XetHub