### PR TITLE
Allow file mode="x" with get_fs_token_paths

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -635,6 +635,8 @@ def get_fs_token_paths(
     else:
         if "w" in mode and expand:
             paths = _expand_paths(paths, name_function, num)
+        elif "x" in mode and expand:
+            paths = _expand_paths(paths, name_function, num)
         elif "*" in paths:
             paths = [f for f in sorted(fs.glob(paths)) if not fs.isdir(f)]
         else:

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -13,6 +13,7 @@ from fsspec.core import (
     _expand_paths,
     expand_paths_if_needed,
     get_compression,
+    get_fs_token_paths,
     open_files,
     open_local,
 )
@@ -73,6 +74,11 @@ def test_expand_paths_if_needed_in_read_mode(create_files, path, out):
 def test_expand_error():
     with pytest.raises(ValueError):
         _expand_paths("*.*", None, 1)
+
+
+@pytest.mark.parametrize("mode", ["w", "w+", "x", "x+"])
+def test_expand_fs_token_paths(mode):
+    assert len(get_fs_token_paths("path", mode, num=2, expand=True)[-1]) == 2
 
 
 def test_openfile_api(m):


### PR DESCRIPTION
Closes https://github.com/fsspec/filesystem_spec/issues/1332
Related: https://github.com/dask/dask/issues/10442

fsspec does not always behave correctly when file mode="x" is used. This PR addresses one particular instance that is causing flow-on problems for dask.