### PR TITLE
Force zip64 when allowZip64 is enabled

### DIFF
--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -56,6 +56,7 @@ class ZipFileSystem(AbstractArchiveFileSystem):
             fo = fsspec.open(
                 fo, mode=m, protocol=target_protocol, **(target_options or {})
             )
+        self.force_zip_64 = allowZip64
         self.of = fo
         self.fo = fo.__enter__()  # the whole instance is a context
         self.zip = zipfile.ZipFile(
@@ -125,7 +126,7 @@ class ZipFileSystem(AbstractArchiveFileSystem):
             raise FileNotFoundError(path)
         if "r" in self.mode and "w" in mode:
             raise OSError("ZipFS can only be open for reading or writing, not both")
-        out = self.zip.open(path, mode.strip("b"))
+        out = self.zip.open(path, mode.strip("b"), force_zip64=self.force_zip_64)
         if "r" in mode:
             info = self.info(path)
             out.size = info["size"]


### PR DESCRIPTION
I came across [this issue](https://github.com/fsspec/filesystem_spec/issues/1474) when it impacted our project [pixelator](https://github.com/pixelgentechnologies/pixelator) where we use fsspec to bundle parquet files into a zip-archive.

I used the code below from the original issue to verify that this works as expected without raising a `RuntimeError: File size unexpectedly exceeded ZIP64 limit` exception.

```
from fsspec.implementations.zip import ZipFileSystem
import zipfile
import numpy as np

small_array = np.random.rand(1000)
with open("small.npz", "wb") as f:
    np.save(f, small_array)

large_array = np.random.rand((int(4e8)))
with open("large.npz", "wb") as f:
    np.save(f, large_array)

with open("./large.npz", "rb") as f:
    large_data = f.read()

with open("./small.npz", "rb") as f:
    small_data = f.read()

# create empty zip file
with zipfile.ZipFile("./test.zip", "w"):
    pass

zfs = ZipFileSystem("./test.zip", "w")

with zfs.open("small_array", "wb") as f:
    f.write(small_data)

with zfs.open("large_array", "wb") as f:
    f.write(large_data)
zfs.close()
```

This closes #1474.