### PR TITLE
 In Python 3, the default source encoding is UTF-8

### DIFF
--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module contains SMBFileSystem class responsible for handling access to
 Windows Samba network shares by using package smbprotocol


### PR DESCRIPTION
No need to explicitly define the source encoding as UTF-8.

See also #1372.