### PR TITLE
Avoid expanding paths when source and destination are lists

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -346,7 +346,7 @@ class AsyncFileSystem(AbstractFileSystem):
 
         if isinstance(path1, list) and isinstance(path2, list):
             # No need to expand paths when both source and destination
-            # are provided as string
+            # are provided as lists
             paths1 = path1
             paths2 = path2
         else:
@@ -516,7 +516,7 @@ class AsyncFileSystem(AbstractFileSystem):
         """
         if isinstance(lpath, list) and isinstance(rpath, list):
             # No need to expand paths when both source and destination
-            # are provided as string
+            # are provided as lists
             rpaths = rpath
             lpaths = lpath
         else:
@@ -593,7 +593,7 @@ class AsyncFileSystem(AbstractFileSystem):
         """
         if isinstance(lpath, list) and isinstance(rpath, list):
             # No need to expand paths when both source and destination
-            # are provided as string
+            # are provided as lists
             rpaths = rpath
             lpaths = lpath
         else:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -940,7 +940,7 @@ class AbstractFileSystem(metaclass=_Cached):
         """
         if isinstance(lpath, list) and isinstance(rpath, list):
             # No need to expand paths when both source and destination
-            # are provided as string
+            # are provided as lists
             rpaths = rpath
             lpaths = lpath
         else:
@@ -1021,7 +1021,7 @@ class AbstractFileSystem(metaclass=_Cached):
         """
         if isinstance(lpath, list) and isinstance(rpath, list):
             # No need to expand paths when both source and destination
-            # are provided as string
+            # are provided as lists
             rpaths = rpath
             lpaths = lpath
         else:
@@ -1099,7 +1099,7 @@ class AbstractFileSystem(metaclass=_Cached):
 
         if isinstance(path1, list) and isinstance(path2, list):
             # No need to expand paths when both source and destination
-            # are provided as string
+            # are provided as lists
             paths1 = path1
             paths2 = path2
         else:

--- a/fsspec/tests/abstract/copy.py
+++ b/fsspec/tests/abstract/copy.py
@@ -1,3 +1,4 @@
+from hashlib import md5
 from itertools import product
 
 import pytest
@@ -518,3 +519,25 @@ class AbstractCopyTests:
         assert fs.isdir(fs_join(target, "subdir"))
         assert fs.isfile(fs_join(target, "subdir", "subfile.txt"))
         assert fs.isfile(fs_join(target, "subdir.txt"))
+
+    def test_copy_with_source_and_destination_as_list(
+        self, fs, fs_target, fs_join, fs_10_files_with_hashed_names
+    ):
+        # Create the test dir
+        source = fs_10_files_with_hashed_names
+        target = fs_target
+
+        # Create list of files for source and destination
+        source_files = []
+        destination_files = []
+        for i in range(10):
+            hashed_i = md5(str(i).encode("utf-8")).hexdigest()
+            source_files.append(fs_join(source, f"{hashed_i}.txt"))
+            destination_files.append(fs_join(target, f"{hashed_i}.txt"))
+
+        # Copy and assert order was kept
+        fs.copy(path1=source_files, path2=destination_files)
+
+        for i in range(10):
+            file_content = fs.cat(destination_files[i]).decode("utf-8")
+            assert file_content == str(i)

--- a/fsspec/tests/abstract/get.py
+++ b/fsspec/tests/abstract/get.py
@@ -575,7 +575,9 @@ class AbstractGetTests:
         for i in range(10):
             hashed_i = md5(str(i).encode("utf-8")).hexdigest()
             source_files.append(fs_join(source, f"{hashed_i}.txt"))
-            destination_files.append(local_join(target, f"{hashed_i}.txt"))
+            destination_files.append(
+                make_path_posix(local_join(target, f"{hashed_i}.txt"))
+            )
 
         # Copy and assert order was kept
         fs.get(rpath=source_files, lpath=destination_files)

--- a/fsspec/tests/abstract/get.py
+++ b/fsspec/tests/abstract/get.py
@@ -1,3 +1,4 @@
+from hashlib import md5
 from itertools import product
 
 import pytest
@@ -554,3 +555,31 @@ class AbstractGetTests:
         assert local_fs.isdir(local_join(target, "subdir"))
         assert local_fs.isfile(local_join(target, "subdir", "subfile.txt"))
         assert local_fs.isfile(local_join(target, "subdir.txt"))
+
+    def test_get_with_source_and_destination_as_list(
+        self,
+        fs,
+        fs_join,
+        local_fs,
+        local_join,
+        local_target,
+        fs_10_files_with_hashed_names,
+    ):
+        # Create the test dir
+        source = fs_10_files_with_hashed_names
+        target = local_target
+
+        # Create list of files for source and destination
+        source_files = []
+        destination_files = []
+        for i in range(10):
+            hashed_i = md5(str(i).encode("utf-8")).hexdigest()
+            source_files.append(fs_join(source, f"{hashed_i}.txt"))
+            destination_files.append(local_join(target, f"{hashed_i}.txt"))
+
+        # Copy and assert order was kept
+        fs.get(rpath=source_files, lpath=destination_files)
+
+        for i in range(10):
+            file_content = local_fs.cat(destination_files[i]).decode("utf-8")
+            assert file_content == str(i)

--- a/fsspec/tests/abstract/put.py
+++ b/fsspec/tests/abstract/put.py
@@ -1,3 +1,4 @@
+from hashlib import md5
 from itertools import product
 
 import pytest
@@ -552,3 +553,25 @@ class AbstractPutTests:
         assert fs.isdir(fs_join(fs_target, "subdir"))
         assert fs.isfile(fs_join(fs_target, "subdir", "subfile.txt"))
         assert fs.isfile(fs_join(fs_target, "subdir.txt"))
+
+    def test_copy_with_source_and_destination_as_list(
+        self, fs, fs_target, fs_join, local_join, local_10_files_with_hashed_names
+    ):
+        # Create the test dir
+        source = local_10_files_with_hashed_names
+        target = fs_target
+
+        # Create list of files for source and destination
+        source_files = []
+        destination_files = []
+        for i in range(10):
+            hashed_i = md5(str(i).encode("utf-8")).hexdigest()
+            source_files.append(local_join(source, f"{hashed_i}.txt"))
+            destination_files.append(fs_join(target, f"{hashed_i}.txt"))
+
+        # Copy and assert order was kept
+        fs.put(lpath=source_files, rpath=destination_files)
+
+        for i in range(10):
+            file_content = fs.cat(destination_files[i]).decode("utf-8")
+            assert file_content == str(i)


### PR DESCRIPTION
As described in #1347, this PR makes sure that the order between the source and destination are kept when lists are provided.

Closes #1347