### PR TITLE
Less strict dictionary merging in core

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -334,7 +334,16 @@ def _un_chain(path, kwargs):
         kws = kwargs.pop(protocol, {})
         if bit is bits[0]:
             kws.update(kwargs)
-        kw = dict(**extra_kwargs, **kws)
+        if any(
+            k_1 == k_2 and v_1 != v_2
+            for k_1, v_1 in extra_kwargs.items()
+            for k_2, v_2 in kws.items()
+        ):
+            raise ValueError(
+                "Tried to merge dictionaries with same key and different values."
+            )
+        else:
+            kw = extra_kwargs | kws
         bit = cls._strip_protocol(bit)
         if (
             protocol in {"blockcache", "filecache", "simplecache"}


### PR DESCRIPTION
In

https://github.com/fsspec/filesystem_spec/blob/7b774c26e30e5ae60b5b63bf4e345a1b32028a4e/fsspec/core.py#L337C9-L337C41

the dictionaries `extra_kwargs` and `kws` are merged with  `kw = dict(**extra_kwargs, **kws)`. This may be an issue when there is redundant information in the two dictionaries, resulting in a `TypeError: dict() got multiple values for keyword argument` (indeed I have just faced this exact situation in a project). I understand it is correct to raise this error when the same key is mapped to different values, but it is not necessary when the values are the same.

An alternative way to approach this merge is with `kw = extra_kwargs | kws` and raising the error only when there are overlapping keys with different values, something along the lines of 

    if any(k_1 == k_2 and v_1 != v_2 for k_1, v_1 in extra_kwargs.items() for k_2, v_2 in kws.items()):
        raise ValueError("Tried to merge dictionaries with same key and different values.")
    else:
        kw = extra_kwargs | kws