### PR TITLE
Infer .lzma files

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -90,15 +90,15 @@ except ImportError:
 try:
     from lzma import LZMAFile
 
-    register_compression("lzma", LZMAFile, "xz")
-    register_compression("xz", LZMAFile, "xz", force=True)
+    register_compression("lzma", LZMAFile, "lzma")
+    register_compression("xz", LZMAFile, "xz")
 except ImportError:
     pass
 
 try:
     import lzmaffi
 
-    register_compression("lzma", lzmaffi.LZMAFile, "xz", force=True)
+    register_compression("lzma", lzmaffi.LZMAFile, "lzma", force=True)
     register_compression("xz", lzmaffi.LZMAFile, "xz", force=True)
 except ImportError:
     pass

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -59,6 +59,7 @@ def test_infer_uppercase_compression():
 def test_lzma_compression_name():
     pytest.importorskip("lzma")
     assert infer_compression("fn.xz") == "xz"
+    assert infer_compression("fn.lzma") == "lzma"
 
 
 def test_lz4_compression(tmpdir):


### PR DESCRIPTION
Currently .lzma files are not inferred correctly and instead are opened as uncompressed stream of data. This PR fixes the problem. There is no issue in the tracker related to this, as far as I can see.