### PR TITLE
use parrow as engine in LazyReferenceMapper.write

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -464,7 +464,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         self.fs.mkdirs(f"{base_url or self.out_root}/{field}", exist_ok=True)
         df.to_parquet(
             fn,
-            engine="fastparquet",
+            engine="pyarrow",
             storage_options=storage_options
             or getattr(self.fs, "storage_options", None),
             compression="zstd",


### PR DESCRIPTION
Closes #1563

Not tested.