### PR TITLE
Add exception handling for SMBFileSystem init connection errors

### DIFF
--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -150,7 +150,7 @@ class SMBFileSystem(AbstractFileSystem):
                 # that the credentials are invalid and not a network issue.
                 raise
             except ValueError as exc:
-                if re.match(r"\[Errno -\d+]", str(exc)):
+                if re.findall(r"\[Errno -\d+]", str(exc)):
                     # This exception is raised by the smbprotocol.transport:Tcp.connect
                     # and originates from socket.gaierror (OSError). These exceptions might
                     # be raised due to network instability. We will retry to connect.

--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -160,7 +160,7 @@ class SMBFileSystem(AbstractFileSystem):
         # will be equal to `wait`. For any number of retries the last wait time will be
         # equal to `wait` and for retries>2 the first wait time will be equal to `wait / factor`.
         wait_times = iter(
-            factor ** (n / n_waits - 1) * wait_time for n in range(1, n_waits + 1)
+            factor ** (n / n_waits - 1) * wait_time for n in range(0, n_waits + 1)
         )
 
         for attempt in range(self.register_session_retries + 1):

--- a/fsspec/implementations/smb.py
+++ b/fsspec/implementations/smb.py
@@ -134,8 +134,18 @@ class SMBFileSystem(AbstractFileSystem):
         self.encrypt = encrypt
         self.temppath = kwargs.pop("temppath", "")
         self.share_access = share_access
+        if register_session_retries < 0:
+            raise ValueError("register_session_retries must be a non-negative integer")
         self.register_session_retries = register_session_retries
+        if register_session_retry_wait < 0:
+            raise ValueError(
+                "register_session_retry_wait must be a non-negative integer"
+            )
         self.register_session_retry_wait = register_session_retry_wait
+        if register_session_retry_factor < 1:
+            raise ValueError(
+                "register_session_retry_factor must be a positive integer greater than 1"
+            )
         self.register_session_retry_factor = register_session_retry_factor
         self.auto_mkdir = auto_mkdir
         self._connect()


### PR DESCRIPTION
Related to #1571 

This PR implements exception handling for `SMBFileSystem._connect()` which brings changes to the current implementation:
- reraise exceptions related to authentication issues 
- reraise ValueError exceptions related to configuration
- retry on connection issues raised by socket
- retry all other exceptions
- distinguished attempts and retries, where always one attempt to register a session is made

Retrying all other exceptions could be dropped in the future once all exceptions suited for retry are identified. Until then, we should probably not affect current behavior as much as we should.

Other feature proposed in this PR is raising latest exception after all retries are exhausted. This will at least inform a user about excepted issue. (related question is whether to implement ExceptionGroup to inform about all exceptions)

Additionally, an implementation for exponential wait time growth from 0 to requested time (included) is added. 
The wait time is calculated using exponential function. For factor=1 all wait times will be equal to `register_session_retry_wait`. For any number of retries, the last wait time will be equal to `register_session_retry_wait` and for retries>1 the first wait time will be equal to `register_session_retry_wait / factor`.  
By default a factor is made 10 as most optimal (quick first attempts)