### PR TITLE
improve test coverage

### DIFF
--- a/fsspec/tests/abstract/copy.py
+++ b/fsspec/tests/abstract/copy.py
@@ -120,7 +120,7 @@ class AbstractCopyTests:
             fs.touch(dummy)
         assert fs.isdir(target)
 
-        for source_slash, target_slash in zip([False, True], [False, True]):
+        for source_slash, target_slash in product([False, True], [False, True]):
             s = fs_join(source, "subdir")
             if source_slash:
                 s += "/"
@@ -195,7 +195,7 @@ class AbstractCopyTests:
         target = fs_target
         fs.mkdir(target)
 
-        for source_slash, target_slash in zip([False, True], [False, True]):
+        for source_slash, target_slash in product([False, True], [False, True]):
             s = fs_join(source, "subdir")
             if source_slash:
                 s += "/"
@@ -274,7 +274,7 @@ class AbstractCopyTests:
             assert fs.ls(target) == ([] if supports_empty_directories else [dummy])
 
             # With recursive
-            for glob, recursive in zip(["*", "**"], [True, False]):
+            for glob, recursive in product(["*", "**"], [True, False]):
                 fs.cp(fs_join(source, "subdir", glob), t, recursive=recursive)
                 assert fs.isfile(fs_join(target, "subfile1"))
                 assert fs.isfile(fs_join(target, "subfile2"))
@@ -338,7 +338,7 @@ class AbstractCopyTests:
             assert not fs.exists(fs_join(target, "newdir"))
 
             # With recursive
-            for glob, recursive in zip(["*", "**"], [True, False]):
+            for glob, recursive in product(["*", "**"], [True, False]):
                 fs.cp(fs_join(source, "subdir", glob), t, recursive=recursive)
                 assert fs.isdir(fs_join(target, "newdir"))
                 assert fs.isfile(fs_join(target, "newdir", "subfile1"))

--- a/fsspec/tests/abstract/get.py
+++ b/fsspec/tests/abstract/get.py
@@ -127,7 +127,7 @@ class AbstractGetTests:
         local_fs.mkdir(target)
         assert local_fs.isdir(target)
 
-        for source_slash, target_slash in zip([False, True], [False, True]):
+        for source_slash, target_slash in product([False, True], [False, True]):
             s = fs_join(source, "subdir")
             if source_slash:
                 s += "/"
@@ -205,7 +205,7 @@ class AbstractGetTests:
         target = local_target
         local_fs.mkdir(target)
 
-        for source_slash, target_slash in zip([False, True], [False, True]):
+        for source_slash, target_slash in product([False, True], [False, True]):
             s = fs_join(source, "subdir")
             if source_slash:
                 s += "/"
@@ -278,7 +278,7 @@ class AbstractGetTests:
             assert local_fs.ls(target) == []
 
             # With recursive
-            for glob, recursive in zip(["*", "**"], [True, False]):
+            for glob, recursive in product(["*", "**"], [True, False]):
                 fs.get(fs_join(source, "subdir", glob), t, recursive=recursive)
                 assert local_fs.isfile(local_join(target, "subfile1"))
                 assert local_fs.isfile(local_join(target, "subfile2"))
@@ -350,7 +350,7 @@ class AbstractGetTests:
             assert local_fs.ls(target) == []
 
             # With recursive
-            for glob, recursive in zip(["*", "**"], [True, False]):
+            for glob, recursive in product(["*", "**"], [True, False]):
                 fs.get(fs_join(source, "subdir", glob), t, recursive=recursive)
                 assert local_fs.isdir(local_join(target, "newdir"))
                 assert local_fs.isfile(local_join(target, "newdir", "subfile1"))

--- a/fsspec/tests/abstract/put.py
+++ b/fsspec/tests/abstract/put.py
@@ -123,7 +123,7 @@ class AbstractPutTests:
             fs.touch(dummy)
         assert fs.isdir(target)
 
-        for source_slash, target_slash in zip([False, True], [False, True]):
+        for source_slash, target_slash in product([False, True], [False, True]):
             s = fs_join(source, "subdir")
             if source_slash:
                 s += "/"
@@ -198,7 +198,7 @@ class AbstractPutTests:
         target = fs_target
         fs.mkdir(target)
 
-        for source_slash, target_slash in zip([False, True], [False, True]):
+        for source_slash, target_slash in product([False, True], [False, True]):
             s = fs_join(source, "subdir")
             if source_slash:
                 s += "/"
@@ -278,7 +278,7 @@ class AbstractPutTests:
             assert fs.ls(target) == ([] if supports_empty_directories else [dummy])
 
             # With recursive
-            for glob, recursive in zip(["*", "**"], [True, False]):
+            for glob, recursive in product(["*", "**"], [True, False]):
                 fs.put(local_join(source, "subdir", glob), t, recursive=recursive)
                 assert fs.isfile(fs_join(target, "subfile1"))
                 assert fs.isfile(fs_join(target, "subfile2"))
@@ -345,7 +345,7 @@ class AbstractPutTests:
             assert not fs.exists(fs_join(target, "newdir"))
 
             # With recursive
-            for glob, recursive in zip(["*", "**"], [True, False]):
+            for glob, recursive in product(["*", "**"], [True, False]):
                 fs.put(local_join(source, "subdir", glob), t, recursive=recursive)
                 assert fs.isdir(fs_join(target, "newdir"))
                 assert fs.isfile(fs_join(target, "newdir", "subfile1"))


### PR DESCRIPTION
The unit tests for get()/put()/copy() did not cover all combinations of input parameters.