### PR TITLE
Attempt to fix flaky smb tests

### DIFF
--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -67,6 +67,7 @@ class SMBFileSystem(AbstractFileSystem):
         timeout=60,
         encrypt=None,
         share_access=None,
+        register_session_retries=5,
         **kwargs,
     ):
         """
@@ -111,6 +112,7 @@ class SMBFileSystem(AbstractFileSystem):
         self.encrypt = encrypt
         self.temppath = kwargs.pop("temppath", "")
         self.share_access = share_access
+        self.register_session_retries = register_session_retries
         self._connect()
 
     @property
@@ -120,7 +122,7 @@ class SMBFileSystem(AbstractFileSystem):
     def _connect(self):
         import time
 
-        for _ in range(5):
+        for _ in range(self.register_session_retries):
             try:
                 smbclient.register_session(
                     self.host,

--- a/fsspec/implementations/tests/test_smb.py
+++ b/fsspec/implementations/tests/test_smb.py
@@ -63,6 +63,7 @@ def smb_params(request):
             "port": request.param,
             "username": "testuser",
             "password": "testpass",
+            "register_session_retries": 100,  # max ~= 10 seconds
         }
     finally:
         import smbclient  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
Hi @martindurant 

While working on the other PR I had a look at the smb tests and could reproduce the random failures locally. The failures that occurred were either connection failures (likely because the container wasn't up yet) or authentication errors.

I noticed, that every time the tests fail, `SMBFileSystem._connect()` which is called in `__init__` errored 5 times, and was not able to register the session in smbclient.

I traced the authentication errors, and it turns out that, if `_connect()` fails to register a session initially, the later calls to smbclient in `SMBFileSystem` lack the username and password credentials because smbclient will fallback to a credential free session, if none is registered.

In this PR I just added a setting to be able to configure the number of retries for registering a session, and I set it to a very high number in the tests. With this fix, I am unable to reproduce failures locally.

It might be worth considering if `_connect()` should raise an explicit error if username is not None and the retries are exhausted. Because if I understand the smbclient behavior correctly, subsequent usage of smbclient in the methods of `SMBFileSystem` will then always raise an AuthenticationError.