### PR TITLE
fix SFTPFileSystem.makedirs to properly handle relative paths

### DIFF
--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -80,12 +80,13 @@ class SFTPFileSystem(AbstractFileSystem):
             raise FileExistsError(f"File exists: {path}")
 
         parts = path.split("/")
-        path = ""
+        new_path = "/" if path[:1] == "/" else ""
 
         for part in parts:
-            path += f"/{part}"
-            if not self.exists(path):
-                self.ftp.mkdir(path, mode)
+            if part:
+                new_path = f"{new_path}/{part}" if new_path else part
+                if not self.exists(new_path):
+                    self.ftp.mkdir(new_path, mode)
 
     def rmdir(self, path):
         logger.debug("Removing folder %s", path)

--- a/fsspec/implementations/tests/test_sftp.py
+++ b/fsspec/implementations/tests/test_sftp.py
@@ -200,27 +200,32 @@ def test_transaction(ssh, root_path):
         f.rm(root_path, recursive=True)
 
 
-def test_mkdir_create_parent(ssh):
+@pytest.mark.parametrize("path", ["/a/b/c", "a/b/c"])
+def test_mkdir_create_parent(ssh, path):
     f = fsspec.get_filesystem_class("sftp")(**ssh)
 
     with pytest.raises(FileNotFoundError):
-        f.mkdir("/a/b/c")
+        f.mkdir(path)
 
-    f.mkdir("/a/b/c", create_parents=True)
-    assert f.exists("/a/b/c")
+    f.mkdir(path, create_parents=True)
+    assert f.exists(path)
 
-    with pytest.raises(FileExistsError, match="/a/b/c"):
-        f.mkdir("/a/b/c")
+    with pytest.raises(FileExistsError, match=path):
+        f.mkdir(path)
 
-    f.rm("/a/b/c", recursive=True)
+    f.rm(path, recursive=True)
+    assert not f.exists(path)
 
 
-def test_makedirs_exist_ok(ssh):
+@pytest.mark.parametrize("path", ["/a/b/c", "a/b/c"])
+def test_makedirs_exist_ok(ssh, path):
     f = fsspec.get_filesystem_class("sftp")(**ssh)
 
-    f.makedirs("/a/b/c")
+    f.makedirs(path)
 
-    with pytest.raises(FileExistsError, match="/a/b/c"):
-        f.makedirs("/a/b/c", exist_ok=False)
+    with pytest.raises(FileExistsError, match=path):
+        f.makedirs(path, exist_ok=False)
 
-    f.makedirs("/a/b/c", exist_ok=True)
+    f.makedirs(path, exist_ok=True)
+    f.rm(path, recursive=True)
+    assert not f.exists(path)


### PR DESCRIPTION
In SFTPFileSystem, there is a difference in the behavior of `mkdir` and `mkdirs`.
`mkdirs` converts relative paths to absolute paths.

The code to reproduce is below.

```
import fsspec

fs = fsspec.filesystem(
    "ssh",
    host="localhost",
    port=9200,
    username="root",
    password="pass"
)

fs.mkdir("test_dir1")  # /root/test_dir1
fs.mkdirs("test_dir2")  # /test_dir2
```

I've pushed code that addresses this issue.
