### PR TITLE
Fix #1476 : do not ignore expand arg in open_files

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -643,7 +643,10 @@ def get_fs_token_paths(
     else:
         paths = fs._strip_protocol(paths)
     if isinstance(paths, (list, tuple, set)):
-        paths = expand_paths_if_needed(paths, mode, num, fs, name_function)
+        if expand:
+            paths = expand_paths_if_needed(paths, mode, num, fs, name_function)
+        else:
+            paths = list(paths)
     else:
         if "w" in mode and expand:
             paths = _expand_paths(paths, name_function, num)

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -645,7 +645,7 @@ def get_fs_token_paths(
     if isinstance(paths, (list, tuple, set)):
         if expand:
             paths = expand_paths_if_needed(paths, mode, num, fs, name_function)
-        else:
+        elif not isinstance(paths, list):
             paths = list(paths)
     else:
         if "w" in mode and expand:

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -247,7 +247,7 @@ def test_pickle_after_open_open():
 # Add tests for more file systems and for more glob magic later
 glob_magic_characters = ("[", "]", "!")
 
-# Unit tests for issue #1476 (expand arg ignored in open file)
+# === Start of unit tests for issue #1476 (expand arg ignored in open file) ===
 
 
 @pytest.mark.parametrize("char", glob_magic_characters)
@@ -257,15 +257,12 @@ def test_open_file_read_with_special_characters(tmp_path, char):
     file_path = tmp_path / file_name
     expected_content = "Hello, world!"
 
-    # Write some content to the file
     with open(file_path, "w") as f:
         f.write(expected_content)
 
-    # Try to open the file using fsspec
     with fsspec.open(file_path, "r") as f:
         actual_content = f.read()
 
-    # Assert that the content read matches the expected content
     assert actual_content == expected_content
 
 
@@ -276,15 +273,12 @@ def test_open_files_read_with_special_characters(tmp_path, char):
     file_path = tmp_path / file_name
     expected_content = "Hello, world!"
 
-    # Write some content to the file
     with open(file_path, "w") as f:
         f.write(expected_content)
 
-    # Try to open the file using fsspec
     with fsspec.open_files(file_path, "r")[0] as f:
         actual_content = f.read()
 
-    # Assert that the content read matches the expected content
     assert actual_content == expected_content
 
 
@@ -295,15 +289,12 @@ def test_open_file_write_with_special_characters(tmp_path, char):
     file_path = tmp_path / file_name
     expected_content = "Hello, world!"
 
-    # Write some content to the file
     with fsspec.open(file_path, "w") as f:
         f.write(expected_content)
 
-    # Try to open the file using fsspec
     with open(file_path, "r") as f:
         actual_content = f.read()
 
-    # Assert that the content read matches the expected content
     assert actual_content == expected_content
 
 
@@ -322,7 +313,6 @@ def test_open_files_read_with_special_characters(tmp_path, char):
     ] as f:
         actual_content = f.read()
 
-    # Assert that the content read matches the expected content
     assert actual_content == expected_content
 
 
@@ -333,18 +323,18 @@ def test_open_files_write_with_special_characters(tmp_path, char):
     file_path = tmp_path / file_name
     expected_content = "Hello, world!"
 
-    # Write some content to the file fsspec
     with fsspec.open_files(urlpath=[os.fspath(file_path)], mode="w", auto_mkdir=False)[
         0
     ] as f:
         f.write(expected_content)
 
-    # Try to open the file using fsspec
     with open(file_path, "r") as f:
         actual_content = f.read()
 
-    # Assert that the content read matches the expected content
     assert actual_content == expected_content
+
+
+# === End of upnit tests for issue #1476 (expand arg ignored in open file) ===
 
 
 def test_mismatch():

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -245,7 +245,9 @@ def test_pickle_after_open_open():
 # Similarly, we're careful with '{', '}', and '@' as their special meaning is
 # context-specific and might not be considered special for filenames.
 # Add tests for more file systems and for more glob magic later
-glob_magic_characters = ("[", "]", "!") # ("*", "?") not valid on Windows 
+glob_magic_characters = ["[", "]", "!"]
+if os.name != "nt":
+    glob_magic_characters.extend(("*", "?"))  # not valid on Windows
 
 
 @pytest.mark.parametrize("char", glob_magic_characters)

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -245,9 +245,7 @@ def test_pickle_after_open_open():
 # Similarly, we're careful with '{', '}', and '@' as their special meaning is
 # context-specific and might not be considered special for filenames.
 # Add tests for more file systems and for more glob magic later
-glob_magic_characters = ("[", "]", "!")
-
-# === Start of unit tests for issue #1476 (expand arg ignored in open file) ===
+glob_magic_characters = ("[", "]", "!", "*", "?")
 
 
 @pytest.mark.parametrize("char", glob_magic_characters)
@@ -308,9 +306,9 @@ def test_open_files_read_with_special_characters(tmp_path, char):
     with open(file_path, "w") as f:
         f.write(expected_content)
 
-    with fsspec.open_files(urlpath=[os.fspath(file_path)], mode="r", auto_mkdir=False)[
-        0
-    ] as f:
+    with fsspec.open_files(
+        urlpath=[os.fspath(file_path)], mode="r", auto_mkdir=False, expand=False
+    )[0] as f:
         actual_content = f.read()
 
     assert actual_content == expected_content
@@ -323,18 +321,15 @@ def test_open_files_write_with_special_characters(tmp_path, char):
     file_path = tmp_path / file_name
     expected_content = "Hello, world!"
 
-    with fsspec.open_files(urlpath=[os.fspath(file_path)], mode="w", auto_mkdir=False)[
-        0
-    ] as f:
+    with fsspec.open_files(
+        urlpath=[os.fspath(file_path)], mode="w", auto_mkdir=False, expand=False
+    )[0] as f:
         f.write(expected_content)
 
     with open(file_path, "r") as f:
         actual_content = f.read()
 
     assert actual_content == expected_content
-
-
-# === End of upnit tests for issue #1476 (expand arg ignored in open file) ===
 
 
 def test_mismatch():

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -239,6 +239,114 @@ def test_pickle_after_open_open():
     of2.close()
 
 
+# Define a list of special glob characters.
+# Note that we need to escape some characters and also consider file system limitations.
+# '*' and '?' are excluded because they are not valid for many file systems.
+# Similarly, we're careful with '{', '}', and '@' as their special meaning is
+# context-specific and might not be considered special for filenames.
+# Add tests for more file systems and for more glob magic later
+glob_magic_characters = ("[", "]", "!")
+
+# Unit tests for issue #1476 (expand arg ignored in open file)
+
+
+@pytest.mark.parametrize("char", glob_magic_characters)
+def test_open_file_read_with_special_characters(tmp_path, char):
+    # Create a filename incorporating the special character
+    file_name = f"test{char}.txt"
+    file_path = tmp_path / file_name
+    expected_content = "Hello, world!"
+
+    # Write some content to the file
+    with open(file_path, "w") as f:
+        f.write(expected_content)
+
+    # Try to open the file using fsspec
+    with fsspec.open(file_path, "r") as f:
+        actual_content = f.read()
+
+    # Assert that the content read matches the expected content
+    assert actual_content == expected_content
+
+
+@pytest.mark.parametrize("char", glob_magic_characters)
+def test_open_files_read_with_special_characters(tmp_path, char):
+    # Create a filename incorporating the special character
+    file_name = f"test{char}.txt"
+    file_path = tmp_path / file_name
+    expected_content = "Hello, world!"
+
+    # Write some content to the file
+    with open(file_path, "w") as f:
+        f.write(expected_content)
+
+    # Try to open the file using fsspec
+    with fsspec.open_files(file_path, "r")[0] as f:
+        actual_content = f.read()
+
+    # Assert that the content read matches the expected content
+    assert actual_content == expected_content
+
+
+@pytest.mark.parametrize("char", glob_magic_characters)
+def test_open_file_write_with_special_characters(tmp_path, char):
+    # Create a filename incorporating the special character
+    file_name = f"test{char}.txt"
+    file_path = tmp_path / file_name
+    expected_content = "Hello, world!"
+
+    # Write some content to the file
+    with fsspec.open(file_path, "w") as f:
+        f.write(expected_content)
+
+    # Try to open the file using fsspec
+    with open(file_path, "r") as f:
+        actual_content = f.read()
+
+    # Assert that the content read matches the expected content
+    assert actual_content == expected_content
+
+
+@pytest.mark.parametrize("char", glob_magic_characters)
+def test_open_files_read_with_special_characters(tmp_path, char):
+    # Create a filename incorporating the special character
+    file_name = f"test{char}.txt"
+    file_path = tmp_path / file_name
+    expected_content = "Hello, world!"
+
+    with open(file_path, "w") as f:
+        f.write(expected_content)
+
+    with fsspec.open_files(urlpath=[os.fspath(file_path)], mode="r", auto_mkdir=False)[
+        0
+    ] as f:
+        actual_content = f.read()
+
+    # Assert that the content read matches the expected content
+    assert actual_content == expected_content
+
+
+@pytest.mark.parametrize("char", glob_magic_characters)
+def test_open_files_write_with_special_characters(tmp_path, char):
+    # Create a filename incorporating the special character
+    file_name = f"test{char}.txt"
+    file_path = tmp_path / file_name
+    expected_content = "Hello, world!"
+
+    # Write some content to the file fsspec
+    with fsspec.open_files(urlpath=[os.fspath(file_path)], mode="w", auto_mkdir=False)[
+        0
+    ] as f:
+        f.write(expected_content)
+
+    # Try to open the file using fsspec
+    with open(file_path, "r") as f:
+        actual_content = f.read()
+
+    # Assert that the content read matches the expected content
+    assert actual_content == expected_content
+
+
 def test_mismatch():
     pytest.importorskip("s3fs")
     with pytest.raises(ValueError):

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -245,7 +245,7 @@ def test_pickle_after_open_open():
 # Similarly, we're careful with '{', '}', and '@' as their special meaning is
 # context-specific and might not be considered special for filenames.
 # Add tests for more file systems and for more glob magic later
-glob_magic_characters = ("[", "]", "!", "*", "?")
+glob_magic_characters = ("[", "]", "!") # ("*", "?") not valid on Windows 
 
 
 @pytest.mark.parametrize("char", glob_magic_characters)


### PR DESCRIPTION
Fixes #1476 . Turns out it was caused by a bug where an arg was not respected when calling `open_files` . This PR fixes that bug and adds some detailed regression test for that behavior