### PR TITLE
Update webhdfs to support BasicAuth and apply proxy on every call

### DIFF
--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -109,14 +109,14 @@ class WebHDFS(AbstractFileSystem):
                 )
             self.pars["delegation"] = token
         self.user = user
+        self.password = password
 
         if password is not None:
-            if self.user is None:
+            if user is None:
                 raise ValueError(
                     "If passing a password, the user must also be"
                     "set in order to set up the basic-auth"
                 )
-            self.password = password
         else:
             if user is not None:
                 self.pars["user.name"] = user

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -151,7 +151,7 @@ class WebHDFS(AbstractFileSystem):
             )
 
     def _call(self, op, method="get", path=None, data=None, redirect=True, **kwargs):
-        url = self._apply_proxy(self.url) + quote(path or "")
+        url = self._apply_proxy(self.url + quote(path or ""))
         args = kwargs.copy()
         args.update(self.pars)
         args["op"] = op.upper()

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -49,6 +49,7 @@ class WebHDFS(AbstractFileSystem):
         kerberos=False,
         token=None,
         user=None,
+        password=None,
         proxy_to=None,
         kerb_kwargs=None,
         data_proxy=None,
@@ -70,6 +71,9 @@ class WebHDFS(AbstractFileSystem):
             given
         user: str or None
             If given, assert the user name to connect with
+        password: str or None
+            If given, assert the password to use for basic auth. If password
+            is provided, user must be provided also
         proxy_to: str or None
             If given, the user has the authority to proxy, and this value is
             the user in who's name actions are taken

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -109,6 +109,7 @@ class WebHDFS(AbstractFileSystem):
                 )
             self.pars["delegation"] = token
         self.user = user
+
         if password is not None:
             if self.user is None:
                 raise ValueError(
@@ -116,6 +117,10 @@ class WebHDFS(AbstractFileSystem):
                     "set in order to set up the basic-auth"
                 )
             self.password = password
+        else:
+            if user is not None:
+                self.pars["user.name"] = user
+
         if proxy_to is not None:
             self.pars["doas"] = proxy_to
         if kerberos and user is not None:

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -139,6 +139,11 @@ class WebHDFS(AbstractFileSystem):
 
             self.session.auth = HTTPKerberosAuth(**self.kerb_kwargs)
 
+        if "user.name" in self.pars and "password" in self.pars:
+            from requests.auth import HTTPBasicAuth
+
+            self.session.auth = HTTPBasicAuth(self.pars["user.name"], self.pars["password"])
+
     def _call(self, op, method="get", path=None, data=None, redirect=True, **kwargs):
         url = self.url + quote(path or "")
         args = kwargs.copy()

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -110,6 +110,13 @@ class WebHDFS(AbstractFileSystem):
             self.pars["delegation"] = token
         if user is not None:
             self.pars["user.name"] = user
+        if password is not None:
+            if user is None:
+                raise ValueError(
+                    "If passing a password, the user must also be"
+                    "set in order to set up the basic-auth"
+                )
+            self.pars["password"] = password
         if proxy_to is not None:
             self.pars["doas"] = proxy_to
         if kerberos and user is not None:

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -146,9 +146,7 @@ class WebHDFS(AbstractFileSystem):
         if self.user is not None and self.password is not None:
             from requests.auth import HTTPBasicAuth
 
-            self.session.auth = HTTPBasicAuth(
-                self.user, self.password
-            )
+            self.session.auth = HTTPBasicAuth(self.user, self.password)
 
     def _call(self, op, method="get", path=None, data=None, redirect=True, **kwargs):
         url = self._apply_proxy(self.url + quote(path or ""))

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -108,7 +108,7 @@ class WebHDFS(AbstractFileSystem):
                     " token"
                 )
             self.pars["delegation"] = token
-        if self.user = user
+        self.user = user
         if password is not None:
             if self.user is None:
                 raise ValueError(

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -142,7 +142,9 @@ class WebHDFS(AbstractFileSystem):
         if "user.name" in self.pars and "password" in self.pars:
             from requests.auth import HTTPBasicAuth
 
-            self.session.auth = HTTPBasicAuth(self.pars["user.name"], self.pars["password"])
+            self.session.auth = HTTPBasicAuth(
+                self.pars["user.name"], self.pars["password"]
+            )
 
     def _call(self, op, method="get", path=None, data=None, redirect=True, **kwargs):
         url = self.url + quote(path or "")

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -267,7 +267,7 @@ class WebHDFS(AbstractFileSystem):
         """Checksum info of file, giving method and result"""
         out = self._call("GETFILECHECKSUM", path=path, redirect=False)
         if "Location" in out.headers:
-            location = self._apply_proxy(out.headers["Location"])
+            location = out.headers["Location"]
             out2 = self.session.get(location)
             out2.raise_for_status()
             return out2.json()["FileChecksum"]
@@ -430,7 +430,7 @@ class WebHDFile(AbstractBufferedFile):
             op, method = "CREATE", "PUT"
             kwargs["overwrite"] = "true"
         out = self.fs._call(op, method, self.path, redirect=False, **kwargs)
-        location = self.fs._apply_proxy(out.headers["Location"])
+        location = out.headers["Location"]
         if "w" in self.mode:
             # create empty file to append to
             out2 = self.fs.session.put(
@@ -439,7 +439,7 @@ class WebHDFile(AbstractBufferedFile):
             out2.raise_for_status()
             # after creating empty file, change location to append to
             out2 = self.fs._call("APPEND", "POST", self.path, redirect=False, **kwargs)
-            self.location = self.fs._apply_proxy(out2.headers["Location"])
+            self.location = out2.headers["Location"]
 
     def _fetch_range(self, start, end):
         start = max(start, 0)
@@ -452,7 +452,7 @@ class WebHDFile(AbstractBufferedFile):
         out.raise_for_status()
         if "Location" in out.headers:
             location = out.headers["Location"]
-            out2 = self.fs.session.get(self.fs._apply_proxy(location))
+            out2 = self.fs.session.get(location)
             return out2.content
         else:
             return out.content

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -108,15 +108,14 @@ class WebHDFS(AbstractFileSystem):
                     " token"
                 )
             self.pars["delegation"] = token
-        if user is not None:
-            self.pars["user.name"] = user
+        if self.user = user
         if password is not None:
-            if user is None:
+            if self.user is None:
                 raise ValueError(
                     "If passing a password, the user must also be"
                     "set in order to set up the basic-auth"
                 )
-            self.pars["password"] = password
+            self.password = password
         if proxy_to is not None:
             self.pars["doas"] = proxy_to
         if kerberos and user is not None:
@@ -139,11 +138,11 @@ class WebHDFS(AbstractFileSystem):
 
             self.session.auth = HTTPKerberosAuth(**self.kerb_kwargs)
 
-        if "user.name" in self.pars and "password" in self.pars:
+        if self.user is not None and self.password is not None:
             from requests.auth import HTTPBasicAuth
 
             self.session.auth = HTTPBasicAuth(
-                self.pars["user.name"], self.pars["password"]
+                self.user, self.password
             )
 
     def _call(self, op, method="get", path=None, data=None, redirect=True, **kwargs):

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -21,7 +21,7 @@ class WebHDFS(AbstractFileSystem):
     """
     Interface to HDFS over HTTP using the WebHDFS API. Supports also HttpFS gateways.
 
-    Three auth mechanisms are supported:
+    Four auth mechanisms are supported:
 
     insecure: no auth is done, and the user is assumed to be whoever they
         say they are (parameter ``user``), or a predefined value such as
@@ -34,6 +34,8 @@ class WebHDFS(AbstractFileSystem):
         service. Indeed, this client can also generate such tokens when
         not insecure. Note that tokens expire, but can be renewed (by a
         previously specified user) and may allow for proxying.
+    basic-auth: used when both parameter ``user`` and parameter ``password``
+        are provided.
 
     """
 

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -146,7 +146,7 @@ class WebHDFS(AbstractFileSystem):
             )
 
     def _call(self, op, method="get", path=None, data=None, redirect=True, **kwargs):
-        url = self.url + quote(path or "")
+        url = self._apply_proxy(self.url) + quote(path or "")
         args = kwargs.copy()
         args.update(self.pars)
         args["op"] = op.upper()


### PR DESCRIPTION
I am using DVC and I am trying to store my dvc cache on a webHDFS remote. 

Unfortunately, I cannot directly use kerberos authentication and I must use Basic Authentication on a proxy server (which introduces some additional part in the path component of the URL (e.g. instead of /webhdfs/v1   it now becomes /gateway/cluster_name/webhdfs/v1)

I found that the current version of filesystem_spec does not support basic authentication, so this PR will add the support for that.

At the same time, I am using the proxy dictionary/callable argument on every outbound call that is made in the `_call` function.

Would be happy to add additional unit tests, but unfortunately as far as I know the cluster created with the htcluster application does not support basic authentication.

The only thing I could add as test is check whether the right ValueError is raised whenever password is provided, but user is not.

I have tested this code with a modified version of DVC (that allows for the extra parameters) and using this updated version I was able to connect to our WebHDFS server without a problem