### PR TITLE
Fix equality for AbstractBufferedFile != b''

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1698,7 +1698,12 @@ class AbstractBufferedFile(io.IOBase):
         """Files are equal if they have the same checksum, only in read mode"""
         if self is other:
             return True
-        return isinstance(other, type(self)) and self.mode == "rb" and other.mode == "rb" and hash(self) == hash(other)
+        return (
+            isinstance(other, type(self))
+            and self.mode == "rb"
+            and other.mode == "rb"
+            and hash(self) == hash(other)
+        )
 
     def commit(self):
         """Move from temp to final destination"""

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1698,7 +1698,7 @@ class AbstractBufferedFile(io.IOBase):
         """Files are equal if they have the same checksum, only in read mode"""
         if self is other:
             return True
-        return self.mode == "rb" and other.mode == "rb" and hash(self) == hash(other)
+        return isinstance(other, type(self)) and self.mode == "rb" and other.mode == "rb" and hash(self) == hash(other)
 
     def commit(self):
         """Move from temp to final destination"""

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -819,6 +819,10 @@ def test_eq():
     result = fs == 1
     assert result is False
 
+    f = AbstractBufferedFile(fs, "misc/foo.txt", cache_type="bytes")
+    result = f == 1
+    assert result is False
+
 
 def test_pickle_multiple():
     a = DummyTestFS(1)


### PR DESCRIPTION
Fix #1230 

For example, boto3's `bucket.Object(remote_path).put(Body=body)` accepts bytes or file-like objects, but compares to b'' somewhere. Modeled on the `__eq__` function for filesystems.