### PR TITLE
Add missing URL encoding in `HTTPFileSystem._put_file()` method

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -307,7 +307,7 @@ class HTTPFileSystem(AsyncFileSystem):
             )
 
         meth = getattr(session, method)
-        async with meth(rpath, data=gen_chunks(), **kw) as resp:
+        async with meth(self.encode_url(rpath), data=gen_chunks(), **kw) as resp:
             self._raise_not_found_for_status(resp, rpath)
 
     async def _exists(self, path, **kwargs):


### PR DESCRIPTION
I've added a missing call to `HTTPFileSystem.encode_url()` applied to the remote URL path in `HTTPFileSystem._put_file()`, which is done consistently in all other methods that perform HTTP requests except this one.