### PR TITLE
improve HTTP debug logging

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -433,7 +433,7 @@ class HTTPFileSystem(AsyncFileSystem):
                 if policy == "get":
                     # If get failed, then raise a FileNotFoundError
                     raise FileNotFoundError(url) from exc
-                logger.debug(str(exc))
+                logger.debug("", exc_info=exc)
 
         return {"name": url, "size": None, **info, "type": "file"}
 


### PR DESCRIPTION
Use `exc_info` to provide the exception info instead.