### PR TITLE
allow ReferenceFileSystem to hold dicts, which are treated as JSON files

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -935,7 +935,10 @@ class ReferenceFileSystem(AsyncFileSystem):
 
     def _process_references0(self, references):
         """Make reference dict for Spec Version 0"""
-        references = {key: json.dumps(val) if isinstance(val, dict) else val for key, val in references.items()}
+        references = {
+            key: json.dumps(val) if isinstance(val, dict) else val
+            for key, val in references.items()
+        }
         self.references = references
 
     def _process_references1(self, references, template_overrides=None):

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -935,6 +935,7 @@ class ReferenceFileSystem(AsyncFileSystem):
 
     def _process_references0(self, references):
         """Make reference dict for Spec Version 0"""
+        references = {key: json.dumps(val) if isinstance(val, dict) else val for key, val in references.items()}
         self.references = references
 
     def _process_references1(self, references, template_overrides=None):

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -964,6 +964,8 @@ class ReferenceFileSystem(AsyncFileSystem):
                     else:
                         u = _render_jinja(u)
                 self.references[k] = [u] if len(v) == 1 else [u, v[1], v[2]]
+            elif isinstance(v, dict):
+                self.references[k] = json.dumps(v)
             else:
                 self.references[k] = v
         self.references.update(self._process_gen(references.get("gen", [])))

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -42,7 +42,7 @@ def test_simple_ver1(server):  # noqa: F811
             "c": (realfile, 1, 5),
             "d": b"base64:aGVsbG8=",
             "e": {"key": "value"},
-        }
+        },
     }
     h = fsspec.filesystem("http")
     fs = fsspec.filesystem("reference", fo=in_data, fs=h)

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -19,6 +19,7 @@ def test_simple(server):  # noqa: F811
         "b": (realfile, 0, 5),
         "c": (realfile, 1, 5),
         "d": b"base64:aGVsbG8=",
+        "e": {"key": "value"},
     }
     h = fsspec.filesystem("http")
     fs = fsspec.filesystem("reference", fo=refs, fs=h)
@@ -27,6 +28,30 @@ def test_simple(server):  # noqa: F811
     assert fs.cat("b") == data[:5]
     assert fs.cat("c") == data[1 : 1 + 5]
     assert fs.cat("d") == b"hello"
+    assert fs.cat("e") == b'{"key": "value"}'
+    with fs.open("d", "rt") as f:
+        assert f.read(2) == "he"
+
+
+def test_simple_ver1(server):  # noqa: F811
+    in_data = {
+        "version": 1,
+        "refs": {
+            "a": b"data",
+            "b": (realfile, 0, 5),
+            "c": (realfile, 1, 5),
+            "d": b"base64:aGVsbG8=",
+            "e": {"key": "value"},
+        }
+    }
+    h = fsspec.filesystem("http")
+    fs = fsspec.filesystem("reference", fo=in_data, fs=h)
+
+    assert fs.cat("a") == b"data"
+    assert fs.cat("b") == data[:5]
+    assert fs.cat("c") == data[1 : 1 + 5]
+    assert fs.cat("d") == b"hello"
+    assert fs.cat("e") == b'{"key": "value"}'
     with fs.open("d", "rt") as f:
         assert f.read(2) == "he"
 


### PR DESCRIPTION
Currently, when a ReferenceFileSystem wants to create an inline JSON file, the value needs to be a JSON string, e.g.

```json
{
  "version": 1,
  "refs": {
    ".zgroup": "{\"zarr_format\": 2}",
    "data/.zarray": "{\"chunks\": [100, 100], \"compressor\": null, \"dtype\": \"<i8\", \"fill_value\": null, \"filters\": null, \"order\": \"C\", \"shape\": [100, 100], \"zarr_format\": 2}",
    "data/.zattrs": "{\"_ARRAY_DIMENSIONS\": [\"a\", \"b\"]}",
    "data/0.0": [
      "example4.h5",
      2048,
      80000
    ]
  }
}
```

The proposed change allows the JSON string to instead be dicts, which would allow the RFS to be:

```json
{
  "version": 1,
  "refs": {
    ".zgroup": {
      "zarr_format": 2
    },
    "data/.zarray": {
      "chunks": [
        100,
        100
      ],
      "compressor": null,
      "dtype": "<i8",
      "fill_value": null,
      "filters": null,
      "order": "C",
      "shape": [
        100,
        100
      ],
      "zarr_format": 2
    },
    "data/.zattrs": {
      "_ARRAY_DIMENSIONS": [
        "a",
        "b"
      ]
    },
    "data/0.0": [
      "example4.h5",
      2048,
      80000
    ]
  }
}
```

This allows for easier reading, writing, manipulation, and JSON-specific search tools