### PR TITLE
dev/hugabora/issue-1559 mv swallows copy errors for recursive

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1170,12 +1170,12 @@ class AbstractFileSystem(metaclass=_Cached):
             raise FileNotFoundError(path)
         return sorted(out)
 
-    def mv(self, path1, path2, recursive=False, maxdepth=None, **kwargs):
+    def mv(self, path1, path2, recursive=False, maxdepth=None, on_error=None, **kwargs):
         """Move file(s) from one location to another"""
         if path1 == path2:
             logger.debug("%s mv: The paths are the same, so no files were moved.", self)
         else:
-            self.copy(path1, path2, recursive=recursive, maxdepth=maxdepth)
+            self.copy(path1, path2, recursive=recursive, maxdepth=maxdepth, on_error)
             self.rm(path1, recursive=recursive)
 
     def rm_file(self, path):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1175,7 +1175,7 @@ class AbstractFileSystem(metaclass=_Cached):
         if path1 == path2:
             logger.debug("%s mv: The paths are the same, so no files were moved.", self)
         else:
-            self.copy(path1, path2, recursive=recursive, maxdepth=maxdepth, on_error)
+            self.copy(path1, path2, recursive=recursive, maxdepth=maxdepth, on_error=on_error)
             self.rm(path1, recursive=recursive)
 
     def rm_file(self, path):


### PR DESCRIPTION
Created an issue ticket https://github.com/fsspec/filesystem_spec/issues/1559
Added on_error to fsspec mv and it is passed on now

```python
# fsspec-test.py
import s3fs

source_path = './fsspec-test.py'
target_path = 's3://good-bucket/foo'
move_path = 's3://BAD_BUCKET/foo'

s3 = s3fs.S3FileSystem(anon=False)
s3.put(source_path, target_path)
s3.mv(target_path, move_path, recursive=True, on_error='raise')
```