### PR TITLE
Automatically delete temporary file cache

### DIFF
--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -1117,7 +1117,10 @@ def test_getitems_errors(tmpdir):
         m.getitems(["afile", "bfile"])
 
 
-def task_cache_dir_auto_deleted(tmpdir, cache_storage, queue):
+@pytest.mark.parametrize("temp_cache", [False, True])
+def test_cache_dir_auto_deleted(temp_cache, tmpdir):
+    import gc
+
     source = os.path.join(tmpdir, "source")
     afile = os.path.join(source, "afile")
     os.mkdir(source)
@@ -1126,7 +1129,8 @@ def task_cache_dir_auto_deleted(tmpdir, cache_storage, queue):
     fs = fsspec.filesystem(
         "filecache",
         target_protocol="file",
-        cache_storage=cache_storage,
+        cache_storage="TMP" if temp_cache else os.path.join(tmpdir, "cache"),
+        skip_instance_cache=True,  # Important to avoid fs itself being cached
     )
 
     cache_dir = fs.storage[-1]
@@ -1139,24 +1143,11 @@ def task_cache_dir_auto_deleted(tmpdir, cache_storage, queue):
     local = fsspec.filesystem("file")
     assert local.exists(cache_dir)
 
-    queue.put(cache_dir)
+    # Delete file system
+    del fs
+    gc.collect()
 
-
-@pytest.mark.parametrize("temp_cache", [False, True])
-def test_cache_dir_auto_deleted(temp_cache, tmpdir):
-    # Run cache creation in separate process to ensure it is deleted
-    import multiprocessing as mp
-
-    queue = mp.SimpleQueue()
-    cache_storage = "TMP" if temp_cache else os.path.join(tmpdir, "cache")
-    process = mp.Process(
-        target=task_cache_dir_auto_deleted, args=(tmpdir, cache_storage, queue)
-    )
-    process.start()
-    process.join()
-
-    cache_dir = queue.get()
-    local = fsspec.filesystem("file")
+    # Ensure cache has been deleted, if it is temporary
     if temp_cache:
         assert not local.exists(cache_dir)
     else:


### PR DESCRIPTION
Fixes #1118.

This links the lifetime of a temporary file cache (obtained using `"TMP"` in `fsspec.filesystem("filecache", cache_storage="TMP"`) to that of the cache filesystem instance. If a specific `cache_storage` location is specified then the behaviour is unchanged and the cache persists.

It is implemented using `weakref.finalize` on the `CachingFileSystem` instance.

To test this I am running the cache creation within a separate process to ensure that the filesystem is deleted at the end. I was surprised this was necessary as I assumed that `del fs` followed by `gc.collect()` would ensure the filesystem was deleted, but this does not seem to be the case. This might be a misunderstanding on my part of how it all works.