### PR TITLE
Allow parquet refs for deep array trees

### DIFF
--- a/fsspec/implementations/data.py
+++ b/fsspec/implementations/data.py
@@ -1,5 +1,6 @@
 import base64
 import io
+from typing import Optional
 from urllib.parse import unquote
 
 from fsspec import AbstractFileSystem
@@ -49,7 +50,7 @@ class DataFileSystem(AbstractFileSystem):
         return io.BytesIO(self.cat_file(path))
 
     @staticmethod
-    def encode(data: bytes, mime: str | None = None):
+    def encode(data: bytes, mime: Optional[str] = None):
         """Format the given data into data-URL syntax
 
         This version always base64 encodes, even when the data is ascii/url-safe.

--- a/fsspec/implementations/data.py
+++ b/fsspec/implementations/data.py
@@ -14,6 +14,7 @@ class DataFileSystem(AbstractFileSystem):
     ...     print(f.read())
     b"Hello, World!"
 
+    See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
     """
 
     protocol = "data"
@@ -46,3 +47,11 @@ class DataFileSystem(AbstractFileSystem):
         if "r" not in mode:
             raise ValueError("Read only filesystem")
         return io.BytesIO(self.cat_file(path))
+
+    @staticmethod
+    def encode(data: bytes, mime: str | None = None):
+        """Format the given data into data-URL syntax
+
+        This version always base64 encodes, even when the data is ascii/url-safe.
+        """
+        return f"data:{mime or ''};base64,{base64.b64encode(data).decode()}"

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -277,7 +277,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
             return json.dumps(self.zmetadata[key]).encode()
         elif "/" not in key or self._is_meta(key):
             raise KeyError(key)
-        field, sub_key = key.split("/")
+        field, _ = key.rsplit("/", 1)
         record, ri, chunk_size = self._key_to_record(key)
         maybe = self._items.get((field, record), {}).get(ri, False)
         if maybe is None:
@@ -309,7 +309,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
     @lru_cache(4096)
     def _key_to_record(self, key):
         """Details needed to construct a reference for one key"""
-        field, chunk = key.split("/")
+        field, chunk = key.rsplit("/", 1)
         chunk_sizes = self._get_chunk_sizes(field)
         if len(chunk_sizes) == 0:
             return 0, 0, 0
@@ -366,7 +366,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
 
     def __setitem__(self, key, value):
         if "/" in key and not self._is_meta(key):
-            field, chunk = key.split("/")
+            field, chunk = key.rsplit("/", 1)
             record, i, _ = self._key_to_record(key)
             subdict = self._items.setdefault((field, record), {})
             subdict[i] = value
@@ -391,7 +391,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
             del self.zmetadata[key]
         else:
             if "/" in key and not self._is_meta(key):
-                field, chunk = key.split("/")
+                field, _ = key.rsplit("/", 1)
                 record, i, _ = self._key_to_record(key)
                 subdict = self._items.setdefault((field, record), {})
                 subdict[i] = None


### PR DESCRIPTION
(also add encode() to dataFS)