### PR TITLE
DirFileSystem.mv should call the underlying fs

### DIFF
--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -329,12 +329,14 @@ class DirFileSystem(AsyncFileSystem):
     def rmdir(self, path):
         return self.fs.rmdir(self._join(path))
 
-    def mv_file(self, path1, path2, **kwargs):
-        return self.fs.mv_file(
+    def mv(self, path1, path2, **kwargs):
+        return self.fs.mv(
             self._join(path1),
             self._join(path2),
             **kwargs,
         )
+
+    mv_file = mv
 
     def touch(self, path, **kwargs):
         return self.fs.touch(self._join(path), **kwargs)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -150,10 +150,12 @@ class LocalFileSystem(AbstractFileSystem):
     def put_file(self, path1, path2, callback=None, **kwargs):
         return self.cp_file(path1, path2, **kwargs)
 
-    def mv_file(self, path1, path2, **kwargs):
+    def mv(self, path1, path2, **kwargs):
         path1 = self._strip_protocol(path1, remove_trailing_slash=True)
         path2 = self._strip_protocol(path2, remove_trailing_slash=True)
         shutil.move(path1, path2)
+
+    mv_file = mv
 
     def link(self, src, dst, **kwargs):
         src = self._strip_protocol(src)

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -542,10 +542,10 @@ def test_rmdir(mocker, dirfs):
     dirfs.fs.rmdir.assert_called_once_with(f"{PATH}/dir")
 
 
-def test_mv_file(mocker, dirfs):
-    dirfs.fs.mv_file = mocker.Mock()
-    dirfs.mv_file("one", "two", **KWARGS)
-    dirfs.fs.mv_file.assert_called_once_with(f"{PATH}/one", f"{PATH}/two", **KWARGS)
+def test_mv(mocker, dirfs):
+    dirfs.fs.mv = mocker.Mock()
+    dirfs.mv("one", "two", **KWARGS)
+    dirfs.fs.mv.assert_called_once_with(f"{PATH}/one", f"{PATH}/two", **KWARGS)
 
 
 def test_touch(mocker, dirfs):


### PR DESCRIPTION
- The issue was discussed here: https://github.com/fsspec/filesystem_spec/issues/1335
- Also taking the opportunity to rename mv_file into mv where needed (as mv_file is not defined in the interface of AbstractFileSystem, while mv is) but keeping mv_file as a copy of mv for retro-compatibility in case someone is using it 