### PR TITLE
Strip protocol from paths in fsspec.generic.GenericFileSystem._copy

### DIFF
--- a/fsspec/generic.py
+++ b/fsspec/generic.py
@@ -348,6 +348,11 @@ class GenericFileSystem(AsyncFileSystem):
             raise NotImplementedError
         fs = _resolve_fs(path1[0], self.method)
         fs2 = _resolve_fs(path2[0], self.method)
+
+        # strip all paths here, after resolve...
+        path1 = [fs._strip_protocol(p) for p in path1]
+        path2 = [fs2._strip_protocol(p) for p in path2]
+
         # not expanding paths atm., assume call is from rsync()
         if fs is fs2:
             # pure remote


### PR DESCRIPTION
Seems to fix a problem I was having.
Can't do it upstream in the `rsync` method because at least one file needs the protocol to resolve the proper filesystem.