### PR TITLE
Remove obsolete `requirements.txt` file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,3 @@ include fsspec/_version.py
 
 include LICENSE
 include README.rst
-include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
     keywords="file",
     packages=["fsspec", "fsspec.implementations", "fsspec.tests.abstract"],
     python_requires=">=3.8",
-    install_requires=open("requirements.txt").read().strip().split("\n"),
     extras_require=extras_require,
     zip_safe=False,
 )


### PR DESCRIPTION
I've removed the obsolete `requirements.txt` file, which was empty, and the `install_requires` keyword argument in `setup.py` which loaded entries from `requirements.txt`. `fsspec` only has optional dependencies specified via `extras_require`.