### PR TITLE
Fix can_be_local for  pathlib.Path

### DIFF
--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -1,5 +1,6 @@
 import io
 import sys
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -8,6 +9,7 @@ import fsspec.utils
 from fsspec.utils import (
     can_be_local,
     common_prefix,
+    get_protocol,
     infer_storage_options,
     merge_offset_ranges,
     mirror_from,
@@ -336,12 +338,31 @@ def test_log():
 @pytest.mark.parametrize(
     "par",
     [
+        ("afile", "file"),
+        ("file://afile", "file"),
+        ("noproto://afile", "noproto"),
+        ("noproto::stuff", "noproto"),
+        ("simplecache::stuff", "simplecache"),
+        ("simplecache://stuff", "simplecache"),
+        ("s3://afile", "s3"),
+        (Path("afile"), "file"),
+    ],
+)
+def test_get_protocol(par):
+    url, outcome = par
+    assert get_protocol(url) == outcome
+
+
+@pytest.mark.parametrize(
+    "par",
+    [
         ("afile", True),
         ("file://afile", True),
         ("noproto://afile", False),
         ("noproto::stuff", False),
         ("simplecache::stuff", True),
         ("simplecache://stuff", True),
+        (Path("afile"), True),
     ],
 )
 def test_can_local(par):

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -436,6 +436,7 @@ def isfilelike(f: Any) -> TypeGuard[IO[bytes]]:
 
 
 def get_protocol(url: str) -> str:
+    url = stringify_path(url)
     parts = re.split(r"(\:\:|\://)", url, 1)
     if len(parts) > 1:
         return parts[0]


### PR DESCRIPTION
If `can_be_local` is given a `pathlib.Path` it now correctly returns `True`.

- [x] Closes #1399
- [x] Tests added