### PR TITLE
Fix logger in memory.py

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar
 
 from fsspec import AbstractFileSystem
 
-logger = logging.Logger("fsspec.memoryfs")
+logger = logging.getLogger("fsspec.memoryfs")
 
 
 class MemoryFileSystem(AbstractFileSystem):


### PR DESCRIPTION
Loggers should never be directly instantiated as this bypasses all configuration and also will not be added to the logger tree. See ruff rule: https://docs.astral.sh/ruff/rules/direct-logger-instantiation/