### PR TITLE
DirFS: Fix `pipe(dict[str, bytes])`

### DIFF
--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -56,6 +56,8 @@ class DirFileSystem(AsyncFileSystem):
             if not path:
                 return self.path
             return self.fs.sep.join((self.path, self._strip_protocol(path)))
+        if isinstance(path, dict):
+            return {self._join(_path): value for _path, value in path.items()}
         return [self._join(_path) for _path in path]
 
     def _relpath(self, path):

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -162,6 +162,11 @@ def test_pipe(dirfs):
     dirfs.fs.pipe.assert_called_once_with(f"{PATH}/file", *ARGS, **KWARGS)
 
 
+def test_pipe_dict(dirfs):
+    dirfs.pipe({"file": b"foo"}, *ARGS, **KWARGS)
+    dirfs.fs.pipe.assert_called_once_with({f"{PATH}/file": b"foo"}, *ARGS, **KWARGS)
+
+
 @pytest.mark.asyncio
 async def test_async_pipe_file(adirfs):
     await adirfs._pipe_file("file", *ARGS, **KWARGS)


### PR DESCRIPTION
`.pipe()` can be called with a dictionary as input. This is currently not supported by `DirFS` as `._join()` silently maps the dictionary input to a list which causes a cryptic error message error when trying to use `.pipe()` with dictionary input.