### PR TITLE
fix: always convert blocks from list to set when loading cache metadata

### DIFF
--- a/fsspec/implementations/cache_metadata.py
+++ b/fsspec/implementations/cache_metadata.py
@@ -58,13 +58,13 @@ class CacheMetadata:
         try:
             with open(fn, "r") as f:
                 loaded = json.load(f)
-                for c in loaded.values():
-                    if isinstance(c.get("blocks"), list):
-                        c["blocks"] = set(c["blocks"])
-                return loaded
         except ValueError:
             with open(fn, "rb") as f:
-                return pickle.load(f)
+                loaded = pickle.load(f)
+        for c in loaded.values():
+            if isinstance(c.get("blocks"), list):
+                c["blocks"] = set(c["blocks"])
+        return loaded
 
     def _save(self, metadata_to_save: Detail, fn: str) -> None:
         """Low-level function to save metadata to specific file"""

--- a/fsspec/implementations/cache_metadata.py
+++ b/fsspec/implementations/cache_metadata.py
@@ -57,7 +57,11 @@ class CacheMetadata:
         """Low-level function to load metadata from specific file"""
         try:
             with open(fn, "r") as f:
-                return json.load(f)
+                loaded = json.load(f)
+                for c in loaded.values():
+                    if isinstance(c.get("blocks"), list):
+                        c["blocks"] = set(c["blocks"])
+                return loaded
         except ValueError:
             with open(fn, "rb") as f:
                 return pickle.load(f)
@@ -152,11 +156,7 @@ class CacheMetadata:
         for fn, _, _ in self._scan_locations():
             if os.path.exists(fn):
                 # TODO: consolidate blocks here
-                loaded_cached_files = self._load(fn)
-                for c in loaded_cached_files.values():
-                    if isinstance(c["blocks"], list):
-                        c["blocks"] = set(c["blocks"])
-                cached_files.append(loaded_cached_files)
+                cached_files.append(self._load(fn))
             else:
                 cached_files.append({})
         self.cached_files = cached_files or [{}]


### PR DESCRIPTION
Currently the `load()` method handles the conversion but the `_load()` method doesn't, even though it's used by `save()`.

This commit moves the conversion to the `_load()` method so that the blocks are always of the expected type.

I've struggled to find a way to test this, would appreciate any advice there!

Fixes #1555.