### PR TITLE
LocalFileSystem restore _strip_protocol signature

### DIFF
--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - git
+  - git <2.45.0
   - py
   - pip:
     - hadoop-test-cluster

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -283,7 +283,9 @@ def make_path_posix(path):
         if isinstance(path, (list, set, tuple)):
             return type(path)(make_path_posix(p) for p in path)
         else:
-            path = str(stringify_path(path))
+            path = stringify_path(path)
+            if not isinstance(path, str):
+                raise TypeError(f"could not convert {path!r} to string")
     if os.sep == "/":
         # Native posix
         if path.startswith("/"):

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -116,8 +116,8 @@ class LocalFileSystem(AbstractFileSystem):
         return osp.lexists(path)
 
     def cp_file(self, path1, path2, **kwargs):
-        path1 = self._strip_protocol(path1).rstrip("/")
-        path2 = self._strip_protocol(path2).rstrip("/")
+        path1 = self._strip_protocol(path1)
+        path2 = self._strip_protocol(path2)
         if self.auto_mkdir:
             self.makedirs(self._parent(path2), exist_ok=True)
         if self.isfile(path1):
@@ -146,8 +146,8 @@ class LocalFileSystem(AbstractFileSystem):
         return self.cp_file(path1, path2, **kwargs)
 
     def mv_file(self, path1, path2, **kwargs):
-        path1 = self._strip_protocol(path1).rstrip("/")
-        path2 = self._strip_protocol(path2).rstrip("/")
+        path1 = self._strip_protocol(path1)
+        path2 = self._strip_protocol(path2)
         shutil.move(path1, path2)
 
     def link(self, src, dst, **kwargs):
@@ -171,7 +171,7 @@ class LocalFileSystem(AbstractFileSystem):
             path = [path]
 
         for p in path:
-            p = self._strip_protocol(p).rstrip("/")
+            p = self._strip_protocol(p)
             if self.isdir(p):
                 if not recursive:
                     raise ValueError("Cannot delete directory, set recursive=True")
@@ -214,11 +214,8 @@ class LocalFileSystem(AbstractFileSystem):
 
     @classmethod
     def _parent(cls, path):
-        path = cls._strip_protocol(path).rstrip("/")
-        if "/" in path:
-            return path.rsplit("/", 1)[0]
-        else:
-            return cls.root_marker
+        path = cls._strip_protocol(path)
+        return osp.dirname(path) or cls.root_marker
 
     @classmethod
     def _strip_protocol(cls, path):
@@ -231,7 +228,9 @@ class LocalFileSystem(AbstractFileSystem):
             path = path[8:]
         elif path.startswith("local:"):
             path = path[6:]
-        return make_path_posix(path).rstrip("/") or cls.root_marker
+        drive, path = osp.splitdrive(make_path_posix(path))
+        path = path.rstrip("/") or cls.root_marker
+        return drive + path
 
     def _isfilestore(self):
         # Inheriting from DaskFileSystem makes this False (S3, etc. were)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -3,6 +3,7 @@ import io
 import logging
 import os
 import os.path as osp
+import re
 import shutil
 import stat
 import tempfile
@@ -13,12 +14,6 @@ from fsspec.core import get_compression
 from fsspec.utils import isfilelike, stringify_path
 
 logger = logging.getLogger("fsspec.local")
-
-
-def _remove_prefix(text: str, prefix: str):
-    if text.startswith(prefix):
-        return text[len(prefix) :]
-    return text
 
 
 class LocalFileSystem(AbstractFileSystem):
@@ -121,8 +116,8 @@ class LocalFileSystem(AbstractFileSystem):
         return osp.lexists(path)
 
     def cp_file(self, path1, path2, **kwargs):
-        path1 = self._strip_protocol(path1, remove_trailing_slash=True)
-        path2 = self._strip_protocol(path2, remove_trailing_slash=True)
+        path1 = self._strip_protocol(path1).rstrip("/")
+        path2 = self._strip_protocol(path2).rstrip("/")
         if self.auto_mkdir:
             self.makedirs(self._parent(path2), exist_ok=True)
         if self.isfile(path1):
@@ -151,8 +146,8 @@ class LocalFileSystem(AbstractFileSystem):
         return self.cp_file(path1, path2, **kwargs)
 
     def mv_file(self, path1, path2, **kwargs):
-        path1 = self._strip_protocol(path1, remove_trailing_slash=True)
-        path2 = self._strip_protocol(path2, remove_trailing_slash=True)
+        path1 = self._strip_protocol(path1).rstrip("/")
+        path2 = self._strip_protocol(path2).rstrip("/")
         shutil.move(path1, path2)
 
     def link(self, src, dst, **kwargs):
@@ -176,7 +171,7 @@ class LocalFileSystem(AbstractFileSystem):
             path = [path]
 
         for p in path:
-            p = self._strip_protocol(p, remove_trailing_slash=True)
+            p = self._strip_protocol(p).rstrip("/")
             if self.isdir(p):
                 if not recursive:
                     raise ValueError("Cannot delete directory, set recursive=True")
@@ -219,32 +214,24 @@ class LocalFileSystem(AbstractFileSystem):
 
     @classmethod
     def _parent(cls, path):
-        path = cls._strip_protocol(path, remove_trailing_slash=True)
-        if os.sep == "/":
-            # posix native
-            return path.rsplit("/", 1)[0] or "/"
+        path = cls._strip_protocol(path).rstrip("/")
+        if "/" in path:
+            return path.rsplit("/", 1)[0]
         else:
-            # NT
-            path_ = path.rsplit("/", 1)[0]
-            if len(path_) <= 3:
-                if path_[1:2] == ":":
-                    # nt root (something like c:/)
-                    return path_[0] + ":/"
-            # More cases may be required here
-            return path_
+            return cls.root_marker
 
     @classmethod
-    def _strip_protocol(cls, path, remove_trailing_slash=False):
+    def _strip_protocol(cls, path):
         path = stringify_path(path)
-        if path.startswith("file:"):
-            path = _remove_prefix(_remove_prefix(path, "file://"), "file:")
-            if os.sep == "\\":
-                path = path.lstrip("/")
+        if path.startswith("file://"):
+            path = path[7:]
+        elif path.startswith("file:"):
+            path = path[5:]
+        elif path.startswith("local://"):
+            path = path[8:]
         elif path.startswith("local:"):
-            path = _remove_prefix(_remove_prefix(path, "local://"), "local:")
-            if os.sep == "\\":
-                path = path.lstrip("/")
-        return make_path_posix(path, remove_trailing_slash)
+            path = path[6:]
+        return make_path_posix(path).rstrip("/") or cls.root_marker
 
     def _isfilestore(self):
         # Inheriting from DaskFileSystem makes this False (S3, etc. were)
@@ -257,42 +244,47 @@ class LocalFileSystem(AbstractFileSystem):
         return os.chmod(path, mode)
 
 
-def make_path_posix(path, remove_trailing_slash=False):
-    """Make path generic for current OS"""
-    if not isinstance(path, str):
-        if isinstance(path, (list, set, tuple)):
-            return type(path)(make_path_posix(p, remove_trailing_slash) for p in path)
-        else:
-            path = str(stringify_path(path))
-    if os.sep == "/":
-        # Native posix
+def make_path_posix(path, sep=os.sep):
+    """Make path generic"""
+    if isinstance(path, (list, set, tuple)):
+        return type(path)(make_path_posix(p) for p in path)
+    if "~" in path:
+        path = osp.expanduser(path)
+    if sep == "/":
+        # most common fast case for posix
         if path.startswith("/"):
-            # most common fast case for posix
-            return path.rstrip("/") or "/" if remove_trailing_slash else path
-        elif path.startswith("~"):
-            return make_path_posix(osp.expanduser(path), remove_trailing_slash)
-        elif path.startswith("./"):
+            return path
+        if path.startswith("./"):
             path = path[2:]
-            path = f"{os.getcwd()}/{path}"
-            return path.rstrip("/") or "/" if remove_trailing_slash else path
         return f"{os.getcwd()}/{path}"
-    else:
-        # NT handling
-        if len(path) > 1:
-            if path[1] == ":":
-                # windows full path like "C:\\local\\path"
-                if len(path) <= 3:
-                    # nt root (something like c:/)
-                    return path[0] + ":/"
-                path = path.replace("\\", "/").replace("//", "/")
-                return path.rstrip("/") if remove_trailing_slash else path
-            elif path[0] == "~":
-                return make_path_posix(osp.expanduser(path), remove_trailing_slash)
-            elif path.startswith(("\\\\", "//")):
-                # windows UNC/DFS-style paths
-                path = "//" + path[2:].replace("\\", "/").replace("//", "/")
-                return path.rstrip("/") if remove_trailing_slash else path
-        return make_path_posix(osp.abspath(path), remove_trailing_slash)
+    if (
+        (sep not in path and "/" not in path)
+        or (sep == "/" and not path.startswith("/"))
+        or (sep == "\\" and ":" not in path and not path.startswith("\\\\"))
+    ):
+        # relative path like "path" or "rel\\path" (win) or rel/path"
+        if os.sep == "\\":
+            # abspath made some more '\\' separators
+            return make_path_posix(osp.abspath(path))
+        else:
+            return f"{os.getcwd()}/{path}"
+    if path.startswith("file://"):
+        path = path[7:]
+    if re.match("/[A-Za-z]:", path):
+        # for windows file URI like "file:///C:/folder/file"
+        # or "file:///C:\\dir\\file"
+        path = path[1:].replace("\\", "/").replace("//", "/")
+    if path.startswith("\\\\"):
+        # special case for windows UNC/DFS-style paths, do nothing,
+        # just flip the slashes around (case below does not work!)
+        return path.replace("\\", "/")
+    if re.match("[A-Za-z]:", path):
+        # windows full path like "C:\\local\\path"
+        return path.lstrip("\\").replace("\\", "/").replace("//", "/")
+    if path.startswith("\\"):
+        # windows network path like "\\server\\path"
+        return "/" + path.lstrip("\\").replace("\\", "/").replace("//", "/")
+    return path
 
 
 def trailing_sep(path):

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -278,7 +278,7 @@ class LocalFileSystem(AbstractFileSystem):
 
 
 def make_path_posix(path):
-    """Make path generic for current OS"""
+    """Make path generic and absolute for current OS"""
     if not isinstance(path, str):
         if isinstance(path, (list, set, tuple)):
             return type(path)(make_path_posix(p) for p in path)

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -474,7 +474,6 @@ def test_make_path_posix():
         assert make_path_posix("/posix") == f"{drive}:/posix"
         # Windows drive requires trailing slash
         assert make_path_posix("C:\\") == "C:/"
-        assert make_path_posix("C:\\", remove_trailing_slash=True) == "C:/"
     else:
         assert make_path_posix("/a/posix/path") == "/a/posix/path"
         assert make_path_posix("/posix") == "/posix"
@@ -656,7 +655,7 @@ def test_strip_protocol_expanduser():
     assert "~" not in stripped
     assert "file://" not in stripped
     assert stripped.startswith(os.path.expanduser("~").replace("\\", "/"))
-    path = LocalFileSystem._strip_protocol("./", remove_trailing_slash=True)
+    path = LocalFileSystem._strip_protocol("./")
     assert not path.endswith("/")
 
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -595,9 +595,8 @@ def test_make_path_posix_set_list_tuple(container_cls):
         object(),
     ],
 )
-@pytest.mark.xfail(reason="all inputs coerced to string")
 def test_make_path_posix_wrong_type(obj):
-    with pytest.raises(AttributeError):  # should probably be changed to TypeError
+    with pytest.raises(TypeError):
         make_path_posix(obj)
 
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -542,10 +542,20 @@ def test_make_path_posix():
         "abc/def",
         "",
         ".",
-        "//server/share",
+        "//server/share/",
+        "\\\\server\\share\\",
         "C:\\",
         "d:/abc/def",
         "e:",
+        pytest.param(
+            "\\\\server\\share",
+            marks=[
+                pytest.mark.xfail(
+                    WIN and sys.version_info < (3, 11),
+                    reason="requires py3.11+ see: python/cpython#96290",
+                )
+            ],
+        ),
         pytest.param(
             "f:foo",
             marks=[pytest.mark.xfail(WIN, reason="unsupported")],

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -350,8 +350,6 @@ def stringify_path(filepath: str | os.PathLike[str] | pathlib.Path) -> str:
         return filepath
     elif hasattr(filepath, "__fspath__"):
         return filepath.__fspath__()
-    elif isinstance(filepath, pathlib.Path):
-        return str(filepath)
     elif hasattr(filepath, "path"):
         return filepath.path
     else:


### PR DESCRIPTION
Hello,

I noticed that the `LocalFileSystem._strip_protocol` signature changed in #1477, when running the universal_pathlib test-suite against the current fsspec version.

To me it seems that the intention of #1477 was initially to prevent `"C:/"` or `"C:\\"` to be reduced to `"C:"` by `_strip_protocol`, but in addition it introduced function signature changes in `fsspec.implementations.local` and minor changes in `fsspec.mapping`.

I created this PR as a basis for discussion if the signature change could be avoided. In this PR I reverted the changes to `LocalFileSystem` and `make_path_posix` but kept the changes to the tests (first commit) and then provide an alternative implementation that avoids the function signature change.

I would also be happy to try to add more tests around the `LocalFileSystem._parent`, `LocalFileSystem._strip_protocol` and `make_path_posix` behavior for edge-cases if there is interest. But windows is not my main OS for daily work, so I am very likely not aware of most of them.


Cheers,
Andreas




