### PR TITLE
FTPFileSystem: ls() fix for root `/` path with dircache (#1635)

### DIFF
--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -107,9 +107,9 @@ class FTPFileSystem(AbstractFileSystem):
                 except error_perm:
                     out = _mlsd2(self.ftp, path)  # Not platform independent
                 for fn, details in out:
-                    if path == "/":
-                        path = ""  # just for forming the names, below
-                    details["name"] = "/".join([path, fn.lstrip("/")])
+                    details["name"] = "/".join(
+                        ["" if path == "/" else path, fn.lstrip("/")]
+                    )
                     if details["type"] == "file":
                         details["size"] = int(details["size"])
                     else:

--- a/fsspec/implementations/tests/test_ftp.py
+++ b/fsspec/implementations/tests/test_ftp.py
@@ -44,6 +44,21 @@ def test_not_cached(ftp):
     assert fs is not fs2
 
 
+def test_ls_root_dircache(ftp):
+    host, port = ftp
+    fs = FTPFileSystem(host, port)
+
+    files = fs.ls("/", detail=False)
+
+    assert "/" in fs.dircache
+
+    fs.ftp = None  # Ensure no ftp action will be done after
+
+    files2 = fs.ls("/", detail=False)
+
+    assert files == files2
+
+
 @pytest.mark.parametrize("cache_type", ["bytes", "mmap"])
 def test_complex(ftp_writable, cache_type):
     from fsspec.core import BytesCache


### PR DESCRIPTION
Add proposed fix for issue #1635 along with a test to check that it is working as intended and prevent regression