### PR TITLE
Improve performance find zip archive

### DIFF
--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -446,6 +446,12 @@ def test_find_returns_expected_result_path_set(zip_file):
     assert result == expected_result
 
 
+def test_find_with_and_without_slash_should_return_same_result(zip_file):
+    zip_file_system = ZipFileSystem(zip_file)
+
+    assert zip_file_system.find("/dir2/") == zip_file_system.find("/dir2")
+
+
 def test_find_should_return_file_if_exact_match(zip_file):
     zip_file_system = ZipFileSystem(zip_file)
 

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -158,16 +158,18 @@ def zip_file_fixture(tmp_path):
     return Path(make_archive(zip_file, "zip", data_dir))
 
 
-def _assert_all_except_date_time(result, expected_result):
+def _assert_all_except_context_dependent_variables(result, expected_result):
     for path in expected_result.keys():
         assert result[path]
         result_without_date_time = result[path].copy()
         result_without_date_time.pop("date_time")
         result_without_date_time.pop("_raw_time")
+        result_without_date_time.pop("external_attr")
 
         expected_result_without_date_time = expected_result[path].copy()
         expected_result_without_date_time.pop("date_time")
         expected_result_without_date_time.pop("_raw_time")
+        expected_result_without_date_time.pop("external_attr")
         assert result_without_date_time == expected_result_without_date_time
 
 
@@ -257,7 +259,7 @@ def test_find_returns_expected_result_detail_true(zip_file):
         },
     }
 
-    _assert_all_except_date_time(result, expected_result)
+    _assert_all_except_context_dependent_variables(result, expected_result)
 
 
 def test_find_returns_expected_result_detail_false(zip_file):
@@ -406,7 +408,7 @@ def test_find_returns_expected_result_detail_true_include_dirs(zip_file):
         },
     }
 
-    _assert_all_except_date_time(result, expected_result)
+    _assert_all_except_context_dependent_variables(result, expected_result)
 
 
 def test_find_returns_expected_result_detail_false_include_dirs(zip_file):

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -165,11 +165,13 @@ def _assert_all_except_context_dependent_variables(result, expected_result):
         result_without_date_time.pop("date_time")
         result_without_date_time.pop("_raw_time")
         result_without_date_time.pop("external_attr")
+        result_without_date_time.pop("create_system")
 
         expected_result_without_date_time = expected_result[path].copy()
         expected_result_without_date_time.pop("date_time")
         expected_result_without_date_time.pop("_raw_time")
         expected_result_without_date_time.pop("external_attr")
+        expected_result_without_date_time.pop("create_system")
         assert result_without_date_time == expected_result_without_date_time
 
 

--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -154,6 +154,9 @@ def zip_file_fixture(tmp_path):
     file3 = dir_with_files / "file3.txt"
     file3.write_text("Hello!")
 
+    potential_mix_up_path = data_dir / "dir2startwithsamename.txt"
+    potential_mix_up_path.write_text("Hello again!")
+
     zip_file = tmp_path / "test"
     return Path(make_archive(zip_file, "zip", data_dir))
 
@@ -197,12 +200,12 @@ def test_find_returns_expected_result_detail_true(zip_file):
             "volume": 0,
             "internal_attr": 0,
             "external_attr": 2175008768,
-            "header_offset": 191,
+            "header_offset": 260,
             "CRC": 2636827734,
             "compress_size": 8,
             "file_size": 6,
             "_raw_time": 21961,
-            "_end_offset": 243,
+            "_end_offset": 312,
             "name": "dir2/file3.txt",
             "size": 6,
             "type": "file",
@@ -223,12 +226,12 @@ def test_find_returns_expected_result_detail_true(zip_file):
             "volume": 0,
             "internal_attr": 0,
             "external_attr": 2175008768,
-            "header_offset": 70,
+            "header_offset": 139,
             "CRC": 3964322768,
             "compress_size": 15,
             "file_size": 13,
             "_raw_time": 21961,
-            "_end_offset": 124,
+            "_end_offset": 193,
             "name": "file1.txt",
             "size": 13,
             "type": "file",
@@ -249,12 +252,12 @@ def test_find_returns_expected_result_detail_true(zip_file):
             "volume": 0,
             "internal_attr": 0,
             "external_attr": 2175008768,
-            "header_offset": 124,
+            "header_offset": 193,
             "CRC": 1596576865,
             "compress_size": 28,
             "file_size": 26,
             "_raw_time": 21961,
-            "_end_offset": 191,
+            "_end_offset": 260,
             "name": "file2.txt",
             "size": 26,
             "type": "file",
@@ -268,7 +271,12 @@ def test_find_returns_expected_result_detail_false(zip_file):
     zip_file_system = ZipFileSystem(zip_file)
 
     result = zip_file_system.find("/", detail=False)
-    expected_result = ["dir2/file3.txt", "file1.txt", "file2.txt"]
+    expected_result = [
+        "dir2/file3.txt",
+        "dir2startwithsamename.txt",
+        "file1.txt",
+        "file2.txt",
+    ]
 
     assert result == expected_result
 
@@ -346,12 +354,12 @@ def test_find_returns_expected_result_detail_true_include_dirs(zip_file):
             "volume": 0,
             "internal_attr": 0,
             "external_attr": 2175008768,
-            "header_offset": 191,
+            "header_offset": 260,
             "CRC": 2636827734,
             "compress_size": 8,
             "file_size": 6,
             "_raw_time": 22220,
-            "_end_offset": 243,
+            "_end_offset": 312,
             "name": "dir2/file3.txt",
             "size": 6,
             "type": "file",
@@ -372,12 +380,12 @@ def test_find_returns_expected_result_detail_true_include_dirs(zip_file):
             "volume": 0,
             "internal_attr": 0,
             "external_attr": 2175008768,
-            "header_offset": 70,
+            "header_offset": 139,
             "CRC": 3964322768,
             "compress_size": 15,
             "file_size": 13,
             "_raw_time": 22220,
-            "_end_offset": 124,
+            "_end_offset": 193,
             "name": "file1.txt",
             "size": 13,
             "type": "file",
@@ -398,12 +406,12 @@ def test_find_returns_expected_result_detail_true_include_dirs(zip_file):
             "volume": 0,
             "internal_attr": 0,
             "external_attr": 2175008768,
-            "header_offset": 124,
+            "header_offset": 193,
             "CRC": 1596576865,
             "compress_size": 28,
             "file_size": 26,
             "_raw_time": 22220,
-            "_end_offset": 191,
+            "_end_offset": 260,
             "name": "file2.txt",
             "size": 26,
             "type": "file",
@@ -417,16 +425,14 @@ def test_find_returns_expected_result_detail_false_include_dirs(zip_file):
     zip_file_system = ZipFileSystem(zip_file)
 
     result = zip_file_system.find("/", detail=False, withdirs=True)
-    expected_result = ["dir1", "dir2", "dir2/file3.txt", "file1.txt", "file2.txt"]
-
-    assert result == expected_result
-
-
-def test_find_returns_expected_result_recursion_depth_set(zip_file):
-    zip_file_system = ZipFileSystem(zip_file)
-    result = zip_file_system.find("/", maxdepth=1)
-
-    expected_result = ["file1.txt", "file2.txt"]
+    expected_result = [
+        "dir1",
+        "dir2",
+        "dir2/file3.txt",
+        "dir2startwithsamename.txt",
+        "file1.txt",
+        "file2.txt",
+    ]
 
     assert result == expected_result
 
@@ -436,5 +442,27 @@ def test_find_returns_expected_result_path_set(zip_file):
 
     result = zip_file_system.find("/dir2")
     expected_result = ["dir2/file3.txt"]
+
+    assert result == expected_result
+
+
+def test_find_should_return_file_if_exact_match(zip_file):
+    zip_file_system = ZipFileSystem(zip_file)
+
+    result = zip_file_system.find("/dir2startwithsamename.txt", detail=False)
+    expected_result = ["dir2startwithsamename.txt"]
+
+    assert result == expected_result
+
+
+def test_find_returns_expected_result_recursion_depth_set(zip_file):
+    zip_file_system = ZipFileSystem(zip_file)
+    result = zip_file_system.find("/", maxdepth=1)
+
+    expected_result = [
+        "dir2startwithsamename.txt",
+        "file1.txt",
+        "file2.txt",
+    ]
 
     assert result == expected_result

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -144,8 +144,6 @@ class ZipFileSystem(AbstractArchiveFileSystem):
             depth = len(path.split("/"))
             return depth > maxdepth
 
-        result = {}
-
         # Remove the leading slash, as the zip file paths are always
         # given without a leading slash
         path = path.lstrip("/")
@@ -160,6 +158,7 @@ class ZipFileSystem(AbstractArchiveFileSystem):
 
         self._get_dirs()
 
+        result = {}
         # To match posix find, if an exact file name is given, we should
         # return only that file
         if path in self.dir_cache and self.dir_cache[path]["type"] == "file":

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -149,6 +149,14 @@ class ZipFileSystem(AbstractArchiveFileSystem):
         # Remove the leading slash, as the zip file paths are always
         # given without a leading slash
         path = path.lstrip("/")
+        path_parts = list(filter(lambda s: bool(s), path.split("/")))
+
+        def _matching_starts(file_path):
+            file_parts = filter(lambda s: bool(s), file_path.split("/"))
+            for a, b in zip(path_parts, file_parts):
+                if a != b:
+                    return False
+            return True
 
         self._get_dirs()
 
@@ -159,7 +167,7 @@ class ZipFileSystem(AbstractArchiveFileSystem):
             return result if detail else [path]
 
         for file_path, file_info in self.dir_cache.items():
-            if not (path == "" or file_path.startswith(path + "/")):
+            if not (path == "" or _matching_starts(file_path)):
                 continue
 
             if _below_max_recursion_depth(file_path):

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -137,13 +137,6 @@ class ZipFileSystem(AbstractArchiveFileSystem):
         if maxdepth is not None and maxdepth < 1:
             raise ValueError("maxdepth must be at least 1")
 
-        def _below_max_recursion_depth(path):
-            if not maxdepth:
-                return False
-
-            depth = len(path.split("/"))
-            return depth > maxdepth
-
         # Remove the leading slash, as the zip file paths are always
         # given without a leading slash
         path = path.lstrip("/")
@@ -169,9 +162,6 @@ class ZipFileSystem(AbstractArchiveFileSystem):
             if not (path == "" or _matching_starts(file_path)):
                 continue
 
-            if _below_max_recursion_depth(file_path):
-                continue
-
             if file_info["type"] == "directory":
                 if withdirs:
                     if file_path not in result:
@@ -181,4 +171,9 @@ class ZipFileSystem(AbstractArchiveFileSystem):
             if file_path not in result:
                 result[file_path] = file_info if detail else None
 
+        if maxdepth:
+            path_depth = path.count("/")
+            result = {
+                k: v for k, v in result.items() if k.count("/") - path_depth < maxdepth
+            }
         return result if detail else sorted(result)

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -144,10 +144,7 @@ class ZipFileSystem(AbstractArchiveFileSystem):
 
         def _matching_starts(file_path):
             file_parts = filter(lambda s: bool(s), file_path.split("/"))
-            for a, b in zip(path_parts, file_parts):
-                if a != b:
-                    return False
-            return True
+            return all(a == b for a, b in zip(path_parts, file_parts))
 
         self._get_dirs()
 

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -156,17 +156,15 @@ class ZipFileSystem(AbstractArchiveFileSystem):
             # from the file paths
             if zip_info.is_dir():
                 if withdirs:
-                    if not result.get(file_name) and _below_max_recursion_depth(
+                    if not file_name in result and _below_max_recursion_depth(
                         file_name
                     ):
                         result[file_name.strip("/")] = (
                             self.info(file_name) if detail else None
                         )
-                    continue
-                else:
-                    continue  # Skip along to the next entry if we don't want to add the dirs
+                continue
 
-            if not result.get(file_name):
+            if file_name not in result:
                 if _below_max_recursion_depth(file_name):
                     result[file_name] = self.info(file_name) if detail else None
 
@@ -187,4 +185,4 @@ class ZipFileSystem(AbstractArchiveFileSystem):
                                 "type": "directory",
                             }
 
-        return result if detail else sorted(result.keys())
+        return result if detail else sorted(result)


### PR DESCRIPTION
This is an attempt to address #1662. Working on a code base that makes extensive us of zip archives containing parquet files that need to be read on the fly to load data, I noticed that `find` was a major bottleneck in that process.

I have made a zip specific implementation of `find` here that relies on the file list of the zip file, rather than explicitly walking.

Here is how I measured the performance:

```
from fsspec.implementations.zip import ZipFileSystem

# Example achieve with roughly 900 files, in some deep directory structures
file_system = ZipFileSystem("example.zip")
%timeit file_system.find("/")
```

Performance for find on current `master`
```
2.14 s ± 146 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Performance for find with this fix applied:
```
318 µs ± 11.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

Let me know what you think.
