### PR TITLE
Add ocilake as known implementation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -211,6 +211,7 @@ Other Known Implementations
 - `huggingface_hub`_ to access the Hugging Face Hub filesystem, with protocol "hf://"
 - `lakefs`_ for lakeFS data lakes
 - `ocifs`_ for access to Oracle Cloud Object Storage
+- `ocilake`_ for OCI Lake storage
 - `ossfs`_ for Alibaba Cloud (Aliyun) Object Storage System (OSS)
 - `s3fs`_ for Amazon S3 and other compatible stores
 - `wandbfs`_ to access Wandb run data (experimental)
@@ -226,6 +227,7 @@ Other Known Implementations
 .. _huggingface_hub: https://huggingface.co/docs/huggingface_hub/main/en/guides/hf_file_system
 .. _lakefs: https://github.com/appliedAI-Initiative/lakefs-spec
 .. _ocifs: https://pypi.org/project/ocifs
+.. _ocilake: https://github.com/oracle/ocifs
 .. _ossfs: https://github.com/fsspec/ossfs
 .. _s3fs: https://s3fs.readthedocs.io/en/latest/
 .. _wandbfs: https://github.com/jkulhanek/wandbfs

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -211,7 +211,7 @@ Other Known Implementations
 - `huggingface_hub`_ to access the Hugging Face Hub filesystem, with protocol "hf://"
 - `lakefs`_ for lakeFS data lakes
 - `ocifs`_ for access to Oracle Cloud Object Storage
-- `ocilake`_ for OCI Lake storage
+- `ocilake`_ for OCI Data Lake storage
 - `ossfs`_ for Alibaba Cloud (Aliyun) Object Storage System (OSS)
 - `s3fs`_ for Amazon S3 and other compatible stores
 - `wandbfs`_ to access Wandb run data (experimental)

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -119,6 +119,10 @@ known_implementations = {
         "class": "ocifs.OCIFileSystem",
         "err": "Install ocifs to access OCI Object Storage",
     },
+    "ocilake": {
+        "class": "ocifs.OCIFileSystem",
+        "err": "Install ocifs to access OCI Lake",
+    },
     "asynclocal": {
         "class": "morefs.asyn_local.AsyncLocalFileSystem",
         "err": "Install 'morefs[asynclocalfs]' to use AsyncLocalFileSystem",

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -121,7 +121,7 @@ known_implementations = {
     },
     "ocilake": {
         "class": "ocifs.OCIFileSystem",
-        "err": "Install ocifs to access OCI Lake",
+        "err": "Install ocifs to access OCI Data Lake",
     },
     "asynclocal": {
         "class": "morefs.asyn_local.AsyncLocalFileSystem",


### PR DESCRIPTION
* docs: Add ocilake as known implementation

The ocilake package provides access to oci data lakes through an fsspec filesystem.

This commit adds a link to the list of known implementations in the API docs.

* Add ocilake to fsspec.registry.known_implementations