### PR TITLE
Avoid use of _pygit2.Blob.hex, which has been removed in pygit2 >= 1.15

### DIFF
--- a/fsspec/implementations/git.py
+++ b/fsspec/implementations/git.py
@@ -80,7 +80,7 @@ class GitFileSystem(AbstractFileSystem):
                         {
                             "type": "directory",
                             "name": "/".join([path, obj.name]).lstrip("/"),
-                            "hex": obj.hex,
+                            "hex": str(obj.id),
                             "mode": f"{obj.filemode:o}",
                             "size": 0,
                         }
@@ -90,7 +90,7 @@ class GitFileSystem(AbstractFileSystem):
                         {
                             "type": "file",
                             "name": "/".join([path, obj.name]).lstrip("/"),
-                            "hex": obj.hex,
+                            "hex": str(obj.id),
                             "mode": f"{obj.filemode:o}",
                             "size": obj.size,
                         }
@@ -101,7 +101,7 @@ class GitFileSystem(AbstractFileSystem):
                 {
                     "type": "file",
                     "name": obj.name,
-                    "hex": obj.hex,
+                    "hex": str(obj.id),
                     "mode": f"{obj.filemode:o}",
                     "size": obj.size,
                 }


### PR DESCRIPTION
Fixes #1702