### PR TITLE
IOError → OSError

### DIFF
--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -113,10 +113,10 @@ class ZipFileSystem(AbstractArchiveFileSystem):
         path = self._strip_protocol(path)
         if "r" in mode and self.mode in set("wa"):
             if self.exists(path):
-                raise IOError("ZipFS can only be open for reading or writing, not both")
+                raise OSError("ZipFS can only be open for reading or writing, not both")
             raise FileNotFoundError(path)
         if "r" in self.mode and "w" in mode:
-            raise IOError("ZipFS can only be open for reading or writing, not both")
+            raise OSError("ZipFS can only be open for reading or writing, not both")
         out = self.zip.open(path, mode.strip("b"))
         if "r" in mode:
             info = self.info(path)


### PR DESCRIPTION
Starting from Python 3.3, `IOError` is an alias of `OSError`:
https://docs.python.org/3/library/exceptions.html#IOError

Strange, for some reason I had left these out in #1279.