### PR TITLE
Adds engine option to `LazyReferenceMapper`

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -158,7 +158,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
             """cached parquet file loader"""
             path = self.url.format(field=field, record=record)
             data = io.BytesIO(self.fs.cat_file(path))
-            df = self.pd.read_parquet(data, engine="fastparquet")
+            df = self.pd.read_parquet(data, engine="pyarrow")
             refs = {c: df[c].to_numpy() for c in df.columns}
             return refs
 
@@ -465,7 +465,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         self.fs.mkdirs(f"{base_url or self.out_root}/{field}", exist_ok=True)
         df.to_parquet(
             fn,
-            engine="fastparquet",
+            engine="pyarrow",
             storage_options=storage_options
             or getattr(self.fs, "storage_options", None),
             compression="zstd",

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -138,7 +138,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
 
         from importlib.util import find_spec
 
-        if find_spec("pyarrow") is not None:
+        if find_spec("pyarrow") is None:
             raise ImportError("engine choice `pyarrow` is not installed.")
 
         self.root = root

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -129,14 +129,14 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         engine: Literal["fastparquet","pyarrow"]
             Engine choice for reading parquet files. (default is "fastparquet")
         """
-        if engine == 'pyarrow'
-        try:
-            import pyarrow
-        except ImportError as IE:
-            raise ImportError(
-                "engine: pyarrow is not installed"
-            ) from IE
-    
+        if engine == 'pyarrow':
+            try:
+                import pyarrow
+            except ImportError as IE:
+                raise ImportError(
+                    "engine: pyarrow is not installed"
+                ) from IE
+        
         self.root = root
         self.chunk_sizes = {}
         self.out_root = out_root or self.root

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -129,6 +129,14 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         engine: Literal["fastparquet","pyarrow"]
             Engine choice for reading parquet files. (default is "fastparquet")
         """
+        if engine == 'pyarrow'
+        try:
+            import pyarrow
+        except ImportError as IE:
+            raise ImportError(
+                "engine: pyarrow is not installed"
+            ) from IE
+    
         self.root = root
         self.chunk_sizes = {}
         self.out_root = out_root or self.root

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -104,7 +104,13 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         return pd
 
     def __init__(
-        self, root, fs=None, out_root=None, cache_size=128, categorical_threshold=10, engine: Literal["fastparquet", "pyarrow"] = "fastparquet"
+        self,
+        root,
+        fs=None,
+        out_root=None,
+        cache_size=128,
+        categorical_threshold=10,
+        engine: Literal["fastparquet", "pyarrow"] = "fastparquet",
     ):
         """
 
@@ -129,14 +135,12 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         engine: Literal["fastparquet","pyarrow"]
             Engine choice for reading parquet files. (default is "fastparquet")
         """
-        if engine == 'pyarrow':
-            try:
-                import pyarrow
-            except ImportError as IE:
-                raise ImportError(
-                    "engine: pyarrow is not installed"
-                ) from IE
-        
+
+        from importlib.util import find_spec
+
+        if find_spec("pyarrow") is not None:
+            raise ImportError("engine choice `pyarrow` is not installed.")
+
         self.root = root
         self.chunk_sizes = {}
         self.out_root = out_root or self.root

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -478,16 +478,17 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
 
         fn = f"{base_url or self.out_root}/{field}/refs.{record}.parq"
         self.fs.mkdirs(f"{base_url or self.out_root}/{field}", exist_ok=True)
+
         df.to_parquet(
-            fn,
+            "tmp.parquet",
             engine=self.engine,
             storage_options=storage_options
             or getattr(self.fs, "storage_options", None),
             compression="zstd",
             index=False,
-            stats=False,
-            object_encoding=object_encoding,
-            has_nulls=has_nulls,
+            # stats=False,
+            # object_encoding=object_encoding,
+            # has_nulls=has_nulls,
             # **kwargs,
         )
         partition.clear()
@@ -501,6 +502,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
         base_url: str
             Location of the output
         """
+
         # write what we have so far and clear sub chunks
         for thing in list(self._items):
             if isinstance(thing, tuple):

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -499,6 +499,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
             index=False,
             **df_backend_kwargs,
         )
+
         partition.clear()
         self._items.pop((field, record))
 

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -761,30 +761,30 @@ def test_append_parquet(lazy_refs, m):
     assert lazy2["data/1"] == b"Adata"
 
 
-# @pytest.mark.parametrize("engine", ["fastparquet", "pyarrow"])
-# def test_deep_parq(m, engine):
-#     # pytest.importorskip("kerchunk")
-#     zarr = pytest.importorskip("zarr")
-#     lz = fsspec.implementations.reference.LazyReferenceMapper.create(
-#         "memory://out.parq",
-#         fs=m,
-#         engine=engine,
-#     )
-#     g = zarr.open_group(lz, mode="w")
+@pytest.mark.parametrize("engine", ["fastparquet", "pyarrow"])
+def test_deep_parq(m, engine):
+    pytest.importorskip("kerchunk")
+    zarr = pytest.importorskip("zarr")
+    lz = fsspec.implementations.reference.LazyReferenceMapper.create(
+        "memory://out.parq",
+        fs=m,
+        engine=engine,
+    )
+    g = zarr.open_group(lz, mode="w")
 
-#     g2 = g.create_group("instant")
-#     g2.create_dataset(name="one", data=[1, 2, 3])
-#     lz.flush()
+    g2 = g.create_group("instant")
+    g2.create_dataset(name="one", data=[1, 2, 3])
+    lz.flush()
 
-#     lz = fsspec.implementations.reference.LazyReferenceMapper("memory://out.parq", fs=m)
-#     g = zarr.open_group(lz)
-#     assert g.instant.one[:].tolist() == [1, 2, 3]
-#     assert sorted(_["name"] for _ in lz.ls("")) == [".zgroup", ".zmetadata", "instant"]
-#     assert sorted(_["name"] for _ in lz.ls("instant")) == [
-#         "instant/.zgroup",
-#         "instant/one",
-#     ]
-#     assert sorted(_["name"] for _ in lz.ls("instant/one")) == [
-#         "instant/one/.zarray",
-#         "instant/one/0",
-#     ]
+    lz = fsspec.implementations.reference.LazyReferenceMapper("memory://out.parq", fs=m)
+    g = zarr.open_group(lz)
+    assert g.instant.one[:].tolist() == [1, 2, 3]
+    assert sorted(_["name"] for _ in lz.ls("")) == [".zgroup", ".zmetadata", "instant"]
+    assert sorted(_["name"] for _ in lz.ls("instant")) == [
+        "instant/.zgroup",
+        "instant/one",
+    ]
+    assert sorted(_["name"] for _ in lz.ls("instant/one")) == [
+        "instant/one/.zarray",
+        "instant/one/0",
+    ]

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -761,15 +761,6 @@ def test_append_parquet(lazy_refs, m):
     assert lazy2["data/1"] == b"Adata"
 
 
-import pytest
-import fsspec
-
-
-@pytest.fixture(autouse=True)
-def mock_fsspec_version(monkeypatch):
-    monkeypatch.setattr(fsspec, "__version__", "2022.11.0")
-
-
 @pytest.mark.parametrize("engine", ["fastparquet", "pyarrow"])
 def test_deep_parq(m, engine):
     pytest.importorskip("kerchunk")

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -773,12 +773,12 @@ def test_deep_parq(m, engine):
     )
     g = zarr.open_group(lz, mode="w")
 
-    # g2 = g.create_group("instant")
-    # g2.create_dataset(name="one", data=[1, 2, 3])
-    # lz.flush()
+    g2 = g.create_group("instant")
+    g2.create_dataset(name="one", data=[1, 2, 3])
+    lz.flush()
 
-    # # lz = fsspec.implementations.reference.LazyReferenceMapper("memory://out.parq", fs=m)
-    # # g = zarr.open_group(lz)
+    lz = fsspec.implementations.reference.LazyReferenceMapper("memory://out.parq", fs=m, engine=engine)
+    g = zarr.open_group(lz)
     # # assert g.instant.one[:].tolist() == [1, 2, 3]
     # # assert sorted(_["name"] for _ in lz.ls("")) == [".zgroup", ".zmetadata", "instant"]
     # # assert sorted(_["name"] for _ in lz.ls("instant")) == [

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -761,12 +761,14 @@ def test_append_parquet(lazy_refs, m):
     assert lazy2["data/1"] == b"Adata"
 
 
-@pytest.mark.parametrize('engine',['fastparquet','pyarrow'])
-def test_deep_parq(m,engine):
+@pytest.mark.parametrize("engine", ["fastparquet", "pyarrow"])
+def test_deep_parq(m, engine):
     pytest.importorskip("kerchunk")
     zarr = pytest.importorskip("zarr")
     lz = fsspec.implementations.reference.LazyReferenceMapper.create(
-        "memory://out.parq", fs=m, engine=engine,
+        "memory://out.parq",
+        fs=m,
+        engine=engine,
     )
     g = zarr.open_group(lz, mode="w")
 

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -761,30 +761,30 @@ def test_append_parquet(lazy_refs, m):
     assert lazy2["data/1"] == b"Adata"
 
 
-@pytest.mark.parametrize("engine", ["fastparquet", "pyarrow"])
-def test_deep_parq(m, engine):
-    pytest.importorskip("kerchunk")
-    zarr = pytest.importorskip("zarr")
-    lz = fsspec.implementations.reference.LazyReferenceMapper.create(
-        "memory://out.parq",
-        fs=m,
-        engine=engine,
-    )
-    g = zarr.open_group(lz, mode="w")
+# @pytest.mark.parametrize("engine", ["fastparquet", "pyarrow"])
+# def test_deep_parq(m, engine):
+#     # pytest.importorskip("kerchunk")
+#     zarr = pytest.importorskip("zarr")
+#     lz = fsspec.implementations.reference.LazyReferenceMapper.create(
+#         "memory://out.parq",
+#         fs=m,
+#         engine=engine,
+#     )
+#     g = zarr.open_group(lz, mode="w")
 
-    g2 = g.create_group("instant")
-    g2.create_dataset(name="one", data=[1, 2, 3])
-    lz.flush()
+#     g2 = g.create_group("instant")
+#     g2.create_dataset(name="one", data=[1, 2, 3])
+#     lz.flush()
 
-    lz = fsspec.implementations.reference.LazyReferenceMapper("memory://out.parq", fs=m)
-    g = zarr.open_group(lz)
-    assert g.instant.one[:].tolist() == [1, 2, 3]
-    assert sorted(_["name"] for _ in lz.ls("")) == [".zgroup", ".zmetadata", "instant"]
-    assert sorted(_["name"] for _ in lz.ls("instant")) == [
-        "instant/.zgroup",
-        "instant/one",
-    ]
-    assert sorted(_["name"] for _ in lz.ls("instant/one")) == [
-        "instant/one/.zarray",
-        "instant/one/0",
-    ]
+#     lz = fsspec.implementations.reference.LazyReferenceMapper("memory://out.parq", fs=m)
+#     g = zarr.open_group(lz)
+#     assert g.instant.one[:].tolist() == [1, 2, 3]
+#     assert sorted(_["name"] for _ in lz.ls("")) == [".zgroup", ".zmetadata", "instant"]
+#     assert sorted(_["name"] for _ in lz.ls("instant")) == [
+#         "instant/.zgroup",
+#         "instant/one",
+#     ]
+#     assert sorted(_["name"] for _ in lz.ls("instant/one")) == [
+#         "instant/one/.zarray",
+#         "instant/one/0",
+#     ]

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -761,13 +761,15 @@ def test_append_parquet(lazy_refs, m):
     assert lazy2["data/1"] == b"Adata"
 
 
-def test_deep_parq(m):
+@pytest.mark.parametrize('engine',['fastparquet','pyarrow'])
+def test_deep_parq(m,engine):
     pytest.importorskip("kerchunk")
     zarr = pytest.importorskip("zarr")
     lz = fsspec.implementations.reference.LazyReferenceMapper.create(
-        "memory://out.parq", fs=m
+        "memory://out.parq", fs=m, engine=engine,
     )
     g = zarr.open_group(lz, mode="w")
+
     g2 = g.create_group("instant")
     g2.create_dataset(name="one", data=[1, 2, 3])
     lz.flush()

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -761,6 +761,15 @@ def test_append_parquet(lazy_refs, m):
     assert lazy2["data/1"] == b"Adata"
 
 
+import pytest
+import fsspec
+
+
+@pytest.fixture(autouse=True)
+def mock_fsspec_version(monkeypatch):
+    monkeypatch.setattr(fsspec, "__version__", "2022.11.0")
+
+
 @pytest.mark.parametrize("engine", ["fastparquet", "pyarrow"])
 def test_deep_parq(m, engine):
     pytest.importorskip("kerchunk")
@@ -777,15 +786,18 @@ def test_deep_parq(m, engine):
     g2.create_dataset(name="one", data=[1, 2, 3])
     lz.flush()
 
-    lz = fsspec.implementations.reference.LazyReferenceMapper("memory://out.parq", fs=m, engine=engine)
+    lz = fsspec.implementations.reference.LazyReferenceMapper(
+        "memory://out.parq", fs=m, engine=engine
+    )
     g = zarr.open_group(lz)
-    # # assert g.instant.one[:].tolist() == [1, 2, 3]
-    # # assert sorted(_["name"] for _ in lz.ls("")) == [".zgroup", ".zmetadata", "instant"]
-    # # assert sorted(_["name"] for _ in lz.ls("instant")) == [
-    # #     "instant/.zgroup",
-    # #     "instant/one",
-    # # ]
-    # # assert sorted(_["name"] for _ in lz.ls("instant/one")) == [
-    # #     "instant/one/.zarray",
-    # #     "instant/one/0",
-    # # ]
+    assert g.instant.one[:].tolist() == [1, 2, 3]
+    assert sorted(_["name"] for _ in lz.ls("")) == [".zgroup", ".zmetadata", "instant"]
+    assert sorted(_["name"] for _ in lz.ls("instant")) == [
+        "instant/.zgroup",
+        "instant/one",
+    ]
+
+    assert sorted(_["name"] for _ in lz.ls("instant/one")) == [
+        "instant/one/.zarray",
+        "instant/one/0",
+    ]

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -773,19 +773,19 @@ def test_deep_parq(m, engine):
     )
     g = zarr.open_group(lz, mode="w")
 
-    g2 = g.create_group("instant")
-    g2.create_dataset(name="one", data=[1, 2, 3])
-    lz.flush()
+    # g2 = g.create_group("instant")
+    # g2.create_dataset(name="one", data=[1, 2, 3])
+    # lz.flush()
 
-    lz = fsspec.implementations.reference.LazyReferenceMapper("memory://out.parq", fs=m)
-    g = zarr.open_group(lz)
-    assert g.instant.one[:].tolist() == [1, 2, 3]
-    assert sorted(_["name"] for _ in lz.ls("")) == [".zgroup", ".zmetadata", "instant"]
-    assert sorted(_["name"] for _ in lz.ls("instant")) == [
-        "instant/.zgroup",
-        "instant/one",
-    ]
-    assert sorted(_["name"] for _ in lz.ls("instant/one")) == [
-        "instant/one/.zarray",
-        "instant/one/0",
-    ]
+    # # lz = fsspec.implementations.reference.LazyReferenceMapper("memory://out.parq", fs=m)
+    # # g = zarr.open_group(lz)
+    # # assert g.instant.one[:].tolist() == [1, 2, 3]
+    # # assert sorted(_["name"] for _ in lz.ls("")) == [".zgroup", ".zmetadata", "instant"]
+    # # assert sorted(_["name"] for _ in lz.ls("instant")) == [
+    # #     "instant/.zgroup",
+    # #     "instant/one",
+    # # ]
+    # # assert sorted(_["name"] for _ in lz.ls("instant/one")) == [
+    # #     "instant/one/.zarray",
+    # #     "instant/one/0",
+    # # ]

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -765,6 +765,7 @@ def test_append_parquet(lazy_refs, m):
 def test_deep_parq(m, engine):
     pytest.importorskip("kerchunk")
     zarr = pytest.importorskip("zarr")
+
     lz = fsspec.implementations.reference.LazyReferenceMapper.create(
         "memory://out.parq",
         fs=m,


### PR DESCRIPTION
Defaults to 'fastparquet', but allows for 'pyarrow'