### PR TITLE
Extend JSON serialization capabilities

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -435,6 +435,7 @@ class CachingFileSystem(AbstractFileSystem):
             "__hash__",
             "__eq__",
             "to_json",
+            "to_dict",
             "cache_size",
             "pipe_file",
             "pipe",

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -510,15 +510,6 @@ class CachingFileSystem(AbstractFileSystem):
             ^ hash(self.target_protocol)
         )
 
-    def to_json(self):
-        """Calculate JSON representation.
-
-        Not implemented yet for CachingFileSystem.
-        """
-        raise NotImplementedError(
-            "CachingFileSystem JSON representation not implemented"
-        )
-
 
 class WholeFileCacheFileSystem(CachingFileSystem):
     """Caches whole remote files on first access

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -873,7 +873,7 @@ def test_filecache_with_checks():
 
 @pytest.mark.parametrize("impl", ["filecache", "simplecache", "blockcache"])
 @pytest.mark.parametrize("fs", ["local", "multi"], indirect=["fs"])
-def test_takes_fs_instance(impl, fs):
+def test_filecache_takes_fs_instance(impl, fs):
     origin = tempfile.mkdtemp()
     data = b"test data"
     f1 = os.path.join(origin, "afile")
@@ -883,6 +883,15 @@ def test_takes_fs_instance(impl, fs):
     fs2 = fsspec.filesystem(impl, fs=fs)
 
     assert fs2.cat(f1) == data
+
+
+@pytest.mark.parametrize("impl", ["filecache", "simplecache", "blockcache"])
+@pytest.mark.parametrize("fs", ["local", "multi"], indirect=["fs"])
+def test_filecache_serialization(impl, fs):
+    fs1 = fsspec.filesystem(impl, fs=fs)
+    json1 = fs1.to_json()
+
+    assert fs1 is fsspec.AbstractFileSystem.from_json(json1)
 
 
 def test_add_file_to_cache_after_save(local_filecache):

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -1253,7 +1253,7 @@ def test_cache_size(tmpdir, protocol):
     # Remove cached file but leave cache metadata file
     fs.pop_from_cache(afile)
     if win and protocol == "filecache":
-        empty_cache_size < fs.cache_size()
+        assert empty_cache_size < fs.cache_size()
     elif protocol != "simplecache":
         assert empty_cache_size < fs.cache_size() < single_file_cache_size
     else:

--- a/fsspec/json.py
+++ b/fsspec/json.py
@@ -56,11 +56,15 @@ class FilesystemJSONDecoder(json.JSONDecoder):
     def try_resolve_fs_cls(cls, dct: Dict[str, Any]):
         with suppress(Exception):
             if "cls" in dct:
-                fs_cls = _import_class(dct["cls"])  # if this fails, we get None
-                if issubclass(fs_cls, AbstractFileSystem):
-                    return fs_cls
-            if "protocol" in dct:
-                return get_filesystem_class(dct["protocol"])
+                try:
+                    fs_cls = _import_class(dct["cls"])  # if this fails, we get None
+                    if issubclass(fs_cls, AbstractFileSystem):
+                        return fs_cls
+                except Exception:
+                    if "protocol" in dct:
+                        return get_filesystem_class(dct["protocol"])
+
+                    raise
 
         return None
 

--- a/fsspec/json.py
+++ b/fsspec/json.py
@@ -57,11 +57,11 @@ class FilesystemJSONDecoder(json.JSONDecoder):
         with suppress(Exception):
             if "cls" in dct:
                 try:
-                    fs_cls = _import_class(dct["cls"])  # if this fails, we get None
+                    fs_cls = _import_class(dct["cls"])
                     if issubclass(fs_cls, AbstractFileSystem):
                         return fs_cls
                 except Exception:
-                    if "protocol" in dct:
+                    if "protocol" in dct:   # Fallback if cls cannot be imported
                         return get_filesystem_class(dct["protocol"])
 
                     raise

--- a/fsspec/json.py
+++ b/fsspec/json.py
@@ -61,7 +61,7 @@ class FilesystemJSONDecoder(json.JSONDecoder):
                     if issubclass(fs_cls, AbstractFileSystem):
                         return fs_cls
                 except Exception:
-                    if "protocol" in dct:   # Fallback if cls cannot be imported
+                    if "protocol" in dct:  # Fallback if cls cannot be imported
                         return get_filesystem_class(dct["protocol"])
 
                     raise

--- a/fsspec/json.py
+++ b/fsspec/json.py
@@ -45,10 +45,7 @@ class FilesystemJSONDecoder(json.JSONDecoder):
         with suppress(Exception):
             fqp = dct["cls"]
 
-            try:
-                path_cls = _import_class(fqp)
-            except Exception:
-                raise
+            path_cls = _import_class(fqp)
 
             if issubclass(path_cls, PurePath):
                 return path_cls
@@ -58,18 +55,12 @@ class FilesystemJSONDecoder(json.JSONDecoder):
     @classmethod
     def try_resolve_fs_cls(cls, dct: Dict[str, Any]):
         with suppress(Exception):
-            fqp = dct["cls"]
-
-            try:
-                fs_cls = _import_class(fqp)
-            except Exception:
-                if "protocol" in dct:
-                    return get_filesystem_class(dct["protocol"])
-
-                raise
-
-            if issubclass(fs_cls, AbstractFileSystem):
-                return fs_cls
+            if "cls" in dct:
+                fs_cls = _import_class(dct["cls"])  # if this fails, we get None
+                if issubclass(fs_cls, AbstractFileSystem):
+                    return fs_cls
+            if "protocol" in dct:
+                return get_filesystem_class(dct["protocol"])
 
         return None
 

--- a/fsspec/json.py
+++ b/fsspec/json.py
@@ -1,0 +1,86 @@
+import json
+from contextlib import suppress
+from pathlib import PurePath
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .registry import _import_class, get_filesystem_class
+from .spec import AbstractFileSystem
+
+
+class FilesystemJSONEncoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:
+        if isinstance(o, AbstractFileSystem):
+            return o.to_dict()
+        if isinstance(o, PurePath):
+            cls = type(o)
+            return {"cls": f"{cls.__module__}.{cls.__name__}", "str": str(o)}
+
+        return super().default(o)
+
+
+class FilesystemJSONDecoder(json.JSONDecoder):
+    def __init__(
+        self,
+        *,
+        object_hook: Optional[Callable[[Dict[str, Any]], Any]] = None,
+        parse_float: Optional[Callable[[str], Any]] = None,
+        parse_int: Optional[Callable[[str], Any]] = None,
+        parse_constant: Optional[Callable[[str], Any]] = None,
+        strict: bool = True,
+        object_pairs_hook: Optional[Callable[[List[Tuple[str, Any]]], Any]] = None,
+    ) -> None:
+        self.original_object_hook = object_hook
+
+        super().__init__(
+            object_hook=self.custom_object_hook,
+            parse_float=parse_float,
+            parse_int=parse_int,
+            parse_constant=parse_constant,
+            strict=strict,
+            object_pairs_hook=object_pairs_hook,
+        )
+
+    @classmethod
+    def try_resolve_path_cls(cls, dct: Dict[str, Any]):
+        with suppress(Exception):
+            fqp = dct["cls"]
+
+            try:
+                path_cls = _import_class(fqp)
+            except Exception:
+                raise
+
+            if issubclass(path_cls, PurePath):
+                return path_cls
+
+        return None
+
+    @classmethod
+    def try_resolve_fs_cls(cls, dct: Dict[str, Any]):
+        with suppress(Exception):
+            fqp = dct["cls"]
+
+            try:
+                fs_cls = _import_class(fqp)
+            except Exception:
+                if "protocol" in dct:
+                    return get_filesystem_class(dct["protocol"])
+
+                raise
+
+            if issubclass(fs_cls, AbstractFileSystem):
+                return fs_cls
+
+        return None
+
+    def custom_object_hook(self, dct: Dict[str, Any]):
+        if "cls" in dct:
+            if (obj_cls := self.try_resolve_fs_cls(dct)) is not None:
+                return AbstractFileSystem.from_dict(dct)
+            if (obj_cls := self.try_resolve_path_cls(dct)) is not None:
+                return obj_cls(dct["str"])
+
+        if self.original_object_hook is not None:
+            return self.original_object_hook(dct)
+
+        return dct

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -258,9 +258,14 @@ update the current installation.
 
 
 def _import_class(fqp: str):
-    """Take a fully-qualified path and return the imported class or identifier
+    """Take a fully-qualified path and return the imported class or identifier.
 
-    ``fqp`` is of the form "package.module.klass" or "package.module:subobject.klass"
+    ``fqp`` is of the form "package.module.klass" or
+    "package.module:subobject.klass".
+
+    Warnings
+    --------
+    This can import arbitrary modules at runtime.
     """
     if ":" in fqp:
         mod, name = fqp.rsplit(":", 1)

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -257,27 +257,27 @@ update the current installation.
 """
 
 
-def _import_class(cls, minv=None):
-    """Take a string FQP and return the imported class or identifier
+def _import_class(fqp: str):
+    """Take a fully-qualified path and return the imported class or identifier
 
-    cls is of the form "package.module.klass" or "package.module:subobject.klass"
+    ``fqp`` is of the form "package.module.klass" or "package.module:subobject.klass"
     """
-    if ":" in cls:
-        mod, name = cls.rsplit(":", 1)
-        s3 = mod == "s3fs"
-        mod = importlib.import_module(mod)
-        if s3 and mod.__version__.split(".") < ["0", "5"]:
-            warnings.warn(s3_msg)
-        for part in name.split("."):
-            mod = getattr(mod, part)
-        return mod
+    if ":" in fqp:
+        mod, name = fqp.rsplit(":", 1)
     else:
-        mod, name = cls.rsplit(".", 1)
-        s3 = mod == "s3fs"
-        mod = importlib.import_module(mod)
-        if s3 and mod.__version__.split(".") < ["0", "5"]:
-            warnings.warn(s3_msg)
-        return getattr(mod, name)
+        mod, name = fqp.rsplit(".", 1)
+
+    is_s3 = mod == "s3fs"
+    mod = importlib.import_module(mod)
+    if is_s3 and mod.__version__.split(".") < ["0", "5"]:
+        warnings.warn(s3_msg)
+    for part in name.split("."):
+        mod = getattr(mod, part)
+
+    if not isinstance(mod, type):
+        raise TypeError(f"{fqp} is not a class")
+
+    return mod
 
 
 def filesystem(protocol, **storage_options):

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -265,7 +265,8 @@ def _import_class(fqp: str):
 
     Warnings
     --------
-    This can import arbitrary modules at runtime.
+    This can import arbitrary modules. Make sure you haven't installed any modules
+    that may execute malicious code at import time.
     """
     if ":" in fqp:
         mod, name = fqp.rsplit(":", 1)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1418,8 +1418,9 @@ class AbstractFileSystem(metaclass=_Cached):
 
         Warnings
         --------
-        This can import arbitrary modules (as determined by the ``cls`` key)
-        at runtime.
+        This can import arbitrary modules (as determined by the ``cls`` key).
+        Make sure you haven't installed any modules that may execute malicious code
+        at import time.
         """
         from .json import FilesystemJSONDecoder
 
@@ -1463,8 +1464,9 @@ class AbstractFileSystem(metaclass=_Cached):
 
         Warnings
         --------
-        This can import arbitrary modules (as determined by the ``cls`` key)
-        at runtime.
+        This can import arbitrary modules (as determined by the ``cls`` key).
+        Make sure you haven't installed any modules that may execute malicious code
+        at import time.
         """
         from .json import FilesystemJSONDecoder
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1508,7 +1508,7 @@ class AbstractFileSystem(metaclass=_Cached):
         proto = self.protocol
 
         return dict(
-            cls=f"{cls.__module__}.{cls.__name__}",
+            cls=f"{cls.__module__}:{cls.__name__}",
             protocol=proto[0] if isinstance(proto, (tuple, list)) else proto,
             args=self.storage_args,
             **self.storage_options,

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1468,23 +1468,23 @@ class AbstractFileSystem(metaclass=_Cached):
 
     def to_json(self) -> str:
         """
-        JSON representation of this filesystem instance
+        JSON representation of this filesystem instance.
 
         Returns
         -------
-        JSON string with keys cls (the python location of this class),
+        JSON string with keys ``cls`` (the python location of this class),
         protocol (text name of this class's protocol, first one in case of
-        multiple), args (positional args, usually empty), and all other
-        kwargs as their own keys.
+        multiple), ``args`` (positional args, usually empty), and all other
+        keyword arguments as their own keys.
         """
         return json.dumps(self, cls=self._JSONEncoder)
 
     @staticmethod
     def from_json(blob: str) -> AbstractFileSystem:
         """
-        Recreate a filesystem instance from JSON representation
+        Recreate a filesystem instance from JSON representation.
 
-        See ``.to_json()`` for the expected structure of the input
+        See ``.to_json()`` for the expected structure of the input.
 
         Parameters
         ----------
@@ -1493,19 +1493,24 @@ class AbstractFileSystem(metaclass=_Cached):
         Returns
         -------
         file system instance, not necessarily of this particular class.
+
+        Warnings
+        --------
+        This can import arbitrary modules (as determined by the ``cls`` key)
+        at runtime.
         """
         return json.loads(blob, cls=AbstractFileSystem._JSONDecoder)
 
     def to_dict(self) -> Dict[str, Any]:
         """
-        JSON-serializable dictionary representation of this filesystem instance
+        JSON-serializable dictionary representation of this filesystem instance.
 
         Returns
         -------
-        Dictionary with keys cls (the python location of this class),
+        Dictionary with keys ``cls`` (the python location of this class),
         protocol (text name of this class's protocol, first one in case of
-        multiple), args (positional args, usually empty), and all other
-        kwargs as their own keys.
+        multiple), ``args`` (positional args, usually empty), and all other
+        keyword arguments as their own keys.
         """
         cls = type(self)
         proto = self.protocol
@@ -1520,9 +1525,9 @@ class AbstractFileSystem(metaclass=_Cached):
     @staticmethod
     def from_dict(dct: Dict[str, Any]) -> AbstractFileSystem:
         """
-        Recreate a filesystem instance from dictionary representation
+        Recreate a filesystem instance from dictionary representation.
 
-        See ``.to_dict()`` for the expected structure of the input
+        See ``.to_dict()`` for the expected structure of the input.
 
         Parameters
         ----------
@@ -1531,6 +1536,11 @@ class AbstractFileSystem(metaclass=_Cached):
         Returns
         -------
         file system instance, not necessarily of this particular class.
+
+        Warnings
+        --------
+        This can import arbitrary modules (as determined by the ``cls`` key)
+        at runtime.
         """
         cls = AbstractFileSystem._JSONDecoder.try_resolve_fs_cls(dct)
         if cls is None:

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -888,6 +888,31 @@ def test_json_fs_attr():
     assert DummyTestFS.from_json(outb) is b
 
 
+def test_from_dict_valid():
+    fs = DummyTestFS.from_dict({"cls": "fsspec.tests.test_spec.DummyTestFS"})
+    assert isinstance(fs, DummyTestFS)
+
+    fs = DummyTestFS.from_dict({"cls": "fsspec.tests.test_spec.DummyTestFS", "bar": 1})
+    assert fs.storage_options["bar"] == 1
+
+    fs = DummyTestFS.from_dict({"cls": "fsspec.implementations.local.LocalFileSystem"})
+    assert isinstance(fs, LocalFileSystem)
+
+    fs = DummyTestFS.from_dict({"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "local"})
+    assert isinstance(fs, LocalFileSystem)
+
+
+def test_from_dict_invalid():
+    with pytest.raises(ValueError, match="Not a serialized AbstractFileSystem"):
+        DummyTestFS.from_dict({})
+
+    with pytest.raises(ValueError, match="Not a serialized AbstractFileSystem"):
+        DummyTestFS.from_dict({"cls": "pathlib.Path"})
+
+    with pytest.raises(ValueError, match="Not a serialized AbstractFileSystem"):
+        DummyTestFS.from_dict({"protocol": "local"})  # cls must be present
+
+
 def test_ls_from_cache():
     fs = DummyTestFS()
     uncached_results = fs.ls("top_level/second_level/", refresh=True)

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -898,7 +898,12 @@ def test_from_dict_valid():
     fs = DummyTestFS.from_dict({"cls": "fsspec.implementations.local.LocalFileSystem"})
     assert isinstance(fs, LocalFileSystem)
 
-    fs = DummyTestFS.from_dict({"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "local"})
+    fs = DummyTestFS.from_dict(
+        {
+            "cls": "fsspec.implementations.local.LocalFileSystem",
+            "protocol": "local",
+        }
+    )
     assert isinstance(fs, LocalFileSystem)
 
 

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -858,6 +858,36 @@ def test_json():
     assert DummyTestFS.from_json(outb) is b
 
 
+def test_json_path_attr():
+    a = DummyTestFS(1)
+    b = DummyTestFS(2, bar=Path("baz"))
+
+    outa = a.to_json()
+    outb = b.to_json()
+
+    assert json.loads(outb)  # is valid JSON
+    assert a != b
+    assert "bar" in outb
+
+    assert DummyTestFS.from_json(outa) is a
+    assert DummyTestFS.from_json(outb) is b
+
+
+def test_json_fs_attr():
+    a = DummyTestFS(1)
+    b = DummyTestFS(2, bar=a)
+
+    outa = a.to_json()
+    outb = b.to_json()
+
+    assert json.loads(outb)  # is valid JSON
+    assert a != b
+    assert "bar" in outb
+
+    assert DummyTestFS.from_json(outa) is a
+    assert DummyTestFS.from_json(outb) is b
+
+
 def test_ls_from_cache():
     fs = DummyTestFS()
     uncached_results = fs.ls("top_level/second_level/", refresh=True)


### PR DESCRIPTION
#247 first introduced JSON serialization of filesystem objects. However, it fails to handle `storage_args` and `storage_options` that contain `Path` or other filesystems. This can occur in a few cases, such as:

- When passing a `Path` instance to construct a `DirFileSystem` (not officially documented but the `Path` object is automatically converted to a string in the initializer, so it is functional)
- When passing a filesystem to wrapper filesystems such as `CachingFileSystem`, `DirFileSystem` and `ReferenceFileSystem`.

This PR makes it possible to serialize such filesystems.
