### PR TITLE
Fix non-str case in `AbstractFileSystem.expand_path()`

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import logging
 import os
-import pathlib
 import threading
 import warnings
 import weakref
@@ -1135,7 +1134,7 @@ class AbstractFileSystem(metaclass=_Cached):
         if maxdepth is not None and maxdepth < 1:
             raise ValueError("maxdepth must be at least 1")
 
-        if isinstance(path, (str, os.PathLike, pathlib.Path)):
+        if isinstance(path, (str, os.PathLike)):
             out = self.expand_path([path], recursive, maxdepth)
         else:
             out = set()

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import logging
 import os
+import pathlib
 import threading
 import warnings
 import weakref
@@ -1134,7 +1135,7 @@ class AbstractFileSystem(metaclass=_Cached):
         if maxdepth is not None and maxdepth < 1:
             raise ValueError("maxdepth must be at least 1")
 
-        if isinstance(path, str):
+        if isinstance(path, (str, os.PathLike, pathlib.Path)):
             out = self.expand_path([path], recursive, maxdepth)
         else:
             out = set()

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -5,6 +5,7 @@ import pickle
 import subprocess
 import sys
 from collections import defaultdict
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -647,6 +648,7 @@ class DummyTestFS(AbstractFileSystem):
             None,
             DummyTestFS.get_test_paths() + [DummyTestFS.root_marker],
         ),
+        [(Path("misc/foo.txt"),), False, None, ["misc/foo.txt"]],
     ],
 )
 def test_expand_path(test_paths, recursive, maxdepth, expected):

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -648,7 +648,12 @@ class DummyTestFS(AbstractFileSystem):
             None,
             DummyTestFS.get_test_paths() + [DummyTestFS.root_marker],
         ),
-        [(Path("misc/foo.txt"),), False, None, ["misc/foo.txt"]],
+        [
+            (Path("misc/foo.txt"),),
+            False,
+            None,
+            [f"misc{os.sep}foo.txt"],
+        ],
     ],
 )
 def test_expand_path(test_paths, recursive, maxdepth, expected):


### PR DESCRIPTION
If the input to `expand_path` is not a string, it needs to be iterable, since the if-branch for the container case tries to loop over the contents.

Previously, the code would fall through to the iterable case even for perfectly legal inputs to `AbstractFileSystem._strip_protocol()`, like `pathlib.Path`s, causing a crash with a less-than-ideal error message.

All of these inputs are now legalized by a changed `isinstance` check on the scalar case, which now contains all types legal in `_strip_protocol` and by proxy `stringify_path`.