### PR TITLE
Add option to skip password when serializing filesystem

### DIFF
--- a/fsspec/json.py
+++ b/fsspec/json.py
@@ -8,7 +8,7 @@ from .spec import AbstractFileSystem
 
 
 class FilesystemJSONEncoder(json.JSONEncoder):
-    include_password: ClassVar[bool] = False
+    include_password: ClassVar[bool] = True
 
     def default(self, o: Any) -> Any:
         if isinstance(o, AbstractFileSystem):

--- a/fsspec/json.py
+++ b/fsspec/json.py
@@ -1,16 +1,18 @@
 import json
 from contextlib import suppress
 from pathlib import PurePath
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 from .registry import _import_class, get_filesystem_class
 from .spec import AbstractFileSystem
 
 
 class FilesystemJSONEncoder(json.JSONEncoder):
+    include_password: ClassVar[bool] = False
+
     def default(self, o: Any) -> Any:
         if isinstance(o, AbstractFileSystem):
-            return o.to_dict()
+            return o.to_dict(include_password=self.include_password)
         if isinstance(o, PurePath):
             cls = type(o)
             return {"cls": f"{cls.__module__}.{cls.__name__}", "str": str(o)}

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1386,9 +1386,15 @@ class AbstractFileSystem(metaclass=_Cached):
                 length = size - offset
             return read_block(f, offset, length, delimiter)
 
-    def to_json(self) -> str:
+    def to_json(self, *, include_password: bool = False) -> str:
         """
         JSON representation of this filesystem instance.
+
+        Parameters
+        ----------
+        include_password: bool, default False
+            Whether to include the password (if any) in the output.
+            For security reasons, this is set to `False` by default.
 
         Returns
         -------
@@ -1399,7 +1405,14 @@ class AbstractFileSystem(metaclass=_Cached):
         """
         from .json import FilesystemJSONEncoder
 
-        return json.dumps(self, cls=FilesystemJSONEncoder)
+        return json.dumps(
+            self,
+            cls=type(
+                "_FilesystemJSONEncoder",
+                (FilesystemJSONEncoder,),
+                {"include_password": include_password},
+            ),
+        )
 
     @staticmethod
     def from_json(blob: str) -> AbstractFileSystem:
@@ -1426,9 +1439,15 @@ class AbstractFileSystem(metaclass=_Cached):
 
         return json.loads(blob, cls=FilesystemJSONDecoder)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self, *, include_password: bool = False) -> Dict[str, Any]:
         """
         JSON-serializable dictionary representation of this filesystem instance.
+
+        Parameters
+        ----------
+        include_password: bool, default False
+            Whether to include the password (if any) in the output.
+            For security reasons, this is set to `False` by default.
 
         Returns
         -------
@@ -1441,7 +1460,8 @@ class AbstractFileSystem(metaclass=_Cached):
         proto = self.protocol
 
         storage_options = dict(self.storage_options)
-        storage_options.pop("password", None)
+        if not include_password:
+            storage_options.pop("password", None)
 
         return dict(
             cls=f"{cls.__module__}:{cls.__name__}",

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1386,15 +1386,14 @@ class AbstractFileSystem(metaclass=_Cached):
                 length = size - offset
             return read_block(f, offset, length, delimiter)
 
-    def to_json(self, *, include_password: bool = False) -> str:
+    def to_json(self, *, include_password: bool = True) -> str:
         """
         JSON representation of this filesystem instance.
 
         Parameters
         ----------
-        include_password: bool, default False
+        include_password: bool, default True
             Whether to include the password (if any) in the output.
-            For security reasons, this is set to `False` by default.
 
         Returns
         -------
@@ -1402,6 +1401,12 @@ class AbstractFileSystem(metaclass=_Cached):
         protocol (text name of this class's protocol, first one in case of
         multiple), ``args`` (positional args, usually empty), and all other
         keyword arguments as their own keys.
+
+        Warnings
+        --------
+        Serialized filesystems may contain sensitive information which have been
+        passed to the constructor, such as passwords and tokens. Make sure you
+        store and send them in a secure environment!
         """
         from .json import FilesystemJSONEncoder
 
@@ -1439,15 +1444,14 @@ class AbstractFileSystem(metaclass=_Cached):
 
         return json.loads(blob, cls=FilesystemJSONDecoder)
 
-    def to_dict(self, *, include_password: bool = False) -> Dict[str, Any]:
+    def to_dict(self, *, include_password: bool = True) -> Dict[str, Any]:
         """
         JSON-serializable dictionary representation of this filesystem instance.
 
         Parameters
         ----------
-        include_password: bool, default False
+        include_password: bool, default True
             Whether to include the password (if any) in the output.
-            For security reasons, this is set to `False` by default.
 
         Returns
         -------
@@ -1455,6 +1459,12 @@ class AbstractFileSystem(metaclass=_Cached):
         protocol (text name of this class's protocol, first one in case of
         multiple), ``args`` (positional args, usually empty), and all other
         keyword arguments as their own keys.
+
+        Warnings
+        --------
+        Serialized filesystems may contain sensitive information which have been
+        passed to the constructor, such as passwords and tokens. Make sure you
+        store and send them in a secure environment!
         """
         cls = type(self)
         proto = self.protocol

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1440,11 +1440,14 @@ class AbstractFileSystem(metaclass=_Cached):
         cls = type(self)
         proto = self.protocol
 
+        storage_options = dict(self.storage_options)
+        storage_options.pop("password", None)
+
         return dict(
             cls=f"{cls.__module__}:{cls.__name__}",
             protocol=proto[0] if isinstance(proto, (tuple, list)) else proto,
             args=self.storage_args,
-            **self.storage_options,
+            **storage_options,
         )
 
     @staticmethod

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -915,11 +915,11 @@ def test_dict_idempotent():
 def test_serialize_no_password():
     fs = DummyTestFS(1, password="admin")
 
-    assert "password" not in fs.to_json()
-    assert "password" not in fs.to_dict()
+    assert "password" not in fs.to_json(include_password=False)
+    assert "password" not in fs.to_dict(include_password=False)
 
 
-def test_serialize_force_password():
+def test_serialize_with_password():
     fs = DummyTestFS(1, password="admin")
 
     assert "password" in fs.to_json(include_password=True)

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -895,6 +895,13 @@ def test_serialize_no_password():
     assert "password" not in fs.to_dict()
 
 
+def test_serialize_force_password():
+    fs = DummyTestFS(1, password="admin")
+
+    assert "password" in fs.to_json(include_password=True)
+    assert "password" in fs.to_dict(include_password=True)
+
+
 def test_from_dict_valid():
     fs = DummyTestFS.from_dict({"cls": "fsspec.tests.test_spec.DummyTestFS"})
     assert isinstance(fs, DummyTestFS)

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -888,6 +888,13 @@ def test_json_fs_attr():
     assert DummyTestFS.from_json(outb) is b
 
 
+def test_serialize_no_password():
+    fs = DummyTestFS(1, password="admin")
+
+    assert "password" not in fs.to_json()
+    assert "password" not in fs.to_dict()
+
+
 def test_from_dict_valid():
     fs = DummyTestFS.from_dict({"cls": "fsspec.tests.test_spec.DummyTestFS"})
     assert isinstance(fs, DummyTestFS)


### PR DESCRIPTION
Currently, `AbstractFileSystem.to_dict` (and by extension `AbstractFileSystem.to_json`) store all arguments used to construct the object. However, there are some cases where the user may provide a password, such as in `FTPFileSystem`, `SMBFileSystem`, and `WebHDFS`. This may cause security issues, especially considering that the password is stored in plain text.

~~This PR disables the aforementioned behaviour by default. Users now have to pass `include_password=True` to the relevant methods if they wish to store the password anyway.~~ After some discussion, this feature is now opt-in. I have added a warning to the documentation to remind users to be careful about this.