### PR TITLE
Give file system classes a transaction type, switch to deque

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -110,6 +110,7 @@ class AbstractFileSystem(metaclass=_Cached):
     async_impl = False
     mirror_sync_methods = False
     root_marker = ""  # For some FSs, may require leading '/' or other character
+    transaction_type = Transaction
 
     #: Extra *class attributes* that should be considered when hashing.
     _extra_tokenize_attributes = ()
@@ -236,13 +237,13 @@ class AbstractFileSystem(metaclass=_Cached):
         for the normal and exception cases.
         """
         if self._transaction is None:
-            self._transaction = Transaction(self)
+            self._transaction = self.transaction_type(self)
         return self._transaction
 
     def start_transaction(self):
         """Begin write transaction for deferring files, non-context version"""
         self._intrans = True
-        self._transaction = Transaction(self)
+        self._transaction = self.transaction_type(self)
         return self.transaction
 
     def end_transaction(self):


### PR DESCRIPTION
This means that subclasses of `AbstractFileSystem` need not override the `transaction` property and `start_transaction` function anymore to be able to use custom transaction classes.

Instead, they can just override the newly created `transaction_type` property to achieve the same.

Also changes the base `Transaction`'s file queue to a `collections.deque` to pick up thread safety on `pop` and `append` events.

Finally, returning `self` in the transaction's context entry means that transaction objects can now be access in the enclosing transaction context.

For reviewers:
The `files` member shouldn't need to be flushed anymore on `start`, so this could just be removed?
Also, I am not sure on how to make the transaction type an instance variable, as the keyword arguments all seem to go to the `DirCache`. (Should I just use `kwargs.pop("transaction_type", Transaction)`?)

Addresses part of #1416.