### PR TITLE
Add lakefs-spec as known implementation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -208,7 +208,8 @@ Other Known Implementations
 - `dvc`_ to access DVC/Git repository as a filesystem
 - `gcsfs`_ for Google Cloud Storage
 - `gdrive`_ to access Google Drive and shares (experimental)
-- `huggingface_hub` to access the Hugging Face Hub filesystem, with protocol "hf://"
+- `huggingface_hub`_ to access the Hugging Face Hub filesystem, with protocol "hf://"
+- `lakefs`_ for lakeFS data lakes
 - `ocifs`_ for access to Oracle Cloud Object Storage
 - `ossfs`_ for Alibaba Cloud (Aliyun) Object Storage System (OSS)
 - `s3fs`_ for Amazon S3 and other compatible stores
@@ -223,6 +224,7 @@ Other Known Implementations
 .. _gcsfs: https://gcsfs.readthedocs.io/en/latest/
 .. _gdrive: https://github.com/fsspec/gdrivefs
 .. _huggingface_hub: https://huggingface.co/docs/huggingface_hub/main/en/guides/hf_file_system
+.. _lakefs: https://github.com/appliedAI-Initiative/lakefs-spec
 .. _ocifs: https://pypi.org/project/ocifs
 .. _ossfs: https://github.com/fsspec/ossfs
 .. _s3fs: https://s3fs.readthedocs.io/en/latest/


### PR DESCRIPTION
The [lakefs-spec](https://github.com/appliedAI-Initiative/lakefs-spec) package provides access to lakeFS data lakes through an fsspec filesystem.

This commit adds a link to the list of known implementations in the API docs and in `fsspec.registry.known_implementations`.