### PR TITLE
[Docs] Add a Prevailing Library User

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,6 +53,8 @@ The following libraries use ``fsspec`` internally for path and file handling:
    maintainable and modular data science code
 #. `pyxet`_, a Python library for mounting and
    accessing very large datasets from XetHub
+#. `Huggingface🤗 Datasets`_, a popular library to 
+   load&manipulate data for Deep Learning models
 
 ``fsspec`` filesystems are also supported by:
 
@@ -69,8 +71,10 @@ The following libraries use ``fsspec`` internally for path and file handling:
 .. _DVC: https://dvc.org/
 .. _kedro: https://kedro.readthedocs.io/en/stable/01_introduction/01_introduction.html
 .. _pyxet: https://github.com/xetdata/pyxet
+.. _Huggingface🤗 Datasets: https://github.com/huggingface/datasets
 .. _pyarrow: https://arrow.apache.org/docs/python/
 .. _petl: https://petl.readthedocs.io/en/stable/io.html#petl.io.remotes.RemoteSource
+
 
 Installation
 ------------


### PR DESCRIPTION
I unexpectedly discovered that the data tool of the most popular Deep Learning/Transformer library also relies on fsspec, and given its widespread popularity, I believe it would be worthwhile to contribute a pull request (PR) for it :)

https://github.com/huggingface/datasets/issues/6214
https://github.com/search?q=repo%3Ahuggingface%2Fdatasets%20fsspec&type=code