### PR TITLE
[feat] caching on demand

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -441,7 +441,7 @@ class CachingFileSystem(AbstractFileSystem):
             "start_transaction",
             "end_transaction",
             "cache_path",
-            "_cache_detail"
+            "_cache_detail",
         }:
             # all the methods defined in this class. Note `open` here, since
             # it calls `_open`, but is actually in superclass

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -265,6 +265,7 @@ class HTTPFileSystem(AsyncFileSystem):
             finally:
                 if not isfilelike(lpath):
                     outfile.close()
+                callback.close()
 
     async def _put_file(
         self,

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -912,6 +912,7 @@ class AbstractFileSystem(metaclass=_Cached):
             finally:
                 if not isfilelike(lpath):
                     outfile.close()
+                callback.close()
 
     def get(
         self,


### PR DESCRIPTION
This PR solves a use case I have where I want to use `filecache` or `simplecache` to assist me in downloading a file and using the local path. Further, I may be working with extremely large files and I want to avoid calling `.read()` since that places the whole file into memory after it has been cached.

Todo:
- [ ] Tests for chaching method
- [ ] Docs

A new method has been added called `.cache_path(path)` to invoke caching (I'm open to better name) and return the local filename.

Here's an example with simplecache, the same works for filecache.

```python
In [1]: import fsspec

In [2]: url = 'https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q5_K_M.ggu
   ...: f?download=True'

In [3]: fs, path = fsspec.url_to_fs(f"simplecache::{url}")

In [4]: from fsspec.callbacks import TqdmCallback

In [5]: fs.cache_path(path, callback=TqdmCallback(), force=True)
100%|██████████████████████████████████████████████████████████████████| 5131409056/5131409056 [02:56<00:00, 29001242.99it/s]
Out[5]: '/var/folders/cg/wyhz9cvx06vdt65k8tr31trc0000gp/T/tmp0ty9rygr/b6d84e10fdf36fa50acdf6e717b1e6ae2814efa70869edefe2d5d4a7182a11fb'

In [6]: fs.cache_path(path, callback=TqdmCallback())
Out[6]: '/var/folders/cg/wyhz9cvx06vdt65k8tr31trc0000gp/T/tmp0ty9rygr/b6d84e10fdf36fa50acdf6e717b1e6ae2814efa70869edefe2d5d4a7182a11fb'

In [7]: 
```

