### PR TITLE
Add ref to cat refs

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -123,7 +123,7 @@ class HTTPFileSystem(AsyncFileSystem):
             try:
                 sync(loop, session.close, timeout=0.1)
                 return
-            except (TimeoutError, FSTimeoutError):
+            except (TimeoutError, FSTimeoutError, NotImplementedError):
                 pass
         connector = getattr(session, "_connector", None)
         if connector is not None:

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -416,6 +416,11 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
             raws = np.full(self.record_size, np.nan, dtype="O")
         for j, data in partition.items():
             if isinstance(data, list):
+                if (
+                    str(paths.dtype) == "category"
+                    and data[0] not in paths.dtype.categories
+                ):
+                    paths = paths.add_categories(data[0])
                 paths[j] = data[0]
                 if len(data) > 1:
                     offsets[j] = data[1]


### PR DESCRIPTION
Since Lazy references can be stored as categorical, it needs special handling during updating a reference set, usually via MultiZarrToZarr.append()