### PR TITLE
Do not swallow errors on mv

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,7 +53,7 @@ The following libraries use ``fsspec`` internally for path and file handling:
    maintainable and modular data science code
 #. `pyxet`_, a Python library for mounting and
    accessing very large datasets from XetHub
-#. `Huggingface🤗 Datasets`_, a popular library to 
+#. `Huggingface🤗 Datasets`_, a popular library to
    load&manipulate data for Deep Learning models
 
 ``fsspec`` filesystems are also supported by:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1177,7 +1177,10 @@ class AbstractFileSystem(metaclass=_Cached):
         if path1 == path2:
             logger.debug("%s mv: The paths are the same, so no files were moved.", self)
         else:
-            self.copy(path1, path2, recursive=recursive, maxdepth=maxdepth)
+            # explicitly raise exception to prevent data corruption
+            self.copy(
+                path1, path2, recursive=recursive, maxdepth=maxdepth, onerror="raise"
+            )
             self.rm(path1, recursive=recursive)
 
     def rm_file(self, path):

--- a/fsspec/tests/abstract/mv.py
+++ b/fsspec/tests/abstract/mv.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+import pytest
+
+import fsspec
+
+
+def test_move_raises_error_with_tmpdir(tmpdir):
+    # Create a file in the temporary directory
+    source = tmpdir.join("source_file.txt")
+    source.write("content")
+
+    # Define a destination that simulates a protected or invalid path
+    destination = tmpdir.join("non_existent_directory/destination_file.txt")
+
+    # Instantiate the filesystem (assuming the local file system interface)
+    fs = fsspec.filesystem("file")
+
+    # Patch the entire `mv` method to control the behavior fully
+    with patch.object(fs, "mv", autospec=True) as mock_mv:
+        # Configure the mock to raise an OSError when called
+        mock_mv.side_effect = OSError("Unable to move the file")
+
+        # Use the actual file paths as string
+        with pytest.raises(OSError) as excinfo:
+            fs.mv(str(source), str(destination))
+
+        # Assert the message of the raised OSError matches the expected message
+        assert "Unable to move the file" in str(excinfo.value)

--- a/fsspec/tests/abstract/mv.py
+++ b/fsspec/tests/abstract/mv.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 import fsspec
@@ -16,14 +14,6 @@ def test_move_raises_error_with_tmpdir(tmpdir):
     # Instantiate the filesystem (assuming the local file system interface)
     fs = fsspec.filesystem("file")
 
-    # Patch the entire `mv` method to control the behavior fully
-    with patch.object(fs, "mv", autospec=True) as mock_mv:
-        # Configure the mock to raise an OSError when called
-        mock_mv.side_effect = OSError("Unable to move the file")
-
-        # Use the actual file paths as string
-        with pytest.raises(OSError) as excinfo:
-            fs.mv(str(source), str(destination))
-
-        # Assert the message of the raised OSError matches the expected message
-        assert "Unable to move the file" in str(excinfo.value)
+    # Use the actual file paths as string
+    with pytest.raises(FileNotFoundError):
+        fs.mv(str(source), str(destination))

--- a/fsspec/tests/abstract/mv.py
+++ b/fsspec/tests/abstract/mv.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import fsspec
@@ -17,3 +19,39 @@ def test_move_raises_error_with_tmpdir(tmpdir):
     # Use the actual file paths as string
     with pytest.raises(FileNotFoundError):
         fs.mv(str(source), str(destination))
+
+
+@pytest.mark.parametrize("recursive", (True, False))
+def test_move_raises_error_with_tmpdir_permission(recursive, tmpdir):
+    # Create a file in the temporary directory
+    source = tmpdir.join("source_file.txt")
+    source.write("content")
+
+    # Create a protected directory (non-writable)
+    protected_dir = tmpdir.mkdir("protected_directory")
+    protected_path = str(protected_dir)
+
+    # Set the directory to read-only
+    if os.name == "nt":
+        os.system(f'icacls "{protected_path}" /deny Everyone:(W)')
+    else:
+        os.chmod(protected_path, 0o555)  # Sets the directory to read-only
+
+    # Define a destination inside the protected directory
+    destination = protected_dir.join("destination_file.txt")
+
+    # Instantiate the filesystem (assuming the local file system interface)
+    fs = fsspec.filesystem("file")
+
+    # Try to move the file to the read-only directory, expecting a permission error
+    with pytest.raises(PermissionError):
+        fs.mv(str(source), str(destination), recursive=recursive)
+
+    # Assert the file was not created in the destination
+    assert not os.path.exists(destination)
+
+    # Cleanup: Restore permissions so the directory can be cleaned up
+    if os.name == "nt":
+        os.system(f'icacls "{protected_path}" /remove:d Everyone')
+    else:
+        os.chmod(protected_path, 0o755)  # Restore write permission for cleanup


### PR DESCRIPTION
fixes #1559 . This prevents data corruption when using fsspec.mv and adds a unit test.