### PR TITLE
Fix `AbstractFileSystem.from_dict` not being idempotent

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1470,6 +1470,8 @@ class AbstractFileSystem(metaclass=_Cached):
         """
         from .json import FilesystemJSONDecoder
 
+        dct = dict(dct)  # Defensive copy
+
         cls = FilesystemJSONDecoder.try_resolve_fs_cls(dct)
         if cls is None:
             raise ValueError("Not a serialized AbstractFileSystem")

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -888,6 +888,30 @@ def test_json_fs_attr():
     assert DummyTestFS.from_json(outb) is b
 
 
+def test_dict():
+    a = DummyTestFS(1)
+    b = DummyTestFS(2, bar=1)
+
+    outa = a.to_dict()
+    outb = b.to_dict()
+
+    assert isinstance(outa, dict)
+    assert a != b
+    assert "bar" in outb
+
+    assert DummyTestFS.from_dict(outa) is a
+    assert DummyTestFS.from_dict(outb) is b
+
+
+def test_dict_idempotent():
+    a = DummyTestFS(1)
+
+    outa = a.to_dict()
+
+    assert DummyTestFS.from_dict(outa) is a
+    assert DummyTestFS.from_dict(outa) is a
+
+
 def test_from_dict_valid():
     fs = DummyTestFS.from_dict({"cls": "fsspec.tests.test_spec.DummyTestFS"})
     assert isinstance(fs, DummyTestFS)


### PR DESCRIPTION
The existing implementation mutates the input dictionary which causes the function to fail if called multiple times in succession. This PR fixes this issue.