### PR TITLE
Skip test_append_parquet when missing kerchunk

### DIFF
--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -690,6 +690,7 @@ def lazy_refs(m):
 
 
 def test_append_parquet(lazy_refs, m):
+    pytest.importorskip("kerchunk")
     with pytest.raises(KeyError):
         lazy_refs["data/0"]
     lazy_refs["data/0"] = b"data"


### PR DESCRIPTION
This is an optional dependency for writing only, and the test crashes if it's not installed.