### PR TITLE
Add dependencies for building docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ CI runtime. For local use, pick a version suitable for you.
 mamba create -n fsspec -c conda-forge  python=3.9 -y
 conda activate fsspec
 
-# Standard dev test install.
-pip install -e ".[dev,test]"
+# Standard dev install with docs and tests.
+pip install -e ".[dev,doc,test]"
 
 # Full tests except for downstream
 pip install s3fs
 pip uninstall s3fs
-pip install -e .[dev,test_full]
+pip install -e .[dev,doc,test_full]
 pip install s3fs --no-deps
 pytest -v
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,9 +3,3 @@ channels:
   - defaults
 dependencies:
   - python=3.9
-  - docutils<0.17
-  - numpydoc
-  - sphinx_rtd_theme
-  - yarl
-  - pip:
-    - sphinx-design

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -107,9 +107,9 @@ The following can be used to install ``fsspec`` in development mode
 
    git clone https://github.com/fsspec/filesystem_spec
    cd filesystem_spec
-   pip install -e .
+   pip install -e .[dev,doc,test]
 
-A number of additional dependencies are required to run tests, see "ci/environment*.yml", as
+A number of additional dependencies are required to run tests in full, see "ci/environment*.yml", as
 well as Docker. Most implementation-specific tests should skip if their requirements are
 not met.
 

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -14,6 +14,10 @@ from fsspec.tests.conftest import data, realfile, reset_files, server, win  # no
 
 
 def test_simple(server):  # noqa: F811
+    # The dictionary in refs may be dumped with a different separator
+    # depending on whether json or ujson is imported
+    from fsspec.implementations.reference import json as json_impl
+
     refs = {
         "a": b"data",
         "b": (realfile, 0, 5),
@@ -28,12 +32,16 @@ def test_simple(server):  # noqa: F811
     assert fs.cat("b") == data[:5]
     assert fs.cat("c") == data[1 : 1 + 5]
     assert fs.cat("d") == b"hello"
-    assert fs.cat("e") == b'{"key": "value"}'
+    assert fs.cat("e") == json_impl.dumps(refs["e"]).encode("utf-8")
     with fs.open("d", "rt") as f:
         assert f.read(2) == "he"
 
 
 def test_simple_ver1(server):  # noqa: F811
+    # The dictionary in refs may be dumped with a different separator
+    # depending on whether json or ujson is imported
+    from fsspec.implementations.reference import json as json_impl
+
     in_data = {
         "version": 1,
         "refs": {
@@ -51,7 +59,7 @@ def test_simple_ver1(server):  # noqa: F811
     assert fs.cat("b") == data[:5]
     assert fs.cat("c") == data[1 : 1 + 5]
     assert fs.cat("d") == b"hello"
-    assert fs.cat("e") == b'{"key": "value"}'
+    assert fs.cat("e") == json_impl.dumps(in_data["refs"]["e"]).encode("utf-8")
     with fs.open("d", "rt") as f:
         assert f.read(2) == "he"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ adl = ["adlfs"]
 arrow = ["pyarrow >= 1"]
 dask = ["dask", "distributed"]
 dev = ["ruff", "pre-commit"]
+doc = ["sphinx", "numpydoc", "sphinx-design", "sphinx-rtd-theme"]
 dropbox = ["dropbox", "dropboxdrivefs", "requests"]
 entrypoints = []
 full = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ adl = ["adlfs"]
 arrow = ["pyarrow >= 1"]
 dask = ["dask", "distributed"]
 dev = ["ruff", "pre-commit"]
-doc = ["sphinx", "numpydoc", "sphinx-design", "sphinx-rtd-theme"]
+doc = ["sphinx", "numpydoc", "sphinx-design", "sphinx-rtd-theme", "yarl"]
 dropbox = ["dropbox", "dropboxdrivefs", "requests"]
 entrypoints = []
 full = [

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -12,6 +12,8 @@ python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - doc
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
I found that I couldn't build the documentation just from installing `dev` and `test` dependencies. It turns out that `pyproject.toml` currently does not specify the dependencies for building the documentation.

This PR adds the `doc` extra which includes such dependencies, making it easier to set up the environment for building documentation.