### PR TITLE
In Python 3, the default source encoding is UTF-8

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # fsspec documentation build configuration file, created by
 # sphinx-quickstart on Mon Jan 15 18:11:02 2018.
 #

--- a/fsspec/implementations/tests/test_smb.py
+++ b/fsspec/implementations/tests/test_smb.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test SMBFileSystem class using a docker container
 """


### PR DESCRIPTION
No need to explictly define the source encoding as UTF-8.