### PR TITLE
TqdmCallback: make it work on absolute_update too

### DIFF
--- a/fsspec/tests/test_callbacks.py
+++ b/fsspec/tests/test_callbacks.py
@@ -44,13 +44,13 @@ def test_callbacks_wrap():
 def test_tqdm_callback(tqdm_kwargs, mocker):
 
     callback = TqdmCallback(tqdm_kwargs=tqdm_kwargs)
-    mocker.patch.object(callback, "_tqdm")
+    mocker.patch.object(callback, "_tqdm_cls")
     callback.set_size(10)
     for _ in callback.wrap(range(10)):
         ...
 
-    assert callback.tqdm.update.call_count == 10
+    assert callback.tqdm.update.call_count == 11
     if not tqdm_kwargs:
-        callback._tqdm.tqdm.assert_called_with(total=10)
+        callback._tqdm_cls.assert_called_with(total=10)
     else:
-        callback._tqdm.tqdm.assert_called_with(total=10, **tqdm_kwargs)
+        callback._tqdm_cls.assert_called_with(total=10, **tqdm_kwargs)


### PR DESCRIPTION
`TqdmCallback` does not support `absolute_update()`, which some of the `fsspec` filesystems use (eg: `adlfs`).

I'm using `self.tqdm.update(self.value - self.tqdm.n)` to do an `absolute_update()` here in `call()`. `call()` is called by all methods, so it should work with relative_update/absolute_update/set_size.

I have a patch to support `update_to` method that does this: https://github.com/tqdm/tqdm/pull/1540, but it'll be a while before we can take advantage of it.

