### PR TITLE
Limit coroutines using a pool instead of chunks

### DIFF
--- a/ci/environment-friends.yml
+++ b/ci/environment-friends.yml
@@ -21,6 +21,7 @@ dependencies:
   - flake8
   - black
   - google-cloud-core
+  - google-cloud-storage
   - google-api-core
   - google-api-python-client
   - httpretty


### PR DESCRIPTION
I've changed the implementation of the function `_run_coros_in_chunks()` by using a coroutine pool instead of running coroutines in chunks.

The goal of this function is to limit the number of simultaneous coroutines, but chunking may lead to inferior throughput when coroutines have different execution times, as the next chunk will run only once all coroutines in the previous chunk have completed. In contrast, a coroutine pool will run the next coroutine in the queue as soon as any of the running coroutines completes.