### PR TITLE
Allow files in `LocalFileSystem.ls()`

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -3,7 +3,6 @@ import io
 import logging
 import os
 import os.path as osp
-import posixpath
 import re
 import shutil
 import stat
@@ -59,11 +58,16 @@ class LocalFileSystem(AbstractFileSystem):
 
     def ls(self, path, detail=False, **kwargs):
         path = self._strip_protocol(path)
-        if detail:
+        info = self.info(path)
+        if info["type"] == "directory":
             with os.scandir(path) as it:
-                return [self.info(f) for f in it]
+                infos = [self.info(f) for f in it]
         else:
-            return [posixpath.join(path, f) for f in os.listdir(path)]
+            infos = [info]
+
+        if not detail:
+            return [i["name"] for i in infos]
+        return infos
 
     def info(self, path, **kwargs):
         if isinstance(path, os.DirEntry):

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -367,6 +367,16 @@ def test_directories(tmpdir):
     assert fs.ls(fs.root_marker)
 
 
+def test_ls_on_file(tmpdir):
+    tmpdir = make_path_posix(str(tmpdir))
+    fs = LocalFileSystem()
+    resource = tmpdir + "/a.json"
+    fs.touch(resource)
+    assert fs.exists(resource)
+    assert fs.ls(tmpdir) == fs.ls(resource)
+    assert fs.ls(resource, detail=True)[0] == fs.info(resource)
+
+
 @pytest.mark.parametrize("file_protocol", ["", "file://"])
 def test_file_ops(tmpdir, file_protocol):
     tmpdir = make_path_posix(str(tmpdir))


### PR DESCRIPTION
Implemented as a 2x2 switch-esque statement on `detail` and `isdir(path)`.

Adds a simple test on a single-file directory, which is assumed to be equal to calling `ls` on the file itself.

Fixes #1478.