### PR TITLE
Apply ruff/flake8-implicit-str-concat rule ISC001

### DIFF
--- a/fsspec/gui.py
+++ b/fsspec/gui.py
@@ -94,7 +94,7 @@ class SigSlot:
         try:
             return self.panel._repr_mimebundle_(*args, **kwargs)
         except (ValueError, AttributeError):
-            raise NotImplementedError("Panel does not seem to be set " "up properly")
+            raise NotImplementedError("Panel does not seem to be set up properly")
 
     def connect(self, signal, slot):
         """Associate call back with given event

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -34,8 +34,8 @@ files = {
 }
 
 csv_files = {
-    ".test.fakedata.1.csv": (b"a,b\n" b"1,2\n"),
-    ".test.fakedata.2.csv": (b"a,b\n" b"3,4\n"),
+    ".test.fakedata.1.csv": (b"a,b\n1,2\n"),
+    ".test.fakedata.2.csv": (b"a,b\n3,4\n"),
 }
 odir = os.getcwd()
 
@@ -123,21 +123,19 @@ def test_urlpath_expand_read():
 def test_cats():
     with filetexts(csv_files, mode="b"):
         fs = fsspec.filesystem("file")
-        assert fs.cat(".test.fakedata.1.csv") == b"a,b\n" b"1,2\n"
+        assert fs.cat(".test.fakedata.1.csv") == b"a,b\n1,2\n"
         out = set(fs.cat([".test.fakedata.1.csv", ".test.fakedata.2.csv"]).values())
-        assert out == {b"a,b\n" b"1,2\n", b"a,b\n" b"3,4\n"}
-        assert fs.cat(".test.fakedata.1.csv", None, None) == b"a,b\n" b"1,2\n"
-        assert fs.cat(".test.fakedata.1.csv", start=1, end=6) == b"a,b\n" b"1,2\n"[1:6]
-        assert fs.cat(".test.fakedata.1.csv", start=-1) == b"a,b\n" b"1,2\n"[-1:]
-        assert (
-            fs.cat(".test.fakedata.1.csv", start=1, end=-2) == b"a,b\n" b"1,2\n"[1:-2]
-        )
+        assert out == {b"a,b\n1,2\n", b"a,b\n3,4\n"}
+        assert fs.cat(".test.fakedata.1.csv", None, None) == b"a,b\n1,2\n"
+        assert fs.cat(".test.fakedata.1.csv", start=1, end=6) == b"a,b\n1,2\n"[1:6]
+        assert fs.cat(".test.fakedata.1.csv", start=-1) == b"a,b\n1,2\n"[-1:]
+        assert fs.cat(".test.fakedata.1.csv", start=1, end=-2) == b"a,b\n1,2\n"[1:-2]
         out = set(
             fs.cat(
                 [".test.fakedata.1.csv", ".test.fakedata.2.csv"], start=1, end=-1
             ).values()
         )
-        assert out == {b"a,b\n" b"1,2\n"[1:-1], b"a,b\n" b"3,4\n"[1:-1]}
+        assert out == {b"a,b\n1,2\n"[1:-1], b"a,b\n3,4\n"[1:-1]}
 
 
 def test_urlpath_expand_write():

--- a/fsspec/implementations/tests/test_sftp.py
+++ b/fsspec/implementations/tests/test_sftp.py
@@ -114,7 +114,7 @@ def test_get_dir(protocol, ssh, root_path, tmpdir):
 
     f.get(
         protocol
-        + "://{username}:{password}@{host}:{port}" "{root_path}".format(
+        + "://{username}:{password}@{host}:{port}{root_path}".format(
             root_path=root_path, **ssh
         ),
         f"{path}/test2",

--- a/fsspec/tests/test_api.py
+++ b/fsspec/tests/test_api.py
@@ -191,7 +191,7 @@ def test_pipe_cat(m):
 def test_read_block_delimiter(m):
     fs = MemoryFileSystem()
     with fs.open("/myfile", "wb") as f:
-        f.write(b"some\n" b"lines\n" b"of\n" b"text")
+        f.write(b"some\nlines\nof\ntext")
     assert fs.read_block("/myfile", 0, 2, b"\n") == b"some\n"
     assert fs.read_block("/myfile", 2, 6, b"\n") == b"lines\n"
     assert fs.read_block("/myfile", 6, 2, b"\n") == b""
@@ -203,7 +203,7 @@ def test_read_block_delimiter(m):
 def test_open_text(m):
     fs = MemoryFileSystem()
     with fs.open("/myfile", "wb") as f:
-        f.write(b"some\n" b"lines\n" b"of\n" b"text")
+        f.write(b"some\nlines\nof\ntext")
     f = fs.open("/myfile", "r", encoding="latin1")
     assert f.encoding == "latin1"
 


### PR DESCRIPTION
	ISC001 Implicitly concatenated string literals on one line

This rule is currently disabled because it conflicts with the formatter:
	https://github.com/astral-sh/ruff/issues/8272