### PR TITLE
allow repeated extra arguments

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -346,7 +346,7 @@ def _un_chain(path, kwargs):
         kws = kwargs.pop(protocol, {})
         if bit is bits[0]:
             kws.update(kwargs)
-        kw = dict(**extra_kwargs, **kws)
+        kw = dict(**{k: v for k, v in extra_kwargs.items() if k not in kws or v != kws[k]}, **kws)
         bit = cls._strip_protocol(bit)
         if (
             protocol in {"blockcache", "filecache", "simplecache"}

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -346,7 +346,10 @@ def _un_chain(path, kwargs):
         kws = kwargs.pop(protocol, {})
         if bit is bits[0]:
             kws.update(kwargs)
-        kw = dict(**{k: v for k, v in extra_kwargs.items() if k not in kws or v != kws[k]}, **kws)
+        kw = dict(
+            **{k: v for k, v in extra_kwargs.items() if k not in kws or v != kws[k]},
+            **kws,
+        )
         bit = cls._strip_protocol(bit)
         if (
             protocol in {"blockcache", "filecache", "simplecache"}

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -96,10 +96,9 @@ def test_run_coros_in_chunks(monkeypatch):
 
         total_running += 1
         await asyncio.sleep(0)
-        total_running -= 1
-
         if total_running > 4:
             raise ValueError("More than 4 coroutines are running together")
+        total_running -= 1
         return 1
 
     async def main(**kwargs):

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -96,9 +96,10 @@ def test_run_coros_in_chunks(monkeypatch):
 
         total_running += 1
         await asyncio.sleep(0)
+        total_running -= 1
+
         if total_running > 4:
             raise ValueError("More than 4 coroutines are running together")
-        total_running -= 1
         return 1
 
     async def main(**kwargs):

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -465,3 +465,20 @@ def test_chained_url(ftp_writable):
 def test_automkdir_local():
     fs, _ = fsspec.core.url_to_fs("file://", auto_mkdir=True)
     assert fs.auto_mkdir is True
+
+
+def test_repeated_argument():
+    from fsspec.core import url_to_fs
+
+    fs, url = url_to_fs(
+        "az://DIR@ACCOUNT.blob.core.windows.net/DATA",
+        anon=False,
+        account_name="ACCOUNT",
+    )
+    assert fs.storage_options == {"account_name": "ACCOUNT", "anon": False}
+    with pytest.raises(TypeError):
+        url_to_fs(
+            "az://DIR@ACCOUNT.blob.core.windows.net/DATA",
+            anon=False,
+            account_name="OTHER",
+        )

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -468,6 +468,7 @@ def test_automkdir_local():
 
 
 def test_repeated_argument():
+    pytest.importorskip("adlfs")
     from fsspec.core import url_to_fs
 
     fs, url = url_to_fs(


### PR DESCRIPTION
This fixes the error happening when the user passes extra parameters that are also inferred automatically. E.g., happens in lib `datasets`:
```
File ./python-default/3.10.14/lib/python3.10/site-packages/datasets/load.py:2692, in load_from_disk(dataset_path, fs, keep_in_memory, storage_options)
   2689     storage_options = fs.storage_options
   2691 fs: fsspec.AbstractFileSystem
-> 2692 fs, *_ = url_to_fs(dataset_path, **(storage_options or {}))
   2693 if not fs.exists(dataset_path):
   2694     raise FileNotFoundError(f"Directory {dataset_path} not found")

File ./3.10.14/lib/python3.10/site-packages/fsspec/core.py:396, in url_to_fs(url, **kwargs)
    385 known_kwargs = {
    386     "compression",
    387     "encoding",
   (...)
    393     "num",
    394 }
    395 kwargs = {k: v for k, v in kwargs.items() if k not in known_kwargs}
--> 396 chain = _un_chain(url, kwargs)
    397 inkwargs = {}
    398 # Reverse iterate the chain, creating a nested target_* structure

File ./3.10.14/lib/python3.10/site-packages/fsspec/core.py:349, in _un_chain(path, kwargs)
    347 if bit is bits[0]:
    348     kws.update(kwargs)
--> 349 kw = dict(**extra_kwargs, **kws)
    350 bit = cls._strip_protocol(bit)
    351 if (
    352     protocol in {"blockcache", "filecache", "simplecache"}
    353     and "target_protocol" not in kw
    354 ):

TypeError: dict() got multiple values for keyword argument 'account_name'
```

### This fix

```python
from fsspec.core import url_to_fs
url_to_fs('az://DIR@ACCOUNT.blob.core.windows.net/DATA', **{'anon': False, 'account_name': 'ACCOUNT'})
```
Out before:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], line 2
      1 from fsspec.core import url_to_fs
----> 2 url_to_fs('az://DIR@ACCOUNT.blob.core.windows.net/DATA', **{'anon': False, 'account_name': 'ACCOUNT'})

...
...
    347 if bit is bits[0]:
    348     kws.update(kwargs)
--> 349 kw = dict(**extra_kwargs, **kws)
    350 bit = cls._strip_protocol(bit)
    351 if (
    352     protocol in {"blockcache", "filecache", "simplecache"}
    353     and "target_protocol" not in kw
    354 ):

TypeError: dict() got multiple values for keyword argument 'account_name'
```


Out after:
```
(<adlfs.spec.AzureBlobFileSystem at 0x10708f460>, 'DIR/DATA')
```