### PR TITLE
Add mimetype and redirect url to HTTP info dict

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -848,7 +848,7 @@ async def _file_info(url, session, size_policy="head", **kwargs):
             info["size"] = int(r.headers["Content-Range"].split("/")[1])
 
         if "Content-Type" in r.headers:
-            info["mime"] = r.headers["Content-Type"].partition(";")[0]
+            info["mimetype"] = r.headers["Content-Type"].partition(";")[0]
 
         info["url"] = str(r.url)
 

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -847,6 +847,11 @@ async def _file_info(url, session, size_policy="head", **kwargs):
         elif "Content-Range" in r.headers:
             info["size"] = int(r.headers["Content-Range"].split("/")[1])
 
+        if "Content-Type" in r.headers:
+            info["mime"] = r.headers["Content-Type"].partition(";")[0]
+
+        info["url"] = str(r.url)
+
         for checksum_field in ["ETag", "Content-MD5", "Digest"]:
             if r.headers.get(checksum_field):
                 info[checksum_field] = r.headers[checksum_field]

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -369,6 +369,14 @@ def test_info(server):
     info = fs.info(server + "/index/realfile")
     assert info["ETag"] == "xxx"
 
+    fs = fsspec.filesystem("http", headers={"give_mimetype": "true"})
+    info = fs.info(server + "/index/realfile")
+    assert info["mimetype"] == "text/html"
+
+    fs = fsspec.filesystem("http", headers={"redirect": "true"})
+    info = fs.info(server + "/redirectme")
+    assert info["url"] == server + "/index/realfile"
+
 
 @pytest.mark.parametrize("method", ["POST", "PUT"])
 def test_put_file(server, tmp_path, method, reset_files):

--- a/fsspec/tests/conftest.py
+++ b/fsspec/tests/conftest.py
@@ -57,6 +57,9 @@ class HTTPTestHandler(BaseHTTPRequestHandler):
         file_data = self.files.get(file_path)
         if "give_path" in self.headers:
             return self._respond(200, data=json.dumps({"path": self.path}).encode())
+        if "redirect" in self.headers and file_path != "/index/realfile":
+            new_url = f"http://127.0.0.1:{port}/index/realfile"
+            return self._respond(301, {"Location": new_url})
         if file_data is None:
             return self._respond(404)
 
@@ -88,6 +91,10 @@ class HTTPTestHandler(BaseHTTPRequestHandler):
             self._respond(status, response_headers, file_data)
         elif "give_range" in self.headers:
             self._respond(status, {"Content-Range": content_range}, file_data)
+        elif "give_mimetype" in self.headers:
+            self._respond(
+                status, {"Content-Type": "text/html; charset=utf-8"}, file_data
+            )
         else:
             self._respond(status, data=file_data)
 


### PR DESCRIPTION
This will allow discovery of a file's mime-type and redirect URL without unnecessary additional HTTP requests.
