### PR TITLE
DirFS: Handle paths with no leading `/` (#1638)

### DIFF
--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -66,7 +66,9 @@ class DirFileSystem(AsyncFileSystem):
                 return path
             # We need to account for S3FileSystem returning paths that do not
             # start with a '/'
-            if path == self.path or (self.path.startswith(self.fs.sep) and path == self.path[1:]):
+            if path == self.path or (
+                self.path.startswith(self.fs.sep) and path == self.path[1:]
+            ):
                 return ""
             prefix = self.path + self.fs.sep
             if self.path.startswith(self.fs.sep) and not path.startswith(self.fs.sep):

--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -64,9 +64,13 @@ class DirFileSystem(AsyncFileSystem):
         if isinstance(path, str):
             if not self.path:
                 return path
-            if path == self.path:
+            # We need to account for S3FileSystem returning paths that do not
+            # start with a '/'
+            if path == self.path or (self.path.startswith(self.fs.sep) and path == self.path[1:]):
                 return ""
             prefix = self.path + self.fs.sep
+            if self.path.startswith(self.fs.sep) and not path.startswith(self.fs.sep):
+                prefix = prefix[1:]
             assert path.startswith(prefix)
             return path[len(prefix) :]
         return [self._relpath(_path) for _path in path]

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -82,11 +82,25 @@ def test_dirfs(fs, asyncfs):
         ("", "foo", "foo"),
         ("root", "", "root"),
         ("root", "foo", "root/foo"),
+        ("/root", "", "/root"),
+        ("/root", "foo", "/root/foo"),
     ],
 )
 def test_path(fs, root, rel, full):
     dirfs = DirFileSystem(root, fs)
     assert dirfs._join(rel) == full
+    assert dirfs._relpath(full) == rel
+
+
+@pytest.mark.parametrize(
+    "root, rel, full",
+    [
+        ("/root", "foo", "root/foo"),
+        ("/root", "", "root"),
+    ],
+)
+def test_path_no_leading_slash(fs, root, rel, full):
+    dirfs = DirFileSystem(root, fs)
     assert dirfs._relpath(full) == rel
 
 


### PR DESCRIPTION
If you wrap an `S3FileSystem` with `DirFileSystem`, `ls()` breaks, since `DirFileSystem` assumes that the underlying FS returns paths with a leading `/`, but `S3FileSystem` does not (see #1638).

This change to _relpath() removes the leading `/` from the `prefix` used in constructing the relative path when the incoming `path` has no leading `/`, but the `DirFileSystem` path does.