### PR TITLE
Fix inconsistent file mode formatting and comparison (`rb+` changed to `r+b`)

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -111,7 +111,7 @@ class MMapCache(BaseCache):
             fd.write(b"1")
             fd.flush()
         else:
-            fd = open(self.location, "rb+")
+            fd = open(self.location, "r+b")
 
         return mmap.mmap(fd.fileno(), self.size)
 

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -62,14 +62,14 @@ class OpenFile:
     """
 
     def __init__(
-        self,
-        fs,
-        path,
-        mode="rb",
-        compression=None,
-        encoding=None,
-        errors=None,
-        newline=None,
+            self,
+            fs,
+            path,
+            mode="rb",
+            compression=None,
+            encoding=None,
+            errors=None,
+            newline=None,
     ):
         self.fs = fs
         self.path = path
@@ -99,8 +99,6 @@ class OpenFile:
 
     def __enter__(self):
         mode = self.mode.replace("t", "").replace("b", "") + "b"
-        sorting_order = {"r": 0, "w": 1, "a": 2, "b": 3, "+": 4}
-        mode = "".join(sorted(mode, key=lambda c: sorting_order.get(c, float("inf"))))
 
         f = self.fs.open(self.path, mode=mode)
 
@@ -204,18 +202,18 @@ class OpenFiles(list):
 
 
 def open_files(
-    urlpath,
-    mode="rb",
-    compression=None,
-    encoding="utf8",
-    errors=None,
-    name_function=None,
-    num=1,
-    protocol=None,
-    newline=None,
-    auto_mkdir=True,
-    expand=True,
-    **kwargs,
+        urlpath,
+        mode="rb",
+        compression=None,
+        encoding="utf8",
+        errors=None,
+        name_function=None,
+        num=1,
+        protocol=None,
+        newline=None,
+        auto_mkdir=True,
+        expand=True,
+        **kwargs,
 ):
     """Given a path or paths, return a list of ``OpenFile`` objects.
 
@@ -339,8 +337,8 @@ def _un_chain(path, kwargs):
         kw = dict(**extra_kwargs, **kws)
         bit = cls._strip_protocol(bit)
         if (
-            protocol in {"blockcache", "filecache", "simplecache"}
-            and "target_protocol" not in kw
+                protocol in {"blockcache", "filecache", "simplecache"}
+                and "target_protocol" not in kw
         ):
             bit = previous_bit
         out.append((bit, protocol, kw))
@@ -399,14 +397,14 @@ def url_to_fs(url, **kwargs):
 
 
 def open(
-    urlpath,
-    mode="rb",
-    compression=None,
-    encoding="utf8",
-    errors=None,
-    protocol=None,
-    newline=None,
-    **kwargs,
+        urlpath,
+        mode="rb",
+        compression=None,
+        encoding="utf8",
+        errors=None,
+        protocol=None,
+        newline=None,
+        **kwargs,
 ):
     """Given a path or paths, return one ``OpenFile`` object.
 
@@ -475,9 +473,9 @@ def open(
 
 
 def open_local(
-    url: str | list[str] | Path | list[Path],
-    mode: str = "rb",
-    **storage_options: dict,
+        url: str | list[str] | Path | list[Path],
+        mode: str = "rb",
+        **storage_options: dict,
 ) -> str | list[str]:
     """Open file(s) which can be resolved to local
 
@@ -583,13 +581,13 @@ def expand_paths_if_needed(paths, mode, num, fs, name_function):
 
 
 def get_fs_token_paths(
-    urlpath,
-    mode="rb",
-    num=1,
-    name_function=None,
-    storage_options=None,
-    protocol=None,
-    expand=True,
+        urlpath,
+        mode="rb",
+        num=1,
+        name_function=None,
+        storage_options=None,
+        protocol=None,
+        expand=True,
 ):
     """Filesystem, deterministic token, and paths from a urlpath and options.
 
@@ -697,13 +695,13 @@ class PickleableTextIOWrapper(io.TextIOWrapper):
     """
 
     def __init__(
-        self,
-        buffer,
-        encoding=None,
-        errors=None,
-        newline=None,
-        line_buffering=False,
-        write_through=False,
+            self,
+            buffer,
+            encoding=None,
+            errors=None,
+            newline=None,
+            line_buffering=False,
+            write_through=False,
     ):
         self.args = buffer, encoding, errors, newline, line_buffering, write_through
         super().__init__(*self.args)

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -62,14 +62,14 @@ class OpenFile:
     """
 
     def __init__(
-            self,
-            fs,
-            path,
-            mode="rb",
-            compression=None,
-            encoding=None,
-            errors=None,
-            newline=None,
+        self,
+        fs,
+        path,
+        mode="rb",
+        compression=None,
+        encoding=None,
+        errors=None,
+        newline=None,
     ):
         self.fs = fs
         self.path = path
@@ -202,18 +202,18 @@ class OpenFiles(list):
 
 
 def open_files(
-        urlpath,
-        mode="rb",
-        compression=None,
-        encoding="utf8",
-        errors=None,
-        name_function=None,
-        num=1,
-        protocol=None,
-        newline=None,
-        auto_mkdir=True,
-        expand=True,
-        **kwargs,
+    urlpath,
+    mode="rb",
+    compression=None,
+    encoding="utf8",
+    errors=None,
+    name_function=None,
+    num=1,
+    protocol=None,
+    newline=None,
+    auto_mkdir=True,
+    expand=True,
+    **kwargs,
 ):
     """Given a path or paths, return a list of ``OpenFile`` objects.
 
@@ -337,8 +337,8 @@ def _un_chain(path, kwargs):
         kw = dict(**extra_kwargs, **kws)
         bit = cls._strip_protocol(bit)
         if (
-                protocol in {"blockcache", "filecache", "simplecache"}
-                and "target_protocol" not in kw
+            protocol in {"blockcache", "filecache", "simplecache"}
+            and "target_protocol" not in kw
         ):
             bit = previous_bit
         out.append((bit, protocol, kw))
@@ -397,14 +397,14 @@ def url_to_fs(url, **kwargs):
 
 
 def open(
-        urlpath,
-        mode="rb",
-        compression=None,
-        encoding="utf8",
-        errors=None,
-        protocol=None,
-        newline=None,
-        **kwargs,
+    urlpath,
+    mode="rb",
+    compression=None,
+    encoding="utf8",
+    errors=None,
+    protocol=None,
+    newline=None,
+    **kwargs,
 ):
     """Given a path or paths, return one ``OpenFile`` object.
 
@@ -473,9 +473,9 @@ def open(
 
 
 def open_local(
-        url: str | list[str] | Path | list[Path],
-        mode: str = "rb",
-        **storage_options: dict,
+    url: str | list[str] | Path | list[Path],
+    mode: str = "rb",
+    **storage_options: dict,
 ) -> str | list[str]:
     """Open file(s) which can be resolved to local
 
@@ -581,13 +581,13 @@ def expand_paths_if_needed(paths, mode, num, fs, name_function):
 
 
 def get_fs_token_paths(
-        urlpath,
-        mode="rb",
-        num=1,
-        name_function=None,
-        storage_options=None,
-        protocol=None,
-        expand=True,
+    urlpath,
+    mode="rb",
+    num=1,
+    name_function=None,
+    storage_options=None,
+    protocol=None,
+    expand=True,
 ):
     """Filesystem, deterministic token, and paths from a urlpath and options.
 
@@ -695,13 +695,13 @@ class PickleableTextIOWrapper(io.TextIOWrapper):
     """
 
     def __init__(
-            self,
-            buffer,
-            encoding=None,
-            errors=None,
-            newline=None,
-            line_buffering=False,
-            write_through=False,
+        self,
+        buffer,
+        encoding=None,
+        errors=None,
+        newline=None,
+        line_buffering=False,
+        write_through=False,
     ):
         self.args = buffer, encoding, errors, newline, line_buffering, write_through
         super().__init__(*self.args)

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -99,6 +99,8 @@ class OpenFile:
 
     def __enter__(self):
         mode = self.mode.replace("t", "").replace("b", "") + "b"
+        sorting_order = {"r": 0, "w": 1, "a": 2, "b": 3, "+": 4}
+        mode = "".join(sorted(mode, key=lambda c: sorting_order.get(c, float("inf"))))
 
         f = self.fs.open(self.path, mode=mode)
 

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -771,10 +771,10 @@ class LocalTempFile:
         self.autocommit = autocommit
 
     def __reduce__(self):
-        # always open in rb+ to allow continuing writing at a location
+        # always open in r+b to allow continuing writing at a location
         return (
             LocalTempFile,
-            (self.fs, self.path, self.fn, "rb+", self.autocommit, self.tell()),
+            (self.fs, self.path, self.fn, "r+b", self.autocommit, self.tell()),
         )
 
     def __enter__(self):

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -802,7 +802,7 @@ async def get_range(session, url, start, end, file=None, **kwargs):
     async with r:
         out = await r.read()
     if file:
-        with open(file, "rb+") as f:
+        with open(file, "r+b") as f:
             f.seek(start)
             f.write(out)
     else:

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -175,7 +175,7 @@ class MemoryFileSystem(AbstractFileSystem):
             parent = self._parent(parent)
             if self.isfile(parent):
                 raise FileExistsError(parent)
-        if mode in ["rb", "ab", "rb+"]:
+        if mode in ["rb", "ab", "r+b"]:
             if path in self.store:
                 f = self.store[path]
                 if mode == "ab":

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -191,6 +191,15 @@ def test_seekable(m):
     assert f.tell() == 2
 
 
+# https://github.com/fsspec/filesystem_spec/issues/1425
+@pytest.mark.parametrize("mode", ["r", "rb", "bw", "w", "wb", "ab", "ba", "rb+", "r+b"])
+def test_open_mode(m, mode):
+    filename = "mode.txt"
+    m.touch(filename)
+    with m.open(filename, mode=mode) as _:
+        pass
+
+
 def test_remove_all(m):
     m.touch("afile")
     m.rm("/", recursive=True)

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -192,7 +192,7 @@ def test_seekable(m):
 
 
 # https://github.com/fsspec/filesystem_spec/issues/1425
-@pytest.mark.parametrize("mode", ["r", "rb", "bw", "w", "wb", "ab", "ba", "rb+", "r+b"])
+@pytest.mark.parametrize("mode", ["r", "rb", "w", "wb", "ab", "r+b"])
 def test_open_mode(m, mode):
     filename = "mode.txt"
     m.touch(filename)


### PR DESCRIPTION
Triggered by https://github.com/fsspec/filesystem_spec/issues/1425

The current processing of the file mode string causes the `b` character to always be on the end of the mode e.g. `rb+` becomes `r+b`.

However in some instances (such as in the memory file system), the valid file modes listed are not compatible with this format, for instance `rb+` is listed. This comparison will never take place given how the mode string is processed.

This PR replaces all instances of `rb+` to `r+b` so that this works now.