### PR TITLE
Implementation of 'local://' URI Scheme Support

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -215,6 +215,10 @@ class LocalFileSystem(AbstractFileSystem):
             path = path[7:]
         elif path.startswith("file:"):
             path = path[5:]
+        elif path.startswith("local://"):
+            path = path[8:]
+        elif path.startswith("local:"):
+            path = path[6:]
         return make_path_posix(path).rstrip("/") or cls.root_marker
 
     def _isfilestore(self):

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -29,7 +29,7 @@ class LocalFileSystem(AbstractFileSystem):
     """
 
     root_marker = "/"
-    protocol = "file"
+    protocol = "file", "local"
     local_file = True
 
     def __init__(self, auto_mkdir=False, **kwargs):

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -408,7 +408,7 @@ def test_fss_has_defaults(m):
 
     fs = fsspec.filesystem("reference", fs={"memory": m}, fo={})
     assert fs.fss["memory"] is m
-    assert fs.fss[None].protocol == "file"
+    assert fs.fss[None].protocol == "file", "local"
 
     fs = fsspec.filesystem("reference", fs={None: m}, fo={})
     assert fs.fss[None] is m

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -408,7 +408,7 @@ def test_fss_has_defaults(m):
 
     fs = fsspec.filesystem("reference", fs={"memory": m}, fo={})
     assert fs.fss["memory"] is m
-    assert fs.fss[None].protocol == "file", "local"
+    assert fs.fss[None].protocol == ("file", "local")
 
     fs = fsspec.filesystem("reference", fs={None: m}, fo={})
     assert fs.fss[None] is m

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -61,6 +61,7 @@ def register_implementation(name, cls, clobber=False, errtxt=None):
 # updated with register_implementation
 known_implementations = {
     "file": {"class": "fsspec.implementations.local.LocalFileSystem"},
+    "local": {"class": "fsspec.implementations.local.LocalFileSystem"},
     "memory": {"class": "fsspec.implementations.memory.MemoryFileSystem"},
     "dropbox": {
         "class": "dropboxdrivefs.DropboxDriveFileSystem",


### PR DESCRIPTION
Added support for the local:// URI scheme. Although it's less ubiquitous than file://, this scheme is employed by key data engineering projects like Apache Spark and Ray.io for local file handling. 

Including this support broadens our software's versatility and adaptability with these projects.

[1] Spark Example -- https://spark.apache.org/docs/latest/submitting-applications.html#advanced-dependency-management:~:text=local%3A%20%2D%20a%20URI%20starting%20with%20local%3A/%20is%20expected%20to%20exist%20as%20a%20local%20file%20on%20each%20worker%20node.%20This%20means%20that%20no%20network%20IO%20will%20be%20incurred%2C%20and%20works%20well%20for%20large%20files/JARs%20that%20are%20pushed%20to%20each%20worker%2C%20or%20shared%20via%20NFS%2C%20GlusterFS%2C%20etc. 
[2] Ray.io example -- https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.write_json.html#:~:text=jsonl%22)%0A%3E%3E%3E-,ds.write_json(%22local%3A///tmp/data%22),-Time%20complexity%3A%20O 
[3] Genera Github Search for "local://" -- https://github.com/search?q=local://&type=code