### PR TITLE
add fastparquet dependency option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
     "libarchive": ["libarchive-c"],
     "gui": ["panel"],
     "tqdm": ["tqdm"],
+    "parquet": ["fastparquet"],
 }
 # To simplify full installation
 extras_require["full"] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
This is necessary for getting tests to work with `pip install .[full]`