### PR TITLE
Avoid the Entrypoint overriding if its already registered

### DIFF
--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -48,10 +48,15 @@ def process_entries():
                 specs = eps.select(group="fsspec.specs")
             else:
                 specs = eps.get("fsspec.specs", [])
+            registered_names = {}
             for spec in specs:
                 err_msg = f"Unable to load filesystem from {spec}"
+                name = spec.name
+                if name in registered_names:
+                    continue
+                registered_names[name] = True
                 register_implementation(
-                    spec.name,
+                    name,
                     spec.value.replace(":", "."),
                     errtxt=err_msg,
                     # We take our implementations as the ones to overload with if


### PR DESCRIPTION
When there are multiple entry points for the same protocol the latest entry point comes at the top of the list like below:
```
[EntryPoint(name='abfs', value='mypackage.AzureBlobFileSystem', group='fsspec.specs'),
 EntryPoint(name='abfss', value='mypackage.AzureBlobFileSystem', group='fsspec.specs'),
 EntryPoint(name='abfss', value='adlfs.AzureBlobFileSystem', group='fsspec.specs')]
```
But the process_entries registers the entry points in the order they are in the list, so instead of the top entry, the "last" entry is taking precedence over others. So adding logic to skip the override if a registry is already present for the protocol.

Resolves issue: https://github.com/fsspec/filesystem_spec/issues/922