### PR TITLE
Enable ruff LOG checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ select = [
     "E7",
     "E9",
     "F",
+    "LOG",
     "PERF",
     "PLC",
     "PLE",


### PR DESCRIPTION
This PR enables the LOG rule family. It is no longer in preview and caught the nasty `logging.getLogger` bug in the codebase that I fixed #1499 