### PR TITLE
Use "post-release" versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ Homepage = "https://github.com/fsspec/filesystem_spec"
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = {'version_scheme'='post-release'}
 
 [tool.hatch.build.hooks.vcs]
 version-file = "fsspec/_version.py"


### PR DESCRIPTION
For version 2024.3.1, further dev commits or working tree will have versions like 2024.3.1.XXX rather than 2024.3.2.XXX to allow s3fs and gcsfs's requirements in CI to be met.