### PR TITLE
Fix ftp test_ls_root_dircache()

### DIFF
--- a/fsspec/implementations/tests/test_ftp.py
+++ b/fsspec/implementations/tests/test_ftp.py
@@ -52,11 +52,14 @@ def test_ls_root_dircache(ftp):
 
     assert "/" in fs.dircache
 
+    ftp_tmp = fs.ftp
     fs.ftp = None  # Ensure no ftp action will be done after
 
     files2 = fs.ls("/", detail=False)
 
     assert files == files2
+
+    fs.ftp = ftp_tmp
 
 
 @pytest.mark.parametrize("cache_type", ["bytes", "mmap"])


### PR DESCRIPTION
Oops, following the tests results for #1643 I noticed this warning:

```
fsspec/implementations/tests/test_ftp.py::test_ls_root_dircache
  /home/runner/micromamba/envs/test_env/lib/python3.8/site-packages/_pytest/unraisableexception.py:80: PytestUnraisableExceptionWarning: Exception ignored in: <function FTPFileSystem.__del__ at 0x7fee3a7bb9d0>
  
  Traceback (most recent call last):
    File "/home/runner/work/filesystem_spec/filesystem_spec/fsspec/implementations/ftp.py", line 251, in __del__
      self.ftp.close()
  AttributeError: 'NoneType' object has no attribute 'close'
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```

I was not aware (but it makes sense) of the closing connection with the `__del__` method.
Fixed it by restoring the ftp variable after test usage.