### PR TITLE
Disable more ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,23 @@ ignore = [
     # Fix these codes later
     "G004",
     "PERF203",
+    # https://github.com/astral-sh/ruff/issues/7871
+    "UP038",
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
They are not compatible with `ruff format` or are actual anti-patterns.