### PR TITLE
callbacks: introduce scoped callbacks

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -568,7 +568,7 @@ class AsyncFileSystem(AbstractFileSystem):
         coros = []
         callback.set_size(len(file_pairs))
         for lfile, rfile in file_pairs:
-            put_file = callback.wrap_and_branch_coro(self._put_file)
+            put_file = callback.branch_coro(self._put_file)
             coros.append(put_file(lfile, rfile, **kwargs))
 
         return await _run_coros_in_chunks(
@@ -645,7 +645,7 @@ class AsyncFileSystem(AbstractFileSystem):
         coros = []
         callback.set_size(len(lpaths))
         for lpath, rpath in zip(lpaths, rpaths):
-            get_file = callback.wrap_and_branch_coro(self._get_file)
+            get_file = callback.branch_coro(self._get_file)
             coros.append(get_file(rpath, lpath, **kwargs))
         return await _run_coros_in_chunks(
             coros, batch_size=batch_size, callback=callback

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -568,8 +568,8 @@ class AsyncFileSystem(AbstractFileSystem):
         coros = []
         callback.set_size(len(file_pairs))
         for lfile, rfile in file_pairs:
-            callback.branch(lfile, rfile, kwargs)
-            coros.append(self._put_file(lfile, rfile, **kwargs))
+            put_file = callback.wrap_and_branch_coro(self._put_file)
+            coros.append(put_file(lfile, rfile, **kwargs))
 
         return await _run_coros_in_chunks(
             coros, batch_size=batch_size, callback=callback
@@ -645,8 +645,8 @@ class AsyncFileSystem(AbstractFileSystem):
         coros = []
         callback.set_size(len(lpaths))
         for lpath, rpath in zip(lpaths, rpaths):
-            callback.branch(rpath, lpath, kwargs)
-            coros.append(self._get_file(rpath, lpath, **kwargs))
+            get_file = callback.wrap_and_branch_coro(self._get_file)
+            coros.append(get_file(rpath, lpath, **kwargs))
         return await _run_coros_in_chunks(
             coros, batch_size=batch_size, callback=callback
         )

--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -46,7 +46,11 @@ class Callback:
         that has to be passed to the child method, e.g., put_file,
         as `callback=` argument.
 
-        This function should be preferred over `branch`.
+        The implementation uses `callback.branch` for compatibility.
+        When implementing callbacks, it is recommended to override this function instead
+        of `branch` and avoid calling `super().branched(...)`.
+
+        Prefer using this function over `branch`.
 
         Parameters
         ----------

--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -285,10 +285,13 @@ class TqdmCallback(Callback):
         self.tqdm.total = self.size
         self.tqdm.update(self.value - self.tqdm.n)
 
-    def __del__(self):
+    def close(self):
         if self.tqdm is not None:
             self.tqdm.close()
             self.tqdm = None
+
+    def __del__(self):
+        return self.close()
 
 
 _DEFAULT_CALLBACK = NoOpCallback()

--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+
 class Callback:
     """
     Base class and interface for callback mechanism
@@ -42,7 +43,8 @@ class Callback:
 
         If this callback is operating at a higher level, e.g., put, which may
         trigger transfers that can also be monitored. The function returns a callback
-        that has to be passed to the child method, e.g., put_file, as `callback=` argument.
+        that has to be passed to the child method, e.g., put_file,
+        as `callback=` argument.
 
         This function should be preferred over `branch`.
 
@@ -69,6 +71,7 @@ class Callback:
         Wraps a coroutine, and pass a new child callback to it.
         When the coroutine completes, we increment the parent callback by 1.
         """
+
         @wraps(fn)
         async def func(path1, path2: str, **kwargs):
             with self.branched(path1, path2, kwargs) as child:

--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -25,6 +25,43 @@ class Callback:
         self.hooks = hooks or {}
         self.kw = kwargs
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_args):
+        self.close()
+
+    def close(self):
+        """Close callback."""
+
+    def branched(self, path_1, path_2, kwargs):
+        """
+        Return callback for child transfers
+
+        If this callback is operating at a higher level, e.g., put, which may
+        trigger transfers that can also be monitored. The function returns a callback
+        that has to be passed to the child method, e.g., put_file, as `callback=` argument.
+
+        This function should be preferred over `branch`.
+
+        Parameters
+        ----------
+        path_1: str
+            Child's source path
+        path_2: str
+            Child's destination path
+        kwargs: dict
+            arguments passed to child method, e.g., put_file.
+
+        Returns
+        -------
+        callback: Callback
+            A callback instance to be passed to the child method
+        """
+        self.branch(path_1, path_2, kwargs)
+        # mutate kwargs so that we can force the caller to pass "callback=" explicitly
+        return kwargs.pop("callback", _DEFAULT_CALLBACK)
+
     def set_size(self, size):
         """
         Set the internal maximum size attribute

--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -66,7 +66,7 @@ class Callback:
         # mutate kwargs so that we can force the caller to pass "callback=" explicitly
         return kwargs.pop("callback", _DEFAULT_CALLBACK)
 
-    def wrap_and_branch_coro(self, fn):
+    def branch_coro(self, fn):
         """
         Wraps a coroutine, and pass a new child callback to it.
         When the coroutine completes, we increment the parent callback by 1.
@@ -75,9 +75,7 @@ class Callback:
         @wraps(fn)
         async def func(path1, path2: str, **kwargs):
             with self.branched(path1, path2, kwargs) as child:
-                res = await fn(path1, path2, callback=child, **kwargs)
-                self.relative_update()
-                return res
+                return await fn(path1, path2, callback=child, **kwargs)
 
         return func
 

--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -69,7 +69,6 @@ class Callback:
     def branch_coro(self, fn):
         """
         Wraps a coroutine, and pass a new child callback to it.
-        When the coroutine completes, we increment the parent callback by 1.
         """
 
         @wraps(fn)

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -1123,7 +1123,7 @@ class ReferenceFileSystem(AsyncFileSystem):
         self.references[path] = data
         self.dircache.clear()  # this is a bit heavy handed
 
-    async def _put_file(self, lpath, rpath):
+    async def _put_file(self, lpath, rpath, **kwargs):
         # puts binary
         with open(lpath, "rb") as f:
             self.references[rpath] = f.read()

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -967,8 +967,8 @@ class AbstractFileSystem(metaclass=_Cached):
 
         callback.set_size(len(lpaths))
         for lpath, rpath in callback.wrap(zip(lpaths, rpaths)):
-            callback.branch(rpath, lpath, kwargs)
-            self.get_file(rpath, lpath, **kwargs)
+            with callback.branched(rpath, lpath, kwargs) as child:
+                self.get_file(rpath, lpath, callback=child, **kwargs)
 
     def put_file(self, lpath, rpath, callback=_DEFAULT_CALLBACK, **kwargs):
         """Copy single file to remote"""
@@ -1053,8 +1053,8 @@ class AbstractFileSystem(metaclass=_Cached):
 
         callback.set_size(len(rpaths))
         for lpath, rpath in callback.wrap(zip(lpaths, rpaths)):
-            callback.branch(lpath, rpath, kwargs)
-            self.put_file(lpath, rpath, **kwargs)
+            with callback.branched(lpath, rpath, kwargs) as child:
+                self.put_file(lpath, rpath, callback=child, **kwargs)
 
     def head(self, path, size=1024):
         """Get the first ``size`` bytes from file"""

--- a/fsspec/tests/test_callbacks.py
+++ b/fsspec/tests/test_callbacks.py
@@ -50,22 +50,17 @@ def test_callbacks_branched():
 
 @pytest.mark.asyncio
 async def test_callbacks_branch_coro(mocker):
-    class IsCallback:
-        def __eq__(self, value):
-            return isinstance(value, Callback)
-
     async_fn = mocker.AsyncMock(return_value=10)
     callback = Callback()
     wrapped_fn = callback.branch_coro(async_fn)
-    spy_branched = mocker.spy(callback, "branched")
+    spy = mocker.spy(callback, "branched")
 
     assert await wrapped_fn("path_1", "path_2", key="value") == 10
 
-    spy_branched.assert_called_once_with("path_1", "path_2", {"key": "value"})
+    spy.assert_called_once_with("path_1", "path_2", {"key": "value"})
     async_fn.assert_called_once_with(
-        "path_1", "path_2", callback=IsCallback(), key="value"
+        "path_1", "path_2", callback=spy.spy_return, key="value"
     )
-    assert isinstance(spy_branched.spy_return, Callback)
 
 
 def test_callbacks_wrap():

--- a/fsspec/tests/test_callbacks.py
+++ b/fsspec/tests/test_callbacks.py
@@ -27,15 +27,11 @@ def test_callbacks_as_callback():
 
 
 def test_callbacks_as_context_manager(mocker):
-    spy_enter = mocker.spy(Callback, "__enter__")
-    spy_exit = mocker.spy(Callback, "__exit__")
     spy_close = mocker.spy(Callback, "close")
 
     with Callback() as cb:
         assert isinstance(cb, Callback)
 
-    spy_enter.assert_called_once()
-    spy_exit.assert_called_once()
     spy_close.assert_called_once()
 
 

--- a/fsspec/tests/test_callbacks.py
+++ b/fsspec/tests/test_callbacks.py
@@ -32,7 +32,7 @@ def test_callbacks_as_context_manager(mocker):
     spy_close = mocker.spy(Callback, "close")
 
     with Callback() as cb:
-        cb.relative_update()
+        assert isinstance(cb, Callback)
 
     spy_enter.assert_called_once()
     spy_exit.assert_called_once()
@@ -40,12 +40,14 @@ def test_callbacks_as_context_manager(mocker):
 
 
 def test_callbacks_branched():
-    with Callback() as cb:
-        kwargs = {"key": "value"}
-        with cb.branched("path_1", "path_2", kwargs) as branch:
-            assert branch is not cb
-            assert isinstance(branch, Callback)
-            assert kwargs == {"key": "value"}
+    callback = Callback()
+    kwargs = {"key": "value"}
+
+    branch = callback.branched("path_1", "path_2", kwargs)
+
+    assert branch is not callback
+    assert isinstance(branch, Callback)
+    assert kwargs == {"key": "value"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
1. This PR introduces a `close()` API that gives an opportunity for callbacks to close themselves, either on error or on completions. We use this to extend `Callback`s into a context-manager by using that `close()` api on `__exit__()`.
2. This PR also introduces `branched()` API that returns an instance of a callback. Since the callback is a context-manager, this gives an opportunity to close child callbacks after they complete. This is very similar to `branch()` API, but unlike `branch`, it should not mutate passed `kwargs`, and always return an instance of a callback. The default return is _DEFAULT_CALLBACK or NoopCallback if left unimplemented.

   For backwards compatibility, this will still call `branch()` API, try to read from the kwargs it has set, pop the `callback` kwarg and return it. But anyone implementing `Callback` does not need to implement `branch` API and should prefer `branched()` instead from now on, and the older API should be considered deprecated.

Closes fsspec/filesystem_spec#1075.