### PR TITLE
Tracking cache requests

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -735,7 +735,6 @@ class BackgroundBlockCache(BaseCache):
         self._fetch_future: Future[bytes] | None = None
         self._fetch_future_lock = threading.Lock()
 
-
     def cache_info(self) -> UpdatableLRU.CacheInfo:
         """
         The statistics on the block cache.

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -80,6 +80,7 @@ class BaseCache:
         self.total_requested_bytes = 0
 
     def __repr__(self) -> str:
+        # TODO: use rich for better formatting
         return f"""
             cache type  :   {self.__class__.__name__} 
             block size  :   {self.blocksize}

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -478,7 +478,6 @@ class BytesCache(BaseCache):
                     self.cache = self.fetcher(start, bend)
                     self.start = start
                 else:
-
                     self.total_requested_bytes += self.start - start
                     new = self.fetcher(start, self.start)
                     self.start = start

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -79,16 +79,28 @@ class BaseCache:
         self.miss_count = 0
         self.total_requested_bytes = 0
 
+    def _log_stats(self) -> str:
+        """Return a formatted string of the cache statistics."""
+        if self.hit_count == 0 and self.miss_count == 0:
+            # a cache that does nothing, this is for logs only
+            return ""
+        return " , %s: %d hits, %d misses, %d total requested bytes" % (
+            self.name,
+            self.hit_count,
+            self.miss_count,
+            self.total_requested_bytes,
+        )
+
     def __repr__(self) -> str:
         # TODO: use rich for better formatting
         return f"""
-            cache type  :   {self.__class__.__name__} 
+        <{self.__class__.__name__}:
             block size  :   {self.blocksize}
             block count :   {self.nblocks}
             file size   :   {self.size}
             cache hits  :   {self.hit_count}
             cache misses:   {self.miss_count}
-            total requested bytes: {self.total_requested_bytes}
+            total requested bytes: {self.total_requested_bytes}>
         """
 
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1847,13 +1847,11 @@ class AbstractBufferedFile(io.IOBase):
         out = self.cache._fetch(self.loc, self.loc + length)
 
         logger.debug(
-            "%s read: %i - %i, total: %i, cache hits: %i, cache misses: %i",
+            "%s read: %i - %i %s",
             self,
             self.loc,
             self.loc + length,
-            self.cache.total_requested_bytes,
-            self.cache.hit_count,
-            self.cache.miss_count,
+            self.cache._log_stats(),
         )
         self.loc += len(out)
         return out

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1846,10 +1846,15 @@ class AbstractBufferedFile(io.IOBase):
             return b""
         out = self.cache._fetch(self.loc, self.loc + length)
 
-        logger.debug("%s read: %i - %i, total: %i, cache hits: %i, cache misses: %i",
-                     self, self.loc, self.loc + length, self.cache.total_requested_bytes,
-                     self.cache.hit_count, self.cache.miss_count
-                     )
+        logger.debug(
+            "%s read: %i - %i, total: %i, cache hits: %i, cache misses: %i",
+            self,
+            self.loc,
+            self.loc + length,
+            self.cache.total_requested_bytes,
+            self.cache.hit_count,
+            self.cache.miss_count,
+        )
         self.loc += len(out)
         return out
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1839,11 +1839,15 @@ class AbstractBufferedFile(io.IOBase):
             length = self.size - self.loc
         if self.closed:
             raise ValueError("I/O operation on closed file.")
-        logger.debug("%s read: %i - %i", self, self.loc, self.loc + length)
         if length == 0:
             # don't even bother calling fetch
             return b""
         out = self.cache._fetch(self.loc, self.loc + length)
+
+        logger.debug("%s read: %i - %i, total: %i, cache hits: %i, cache misses: %i",
+                     self, self.loc, self.loc + length, self.cache.total_requested_bytes,
+                     self.cache.hit_count, self.cache.miss_count
+                     )
         self.loc += len(out)
         return out
 

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -25,7 +25,9 @@ def test_block_cache_lru():
     BlockCache is a cache that stores blocks of data and uses LRU to evict
     """
     block_size = 4
-    cache = BlockCache(block_size, letters_fetcher, len(string.ascii_letters), maxblocks=2)
+    cache = BlockCache(
+        block_size, letters_fetcher, len(string.ascii_letters), maxblocks=2
+    )
     # miss
     cache._fetch(0, 2)
     assert cache.cache_info().misses == 1

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -21,9 +21,7 @@ def test_cache_getitem(Cache_imp):
 
 
 def test_block_cache_lru():
-    """
-    BlockCache is a cache that stores blocks of data and uses LRU to evict
-    """
+    # BlockCache is a cache that stores blocks of data and uses LRU to evict
     block_size = 4
     cache = BlockCache(
         block_size, letters_fetcher, len(string.ascii_letters), maxblocks=2

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -92,8 +92,8 @@ def test_first_cache():
 
 def test_readahead_cache():
     """
-    ReadAheadCache is a cache that reads ahead of the requested range
-    and if a reasd is not sequential it will be very inefficient.
+    ReadAheadCache is a cache that reads ahead of the requested range.
+    If the access pattern is not sequential it will be very inefficient.
     """
     cache = ReadAheadCache(5, letters_fetcher, len(string.ascii_letters))
     assert cache._fetch(12, 15) == letters_fetcher(12, 15)


### PR DESCRIPTION
As discussed in https://github.com/fsspec/filesystem_spec/discussions/1527 this PR adds a few extra variables in the cache implementation to keep track of bytes requested vs cache hits. The numbers can be accessed directly or via the logs in debug mode. 

This is also useful to benchmark the I/O behavior of the different cache implementations.