### PR TITLE
Remove tests from package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,8 +140,7 @@ raw-options = {'version_scheme'='post-release'}
 [tool.hatch.build.hooks.vcs]
 version-file = "fsspec/_version.py"
 
-[tool.hatch.build.targets.wheel]
-package = ["fsspec"]
+[tool.hatch.build]
 exclude = ["**/tests/*", "!**/tests/abstract/"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,10 @@ raw-options = {'version_scheme'='post-release'}
 [tool.hatch.build.hooks.vcs]
 version-file = "fsspec/_version.py"
 
+[tool.hatch.build.targets.wheel]
+package = ["fsspec"]
+exclude = ["**/tests/*", "!**/tests/abstract/"]
+
 [tool.ruff]
 target-version = "py38"
 exclude = [".tox", "build", "docs/source/conf.py", "fsspec/_version"]


### PR DESCRIPTION
Once installed, the package got ~11x bigger with the release of `2024.5.0`.

I see that you are now shipping files under `tests` folders that were not included before. Going through the latest commits, I couldn't tell if this was on purpose or just overlooked with the transition to the **hatch** build system.

In this PR I set an `exclude` rule to mimic the state of the distributed packages as they were in version `2024.3.1`.

I am available to discuss this further or make any adjustments.