### PR TITLE
Make AbstractBufferedFile-derived classes equal to themselves

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1691,6 +1691,8 @@ class AbstractBufferedFile(io.IOBase):
 
     def __eq__(self, other):
         """Files are equal if they have the same checksum, only in read mode"""
+        if self is other:
+            return True
         return self.mode == "rb" and other.mode == "rb" and hash(self) == hash(other)
 
     def commit(self):


### PR DESCRIPTION
Fixes [#827](https://github.com/fsspec/s3fs/issues/827)

Allow a class instance derived from AbstractBufferedFile to be considered equal to another class instance if it IS that other class instance.  Current logic in __eq__ treats an object as different than itself if it is in write mode.  This addresses fsspec/s3fs issue 827.