### PR TITLE
Save cache metadata in JSON format

### DIFF
--- a/fsspec/implementations/cache_metadata.py
+++ b/fsspec/implementations/cache_metadata.py
@@ -58,7 +58,7 @@ class CacheMetadata:
         try:
             with open(fn, "r") as f:
                 return json.load(f)
-        except Exception:
+        except ValueError:
             with open(fn, "rb") as f:
                 return pickle.load(f)
 

--- a/fsspec/implementations/cache_metadata.py
+++ b/fsspec/implementations/cache_metadata.py
@@ -7,6 +7,12 @@ from typing import TYPE_CHECKING
 
 from fsspec.utils import atomic_write
 
+try:
+    import ujson as json
+except ImportError:
+    if not TYPE_CHECKING:
+        import json
+
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, Literal
 
@@ -23,7 +29,9 @@ class CacheMetadata:
     All reading and writing of cache metadata is performed by this class,
     accessing the cached files and blocks is not.
 
-    Metadata is stored in a single file per storage directory, pickled.
+    Metadata is stored in a single file per storage directory in JSON format.
+    For backward compatibility, also reads metadata stored in pickle format
+    which is converted to JSON when next saved.
     """
 
     def __init__(self, storage: list[str]):
@@ -41,15 +49,27 @@ class CacheMetadata:
         self._storage = storage
         self.cached_files: list[Detail] = [{}]
 
+        # Private attribute to force saving of metadata in pickle format rather than
+        # JSON for use in tests to confirm can read both pickle and JSON formats.
+        self._force_save_pickle = False
+
     def _load(self, fn: str) -> Detail:
         """Low-level function to load metadata from specific file"""
-        with open(fn, "rb") as f:
-            return pickle.load(f)
+        try:
+            with open(fn, "r") as f:
+                return json.load(f)
+        except Exception:
+            with open(fn, "rb") as f:
+                return pickle.load(f)
 
     def _save(self, metadata_to_save: Detail, fn: str) -> None:
         """Low-level function to save metadata to specific file"""
-        with atomic_write(fn) as f:
-            pickle.dump(metadata_to_save, f)
+        if self._force_save_pickle:
+            with atomic_write(fn) as f:
+                pickle.dump(metadata_to_save, f)
+        else:
+            with atomic_write(fn, mode="w") as f:
+                json.dump(metadata_to_save, f)
 
     def _scan_locations(
         self, writable_only: bool = False

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -170,7 +170,7 @@ def test_metadata_replace_pickle_with_json(tmpdir):
     cache_fn = os.path.join(fs.storage[-1], "cache")
     with open(cache_fn, "rb") as f:
         metadata = pickle.load(f)
-    assert list(metadata.keys()) == [afile]
+    assert list(metadata.keys()) == [make_path_posix(afile)]
 
     # Force rewrite of metadata, now in json format
     fs._metadata._force_save_pickle = False
@@ -181,7 +181,7 @@ def test_metadata_replace_pickle_with_json(tmpdir):
     # Confirm metadata is in json format
     with open(cache_fn, "r") as f:
         metadata = json.load(f)
-    assert list(metadata.keys()) == [afile]
+    assert list(metadata.keys()) == [make_path_posix(afile)]
 
 
 def test_constructor_kwargs(tmpdir):


### PR DESCRIPTION
This changes the file format used for storing cached metadata from pickle to JSON. It eliminates the problem that pickled files written using one version of Python might not be readable using a different version of python, and an extra benefit is that such files are now human readable so easier to understand/debug.

All loading and saving of cache metadata is now performed in specific low-level functions `CacheMetadata._load` and `CacheMetadata._save`.

We still support the reading of cached metadata from pickled files so that pre-existing caches should still be usable. Such files will be saved as JSON the next time they are saved.

The implementation uses `ujson` if it is installed, falling back to `json`. This is the same approach used in `ReferenceFileSystem`.

The only slight complexity here is that we have to test both JSON and pickle formats in CI, so I have added a private boolean attribute `CacheMetadata._force_save_pickle`. This should only be used in tests, not by end users. If set to `True` subsequent saves are in pickle format so we can simulate old pickled metadata to confirm it can still be read and is converted to JSON on next save.

Fixes #825.