### PR TITLE
Use inplace reverse method. More efficient

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -343,7 +343,7 @@ def _un_chain(path, kwargs):
             bit = previous_bit
         out.append((bit, protocol, kw))
         previous_bit = bit
-    out = list(reversed(out))
+    out.reverse()
     return out
 
 

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -1035,7 +1035,7 @@ class ReferenceFileSystem(AsyncFileSystem):
                 par0 = self._parent(par0)
                 subdirs.append(par0)
 
-            subdirs = subdirs[::-1]
+            subdirs.reverse()
             for parent, child in zip(subdirs, subdirs[1:]):
                 # register newly discovered directories
                 assert child not in self.dircache


### PR DESCRIPTION
Uses inplace reverse methods on lists. It's more efficient than `[::-1]` and `list(reversed(a))` which creates a temporary copy.