### PR TITLE
Fix dict representation not being JSON serializable

### DIFF
--- a/fsspec/json.py
+++ b/fsspec/json.py
@@ -113,9 +113,9 @@ class FilesystemJSONDecoder(json.JSONDecoder):
         """
         if isinstance(obj, dict):
             obj = self.custom_object_hook(obj)
-        if isinstance(obj, Mapping):
+        if isinstance(obj, dict):
             return {k: self.unmake_serializable(v) for k, v in obj.items()}
-        if isinstance(obj, Sequence):
+        if isinstance(obj, (list, tuple)):
             return [self.unmake_serializable(v) for v in obj]
 
         return obj

--- a/fsspec/json.py
+++ b/fsspec/json.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import suppress
 from pathlib import PurePath
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from .registry import _import_class, get_filesystem_class
 from .spec import AbstractFileSystem
@@ -25,9 +25,9 @@ class FilesystemJSONEncoder(json.JSONEncoder):
         """
         if isinstance(obj, (str, int, float, bool)):
             return obj
-        if isinstance(obj, dict):
+        if isinstance(obj, Mapping):
             return {k: self.make_serializable(v) for k, v in obj.items()}
-        if isinstance(obj, (list, tuple)):
+        if isinstance(obj, Sequence):
             return [self.make_serializable(v) for v in obj]
 
         return self.default(obj)
@@ -101,10 +101,9 @@ class FilesystemJSONDecoder(json.JSONDecoder):
         """
         if isinstance(obj, dict):
             obj = self.custom_object_hook(obj)
-            if isinstance(obj, dict):
-                return {k: self.unmake_serializable(v) for k, v in obj.items()}
-
-        if isinstance(obj, (list, tuple)):
+        if isinstance(obj, Mapping):
+            return {k: self.unmake_serializable(v) for k, v in obj.items()}
+        if isinstance(obj, Sequence):
             return [self.unmake_serializable(v) for v in obj]
 
         return obj

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -875,17 +875,20 @@ def test_json_path_attr():
 
 def test_json_fs_attr():
     a = DummyTestFS(1)
-    b = DummyTestFS(2, bar=a)
+    b = DummyTestFS(2, bar=Path("baz"))
+    c = DummyTestFS(3, baz=b)
 
     outa = a.to_json()
     outb = b.to_json()
+    outc = c.to_json()
 
-    assert json.loads(outb)  # is valid JSON
-    assert a != b
-    assert "bar" in outb
+    assert json.loads(outc)  # is valid JSON
+    assert b != c
+    assert "baz" in outc
 
     assert DummyTestFS.from_json(outa) is a
     assert DummyTestFS.from_json(outb) is b
+    assert DummyTestFS.from_json(outc) is c
 
 
 def test_dict():
@@ -903,6 +906,39 @@ def test_dict():
     assert DummyTestFS.from_dict(outb) is b
 
 
+def test_dict_path_attr():
+    a = DummyTestFS(1)
+    b = DummyTestFS(2, bar=Path("baz"))
+
+    outa = a.to_dict()
+    outb = b.to_dict()
+
+    assert isinstance(outa, dict)
+    assert a != b
+    assert outb["bar"]["str"] == "baz"
+
+    assert DummyTestFS.from_dict(outa) is a
+    assert DummyTestFS.from_dict(outb) is b
+
+
+def test_dict_fs_attr():
+    a = DummyTestFS(1)
+    b = DummyTestFS(2, bar=Path("baz"))
+    c = DummyTestFS(3, baz=b)
+
+    outa = a.to_dict()
+    outb = b.to_dict()
+    outc = c.to_dict()
+
+    assert isinstance(outc, dict)
+    assert b != c
+    assert outc["baz"] == outb
+
+    assert DummyTestFS.from_dict(outa) is a
+    assert DummyTestFS.from_dict(outb) is b
+    assert DummyTestFS.from_dict(outc) is c
+
+
 def test_dict_idempotent():
     a = DummyTestFS(1)
 
@@ -910,6 +946,20 @@ def test_dict_idempotent():
 
     assert DummyTestFS.from_dict(outa) is a
     assert DummyTestFS.from_dict(outa) is a
+
+
+def test_dict_json_serializable():
+    a = DummyTestFS(1)
+    b = DummyTestFS(2, bar=Path("baz"))
+    c = DummyTestFS(3, baz=b)
+
+    outa = a.to_dict()
+    outb = b.to_dict()
+    outc = c.to_dict()
+
+    json.dumps(outa)
+    json.dumps(outb)
+    json.dumps(outc)
 
 
 def test_from_dict_valid():

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -891,6 +891,24 @@ def test_json_fs_attr():
     assert DummyTestFS.from_json(outc) is c
 
 
+def test_json_dict_attr():
+    a = DummyTestFS(1)
+    b = DummyTestFS(2, bar=Path("baz"))
+    c = DummyTestFS(3, baz={"key": b})
+
+    outa = a.to_json()
+    outb = b.to_json()
+    outc = c.to_json()
+
+    assert json.loads(outc)  # is valid JSON
+    assert b != c
+    assert "baz" in outc
+
+    assert DummyTestFS.from_json(outa) is a
+    assert DummyTestFS.from_json(outb) is b
+    assert DummyTestFS.from_json(outc) is c
+
+
 def test_dict():
     a = DummyTestFS(1)
     b = DummyTestFS(2, bar=1)
@@ -933,6 +951,24 @@ def test_dict_fs_attr():
     assert isinstance(outc, dict)
     assert b != c
     assert outc["baz"] == outb
+
+    assert DummyTestFS.from_dict(outa) is a
+    assert DummyTestFS.from_dict(outb) is b
+    assert DummyTestFS.from_dict(outc) is c
+
+
+def test_dict_dict_attr():
+    a = DummyTestFS(1)
+    b = DummyTestFS(2, bar=Path("baz"))
+    c = DummyTestFS(3, baz={"key": b})
+
+    outa = a.to_dict()
+    outb = b.to_dict()
+    outc = c.to_dict()
+
+    assert isinstance(outc, dict)
+    assert b != c
+    assert outc["baz"]["key"] == outb
 
     assert DummyTestFS.from_dict(outa) is a
     assert DummyTestFS.from_dict(outb) is b


### PR DESCRIPTION
This PR fixes `AbstractFileSystem.to_dict()` failing to serialize recursive filesystem/paths which caused the output to not be JSON serializable.