### PR TITLE
fix the incorrect list of ends for _cat_ranges

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -475,7 +475,7 @@ class AsyncFileSystem(AbstractFileSystem):
             A list of of filepaths on this filesystems
         starts, ends: int or list
             Bytes limits of the read. If using a single int, the same value will be
-            used to read all the specified files.    
+            used to read all the specified files.
         """
         # TODO: on_error
         if max_gap is not None:

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -467,6 +467,16 @@ class AsyncFileSystem(AbstractFileSystem):
         on_error="return",
         **kwargs,
     ):
+        """Get the contents of multiple files
+
+        Parameters
+        ----------
+        paths: list
+            A list of of filepaths on this filesystems
+        starts, ends: int or list
+            Bytes limits of the read. If using a single int, the same value will be
+            used to read all the specified files.    
+        """
         # TODO: on_error
         if max_gap is not None:
             # use utils.merge_offset_ranges
@@ -476,7 +486,7 @@ class AsyncFileSystem(AbstractFileSystem):
         if not isinstance(starts, Iterable):
             starts = [starts] * len(paths)
         if not isinstance(ends, Iterable):
-            ends = [starts] * len(paths)
+            ends = [ends] * len(paths)
         if len(starts) != len(paths) or len(ends) != len(paths):
             raise ValueError
         coros = [

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -467,7 +467,7 @@ class AsyncFileSystem(AbstractFileSystem):
         on_error="return",
         **kwargs,
     ):
-        """Get the contents of multiple files
+        """Get the contents of byte ranges from one or more files
 
         Parameters
         ----------

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -828,7 +828,7 @@ class AbstractFileSystem(metaclass=_Cached):
     def cat_ranges(
         self, paths, starts, ends, max_gap=None, on_error="return", **kwargs
     ):
-        """Get the contents of multiple files
+        """Get the contents of byte ranges from one or more files
 
         Parameters
         ----------

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -828,6 +828,16 @@ class AbstractFileSystem(metaclass=_Cached):
     def cat_ranges(
         self, paths, starts, ends, max_gap=None, on_error="return", **kwargs
     ):
+        """Get the contents of multiple files
+
+        Parameters
+        ----------
+        paths: list
+            A list of of filepaths on this filesystems
+        starts, ends: int or list
+            Bytes limits of the read. If using a single int, the same value will be
+            used to read all the specified files.    
+        """
         if max_gap is not None:
             raise NotImplementedError
         if not isinstance(paths, list):
@@ -835,7 +845,7 @@ class AbstractFileSystem(metaclass=_Cached):
         if not isinstance(starts, list):
             starts = [starts] * len(paths)
         if not isinstance(ends, list):
-            ends = [starts] * len(paths)
+            ends = [ends] * len(paths)
         if len(starts) != len(paths) or len(ends) != len(paths):
             raise ValueError
         out = []

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -836,7 +836,7 @@ class AbstractFileSystem(metaclass=_Cached):
             A list of of filepaths on this filesystems
         starts, ends: int or list
             Bytes limits of the read. If using a single int, the same value will be
-            used to read all the specified files.    
+            used to read all the specified files.
         """
         if max_gap is not None:
             raise NotImplementedError


### PR DESCRIPTION
I think the list of "ends" should come from the argument "ends" if it is not iterable for the function "_cat_ranges".