### PR TITLE
kwargs widget should be initialized with parameter

### DIFF
--- a/fsspec/gui.py
+++ b/fsspec/gui.py
@@ -262,7 +262,9 @@ class FileSelector(SigSlot):
             name="protocol",
             align="center",
         )
-        self.kwargs = pn.widgets.TextInput(name="kwargs", value=self.init_kwargs, align="center")
+        self.kwargs = pn.widgets.TextInput(
+            name="kwargs", value=self.init_kwargs, align="center"
+        )
         self.go = pn.widgets.Button(name="⇨", align="end", width=45)
         self.main = SingleSelect(size=10)
         self.home = pn.widgets.Button(name="🏠", width=40, height=30, align="end")

--- a/fsspec/gui.py
+++ b/fsspec/gui.py
@@ -262,7 +262,7 @@ class FileSelector(SigSlot):
             name="protocol",
             align="center",
         )
-        self.kwargs = pn.widgets.TextInput(name="kwargs", value="{}", align="center")
+        self.kwargs = pn.widgets.TextInput(name="kwargs", value=self.init_kwargs, align="center")
         self.go = pn.widgets.Button(name="⇨", align="end", width=45)
         self.main = SingleSelect(size=10)
         self.home = pn.widgets.Button(name="🏠", width=40, height=30, align="end")

--- a/fsspec/tests/test_gui.py
+++ b/fsspec/tests/test_gui.py
@@ -11,10 +11,9 @@ def test_basic():
 
 
 def test_kwargs(tmpdir):
-    """ confirm kwargs are passed to the filesystem instance"""
+    """confirm kwargs are passed to the filesystem instance"""
     import fsspec.gui
 
-    gui = fsspec.gui.FileSelector(f"file://{tmpdir}", 
-                                  kwargs="{'auto_mkdir': True}")
-    
+    gui = fsspec.gui.FileSelector(f"file://{tmpdir}", kwargs="{'auto_mkdir': True}")
+
     assert gui.fs.auto_mkdir

--- a/fsspec/tests/test_gui.py
+++ b/fsspec/tests/test_gui.py
@@ -8,3 +8,13 @@ def test_basic():
 
     gui = fsspec.gui.FileSelector()
     assert "url" in str(gui.panel)
+
+
+def test_kwargs(tmpdir):
+    """ confirm kwargs are passed to the filesystem instance"""
+    import fsspec.gui
+
+    gui = fsspec.gui.FileSelector(f"file://{tmpdir}", 
+                                  kwargs="{'auto_mkdir': True}")
+    
+    assert gui.fs.auto_mkdir


### PR DESCRIPTION
fixes 
[fsspec.gui.FileSelector, doesn't work with remote protocols?](https://github.com/fsspec/filesystem_spec/issues/1359)