### PR TITLE
SMB: Remove unexpected kwargs (coming from UPath.rename)

### DIFF
--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -251,6 +251,8 @@ class SMBFileSystem(AbstractFileSystem):
     def mv(self, path1, path2, **kwargs):
         wpath1 = _as_unc_path(self.host, path1)
         wpath2 = _as_unc_path(self.host, path2)
+        kwargs.pop("recursive", None)
+        kwargs.pop("maxdepth", None)
         smbclient.rename(wpath1, wpath2, port=self._port, **kwargs)
 
 

--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -248,11 +248,9 @@ class SMBFileSystem(AbstractFileSystem):
             else:
                 smbclient.remove(wpath, port=self._port)
 
-    def mv(self, path1, path2, **kwargs):
+    def mv(self, path1, path2, recursive=None, maxdepth=None, **kwargs):
         wpath1 = _as_unc_path(self.host, path1)
         wpath2 = _as_unc_path(self.host, path2)
-        kwargs.pop("recursive", None)
-        kwargs.pop("maxdepth", None)
         smbclient.rename(wpath1, wpath2, port=self._port, **kwargs)
 
 

--- a/fsspec/implementations/tests/test_smb.py
+++ b/fsspec/implementations/tests/test_smb.py
@@ -10,7 +10,6 @@ import time
 import pytest
 
 import fsspec
-import fsspec.implementations.smb
 
 pytest.importorskip("smbprotocol")
 
@@ -122,8 +121,6 @@ def test_makedirs_exist_ok(smb_params):
 
 
 def test_rename_from_upath(smb_params):
-    fsmb: fsspec.implementations.smb.SMBFileSystem = fsspec.get_filesystem_class("smb")(
-        **smb_params
-    )
+    fsmb = fsspec.get_filesystem_class("smb")(**smb_params)
     fsmb.makedirs("/home/a/b/c", exist_ok=True)
     fsmb.mv("/home/a/b/c", "/home/a/b/d", recursive=False, maxdepth=None)

--- a/fsspec/implementations/tests/test_smb.py
+++ b/fsspec/implementations/tests/test_smb.py
@@ -10,6 +10,7 @@ import time
 import pytest
 
 import fsspec
+import fsspec.implementations.smb
 
 pytest.importorskip("smbprotocol")
 
@@ -118,3 +119,11 @@ def test_makedirs_exist_ok(smb_params):
     fsmb = fsspec.get_filesystem_class("smb")(**smb_params)
     fsmb.makedirs("/home/a/b/c")
     fsmb.makedirs("/home/a/b/c", exist_ok=True)
+
+
+def test_rename_from_upath(smb_params):
+    fsmb: fsspec.implementations.smb.SMBFileSystem = fsspec.get_filesystem_class("smb")(
+        **smb_params
+    )
+    fsmb.makedirs("/home/a/b/c", exist_ok=True)
+    fsmb.mv("/home/a/b/c", "/home/a/b/d", recursive=False, maxdepth=None)


### PR DESCRIPTION
When using this library through `UPath("smb://host/share/file").rename("other_name")`, I get the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/martin/.local/lib/python3.10/site-packages/upath/core.py", line 511, in rename
    self._accessor.mv(
  File "/home/martin/.local/lib/python3.10/site-packages/upath/core.py", line 94, in mv
    return self._fs.mv(
  File "/home/martin/.local/lib/python3.10/site-packages/fsspec/implementations/smb.py", line 254, in mv
    smbclient.rename(wpath1, wpath2, port=self._port, **kwargs)
  File "/home/martin/.local/lib/python3.10/site-packages/smbclient/_os.py", line 483, in rename
    _rename_information(src, dst, replace_if_exists=False, **kwargs)
  File "/home/martin/.local/lib/python3.10/site-packages/smbclient/_os.py", line 1107, in _rename_information
    dst_raw = SMBRawIO(dst, desired_access=FilePipePrinterAccessMask.FILE_EXECUTE, **raw_args)
  File "/home/martin/.local/lib/python3.10/site-packages/smbclient/_io.py", line 362, in __init__
    tree, fd_path = get_smb_tree(path, **kwargs)
TypeError: get_smb_tree() got an unexpected keyword argument 'recursive'
```

This is due to [UPath calling `mv`](https://github.com/fsspec/universal_pathlib/blob/7e3836d0291539cb9876f3d5590c30eec9fbd228/upath/core.py#L107C1-L113C10) with `recursive=False, maxdepth=None`:

```
        return self._fs.mv(
            self._format_path(path),
            target,
            recursive=recursive,
            maxdepth=maxdepth,
            **kwargs,
        )
```

These are forwarded down to `get_smb_tree` where they are not expected.

There could be interactions with https://github.com/fsspec/filesystem_spec/issues/1335