### PR TITLE
Fix tqdm callback garbage collection

### DIFF
--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -231,7 +231,8 @@ class TqdmCallback(Callback):
         self.tqdm.update(inc)
 
     def __del__(self):
-        self.tqdm.close()
+        if hasattr(self.tqdm, "close"):
+            self.tqdm.close()
         self.tqdm = None
 
 


### PR DESCRIPTION
Calling `close()` on `TqdmCallback.tqdm` reliably results in an exception on interpreter exit. Debug prints show that in such cases, the value of `tqdm` is not, as expected, the progress bar instance, but rather the `no_op` bound method, which does not have a `close` attribute.

This change checks attribute existence of `close()` first before calling it on the class. Checking this way does not require a `tqdm` import.