### PR TITLE
Remove obsolete `requests` dependency from HTTP filesystem implementation

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -7,7 +7,6 @@ from copy import copy
 from urllib.parse import urlparse
 
 import aiohttp
-import requests
 import yarl
 
 from fsspec.asyn import AbstractAsyncStreamedFile, AsyncFileSystem, sync, sync_wrapper
@@ -319,7 +318,7 @@ class HTTPFileSystem(AsyncFileSystem):
             r = await session.get(self.encode_url(path), **kw)
             async with r:
                 return r.status < 400
-        except (requests.HTTPError, aiohttp.ClientError):
+        except aiohttp.ClientError:
             return False
 
     async def _isfile(self, path, **kwargs):
@@ -529,7 +528,7 @@ class HTTPFile(AbstractBufferedFile):
     ----------
     url: str
         Full URL of the remote resource, including the protocol
-    session: requests.Session or None
+    session: aiohttp.ClientSession or None
         All calls will be made within this session, to avoid restarting
         connections where the server allows this
     block_size: int or None

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = {
     "gs": ["gcsfs"],
     "hdfs": ["pyarrow >= 1"],
     "arrow": ["pyarrow >= 1"],
-    "http": ["requests", "aiohttp !=4.0.0a0, !=4.0.0a1"],
+    "http": ["aiohttp !=4.0.0a0, !=4.0.0a1"],
     "sftp": ["paramiko"],
     "s3": ["s3fs"],
     "oci": ["ocifs"],


### PR DESCRIPTION
I've removed the `requests` dependency and leftovers from past use of `requests` in the HTTP filesystem implementation. According to my research, the current HTTP filesystem implementation is asynchronous and exclusively based on `aiohttp`, and it doesn't support `requests` anymore.