### PR TITLE
Add PyPI downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/fsspec/badges/version.svg)](https://anaconda.org/conda-forge/fsspec)
 ![Build](https://github.com/fsspec/filesystem_spec/workflows/CI/badge.svg)
 [![Docs](https://readthedocs.org/projects/filesystem-spec/badge/?version=latest)](https://filesystem-spec.readthedocs.io/en/latest/?badge=latest)
+[![PyPi downloads](https://img.shields.io/pypi/dm/fsspec?label=pypi%20downloads&style=flat)](https://pepy.tech/project/fsspec)
 
 A specification for pythonic filesystems.
 


### PR DESCRIPTION
This adds a new badge to the README to show the latest number of downloads from PyPI. I remember the figure of 60 million downloads a month being talked about, this badge shows it is now double that.

README renders in light mode as
<img width="697" alt="Screenshot 2023-09-26 at 13 23 33" src="https://github.com/fsspec/filesystem_spec/assets/580326/4b11425b-471d-4b64-9fe2-a9c77ee400dd">

and dark mode as:
<img width="705" alt="Screenshot 2023-09-26 at 13 20 51" src="https://github.com/fsspec/filesystem_spec/assets/580326/ca18318a-d7c5-475d-8bbe-b617f5c30214">

Colours, text, etc, can be easily changed. Clicking on the badge takes you to https://www.pepy.tech/projects/fsspec where you can see the daily downloads by version number.

S3FS has similar numbers, about 115 million a month, GCSFS is about 9 million a month.