### PR TITLE
Use setup-micromamba github action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - uses: actions/checkout@main
       - uses: actions/setup-python@main
+        with:
+          python-version: "3.11"
       - uses: pre-commit/action@main
 
   typecheck:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,8 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/environment-py38.yml
-          extra-specs: python=${{ matrix.PY }}
+          create-args: >-
+            python=${{ matrix.PY }}
 
       - name: Run Tests
         shell: bash -l {0}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup conda
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/environment-py38.yml
           extra-specs: python=${{ matrix.PY }}
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup conda
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/environment-win.yml
 
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup conda
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/environment-typecheck.yml
 
@@ -95,7 +95,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup conda
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/environment-downstream.yml
 
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup conda
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/environment-friends.yml
 


### PR DESCRIPTION
The github action `mamba-org/provision-with-micromamba` is deprecated and the recommendation is to use `mamba-org/setup-micromamba` instead (https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba). This PR follows that recommendation, and also adds a `python-version` to the `lint` github action to suppress another warning.