### PR TITLE
`.super(C, self)` → `.super()`

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -451,7 +451,7 @@ class KnownPartsOfAFile(BaseCache):
     name = "parts"
 
     def __init__(self, blocksize, fetcher, size, data={}, strict=True, **_):
-        super(KnownPartsOfAFile, self).__init__(blocksize, fetcher, size)
+        super().__init__(blocksize, fetcher, size)
         self.strict = strict
 
         # simple consolidation of contiguous blocks

--- a/fsspec/fuse.py
+++ b/fsspec/fuse.py
@@ -231,7 +231,7 @@ def main(args):
 
     class RawDescriptionArgumentParser(argparse.ArgumentParser):
         def format_help(self):
-            usage = super(RawDescriptionArgumentParser, self).format_help()
+            usage = super().format_help()
             parts = usage.split("\n\n")
             parts[1] = self.description.rstrip()
             return "\n\n".join(parts)

--- a/fsspec/generic.py
+++ b/fsspec/generic.py
@@ -169,7 +169,7 @@ class GenericFileSystem(AsyncFileSystem):
             - "current": takes the most recently instantiated version of each FS
         """
         self.method = default_method
-        super(GenericFileSystem, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _strip_protocol(self, path):
         # normalization only

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -57,7 +57,7 @@ class FTPFileSystem(AbstractFileSystem):
         encoding: str
             Encoding to use for directories and filenames in FTP connection
         """
-        super(FTPFileSystem, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.host = host
         self.port = port
         self.tempdir = tempdir or "/tmp"
@@ -252,7 +252,7 @@ class FTPFileSystem(AbstractFileSystem):
             self.dircache.clear()
         else:
             self.dircache.pop(path, None)
-        super(FTPFileSystem, self).invalidate_cache(path)
+        super().invalidate_cache(path)
 
 
 class TransferDone(Exception):

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -41,7 +41,7 @@ class SFTPFileSystem(AbstractFileSystem):
         """
         if self._cached:
             return
-        super(SFTPFileSystem, self).__init__(**ssh_kwargs)
+        super().__init__(**ssh_kwargs)
         self.temppath = ssh_kwargs.pop("temppath", "/tmp")  # remote temp directory
         self.host = host
         self.ssh_kwargs = ssh_kwargs

--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -103,7 +103,7 @@ class SMBFileSystem(AbstractFileSystem):
             - 'w': Allow other handles to be opened with write access.
             - 'd': Allow other handles to be opened with delete access.
         """
-        super(SMBFileSystem, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.host = host
         self.port = port
         self.username = username

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -935,7 +935,7 @@ class DummyOpenFS(DummyTestFS):
 class BasicCallback(fsspec.Callback):
     def __init__(self, **kwargs):
         self.events = []
-        super(BasicCallback, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def set_size(self, size):
         self.events.append(("set_size", size))
@@ -1009,7 +1009,7 @@ def test_dummy_callbacks_files(tmpdir):
 
 class BranchableCallback(BasicCallback):
     def __init__(self, source, dest=None, events=None, **kwargs):
-        super(BranchableCallback, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if dest:
             self.key = source, dest
         else:


### PR DESCRIPTION
In Python 3, you generally don't need the arguments for `super()` any more – they are inserted automatically ([PEP 3135](https://www.python.org/dev/peps/pep-3135/)).