### PR TITLE
ArrowFSWrapper should not use "/" root_marker for all filesystems

### DIFF
--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -62,6 +62,20 @@ class ArrowFSWrapper(AbstractFileSystem):
         return "hdfs_" + tokenize(self.fs.host, self.fs.port)
 
     @classmethod
+    def from_fs(cls, fs, **kwargs):
+        override = {"local": "file"}
+        type_name = override.get(fs.type_name, fs.type_name)
+
+        try:
+            fs.from_uri(f"{type_name}:///")
+            root_marker = "/"
+        except BaseException:
+            root_marker = ""
+
+        wrapper = type(cls.__name__, (cls,), {"root_marker": root_marker})
+        return wrapper(fs, **kwargs)
+
+    @classmethod
     def _strip_protocol(cls, path):
         ops = infer_storage_options(path)
         path = ops["path"]

--- a/fsspec/implementations/tests/test_arrow.py
+++ b/fsspec/implementations/tests/test_arrow.py
@@ -241,3 +241,17 @@ def test_seekable(fs, remote_dir):
     with fs.open(remote_dir + "/a.txt", "rb", seekable=False) as file:
         with pytest.raises(OSError):
             file.seek(5)
+
+
+@pytest.mark.parametrize(
+    ["filesystem", "root_marker"],
+    [
+        (pyarrow_fs.LocalFileSystem(), "/"),
+        (pyarrow_fs.S3FileSystem(), ""),
+        (pyarrow_fs.GcsFileSystem(), ""),
+    ],
+)
+def test_from_fs(filesystem, root_marker):
+    wrapper = ArrowFSWrapper.from_fs(filesystem)
+    assert wrapper.root_marker == root_marker
+    assert wrapper.__class__.root_marker == root_marker


### PR DESCRIPTION
Perhaps a bit too hacky to be merged, but Fixes https://github.com/fsspec/filesystem_spec/issues/1464 , in theory. Basic idea is to check if the provided arrow filesystem supports a `/` path, then create an `ArrowFSWrapper` class dynamically based on the result. 