### PR TITLE
callbacks: replace kwargs positional argument with arbitrary kwargs in `branched`

### DIFF
--- a/fsspec/callbacks.py
+++ b/fsspec/callbacks.py
@@ -37,7 +37,7 @@ class Callback:
     def close(self):
         """Close callback."""
 
-    def branched(self, path_1, path_2, kwargs):
+    def branched(self, path_1, path_2, **kwargs):
         """
         Return callback for child transfers
 
@@ -58,8 +58,8 @@ class Callback:
             Child's source path
         path_2: str
             Child's destination path
-        kwargs: dict
-            arguments passed to child method, e.g., put_file.
+        **kwargs:
+            Arbitrary keyword arguments
 
         Returns
         -------
@@ -77,7 +77,7 @@ class Callback:
 
         @wraps(fn)
         async def func(path1, path2: str, **kwargs):
-            with self.branched(path1, path2, kwargs) as child:
+            with self.branched(path1, path2, **kwargs) as child:
                 return await fn(path1, path2, callback=child, **kwargs)
 
         return func

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -967,7 +967,7 @@ class AbstractFileSystem(metaclass=_Cached):
 
         callback.set_size(len(lpaths))
         for lpath, rpath in callback.wrap(zip(lpaths, rpaths)):
-            with callback.branched(rpath, lpath, kwargs) as child:
+            with callback.branched(rpath, lpath) as child:
                 self.get_file(rpath, lpath, callback=child, **kwargs)
 
     def put_file(self, lpath, rpath, callback=_DEFAULT_CALLBACK, **kwargs):
@@ -1053,7 +1053,7 @@ class AbstractFileSystem(metaclass=_Cached):
 
         callback.set_size(len(rpaths))
         for lpath, rpath in callback.wrap(zip(lpaths, rpaths)):
-            with callback.branched(lpath, rpath, kwargs) as child:
+            with callback.branched(lpath, rpath) as child:
                 self.put_file(lpath, rpath, callback=child, **kwargs)
 
     def head(self, path, size=1024):

--- a/fsspec/tests/test_callbacks.py
+++ b/fsspec/tests/test_callbacks.py
@@ -37,13 +37,11 @@ def test_callbacks_as_context_manager(mocker):
 
 def test_callbacks_branched():
     callback = Callback()
-    kwargs = {"key": "value"}
 
-    branch = callback.branched("path_1", "path_2", kwargs)
+    branch = callback.branched("path_1", "path_2")
 
     assert branch is not callback
     assert isinstance(branch, Callback)
-    assert kwargs == {"key": "value"}
 
 
 @pytest.mark.asyncio
@@ -55,7 +53,7 @@ async def test_callbacks_branch_coro(mocker):
 
     assert await wrapped_fn("path_1", "path_2", key="value") == 10
 
-    spy.assert_called_once_with("path_1", "path_2", {"key": "value"})
+    spy.assert_called_once_with("path_1", "path_2", key="value")
     async_fn.assert_called_once_with(
         "path_1", "path_2", callback=spy.spy_return, key="value"
     )


### PR DESCRIPTION
The following would be an example of someone using a `branched` callback. 

```python
with callback.branched(path_1, path_2, {}) as child:
    pass
```

The kwargs feel unnecessary to me. So I am proposing to remove that. It can be added later if someone requests it.

Also see https://github.com/fsspec/filesystem_spec/pull/1460#discussion_r1447531484.