### PR TITLE
Working async rsync

### DIFF
--- a/fsspec/generic.py
+++ b/fsspec/generic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import logging
 import os
@@ -315,11 +317,15 @@ class GenericFileSystem(AsyncFileSystem):
         self,
         url: list[str],
         url2: list[str],
+        recursive=False,
+        on_error=None,
+        maxdepth=None,
+        batch_size=None,
         tempdir=None,
-        batch_size=20,
-        on_error="ignore",
         **kwargs,
     ):
+        if recursive:
+            raise NotImplementedError
         fs = _resolve_fs(url[0], self.method)
         fs2 = _resolve_fs(url2[0], self.method)
         # not expanding paths atm., assume call is from rsync()

--- a/fsspec/generic.py
+++ b/fsspec/generic.py
@@ -180,11 +180,11 @@ class GenericFileSystem(AsyncFileSystem):
         fs = _resolve_fs(path, self.method)
         if fs.async_impl:
             out = await fs._find(
-                path, maxdepth=maxdepth, withdirs=withdirs, detail=detail, **kwargs
+                path, maxdepth=maxdepth, withdirs=withdirs, detail=True, **kwargs
             )
         else:
             out = fs.find(
-                path, maxdepth=maxdepth, withdirs=withdirs, detail=detail, **kwargs
+                path, maxdepth=maxdepth, withdirs=withdirs, detail=True, **kwargs
             )
         result = {}
         for k, v in out.items():

--- a/fsspec/generic.py
+++ b/fsspec/generic.py
@@ -84,8 +84,8 @@ def rsync(
         to make downstream file system instances from paths.
     """
     fs = fs or GenericFileSystem(**(inst_kwargs or {}))
-    source = fs._strip_protocol(source).rstrip("/")
-    destination = fs._strip_protocol(destination).rstrip("/")
+    source = fs._strip_protocol(source)
+    destination = fs._strip_protocol(destination)
     allfiles = fs.find(source, withdirs=True, detail=True)
     if not fs.isdir(source):
         raise ValueError("Can only rsync on a directory")

--- a/fsspec/tests/test_generic.py
+++ b/fsspec/tests/test_generic.py
@@ -29,7 +29,7 @@ def test_touch_rm(m):
 def test_cp_async_to_sync(server, m):
     fsspec.filesystem("http", headers={"give_length": "true", "head_ok": "true"})
     fs = fsspec.filesystem("generic", default_method="current")
-    fs.cp(server + "/index/realfile", "memory://realfile")
+    fs.cp([server + "/index/realfile"], ["memory://realfile"])
     assert m.cat("realfile") == data
 
     fs.rm("memory://realfile")


### PR DESCRIPTION
Fixes async-async and sync-async copying for generic/rsync by using local files to buffer whole remote files.

If one of the filesystems actually *is* the local filesystem, this would mean duplication of space and operations for now :|