### PR TITLE
Skip test_deep_parq without kerchunk installed

### DIFF
--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -762,6 +762,7 @@ def test_append_parquet(lazy_refs, m):
 
 
 def test_deep_parq(m):
+    pytest.importorskip("kerchunk")
     zarr = pytest.importorskip("zarr")
     lz = fsspec.implementations.reference.LazyReferenceMapper.create(
         "memory://out.parq", fs=m


### PR DESCRIPTION
Similar to `test_append_parquet` (#1523).