### PR TITLE
Fix performance issues with MemoryFileSystem.rm

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -248,6 +248,10 @@ class MemoryFileSystem(AbstractFileSystem):
         except KeyError:
             raise FileNotFoundError(path)
 
+    def isfile(self, path):
+        path = self._strip_protocol(path)
+        return path in self.store
+
     def rm(self, path, recursive=False, maxdepth=None):
         if isinstance(path, str):
             path = self._strip_protocol(path)
@@ -255,14 +259,14 @@ class MemoryFileSystem(AbstractFileSystem):
             path = [self._strip_protocol(p) for p in path]
         paths = self.expand_path(path, recursive=recursive, maxdepth=maxdepth)
         for p in reversed(paths):
+            if self.isfile(p):
+                self.rm_file(p)
             # If the expanded path doesn't exist, it is only because the expanded
             # path was a directory that does not exist in self.pseudo_dirs. This
             # is possible if you directly create files without making the
             # directories first.
-            if not self.exists(p):
+            elif not self.exists(p):
                 continue
-            if self.isfile(p):
-                self.rm_file(p)
             else:
                 self.rmdir(p)
 


### PR DESCRIPTION
Closes #1724.

The idea is that the nominal case is deleting an existing file, and verifying that a path corresponds to a file is an extremely fast key-existence check on the underlying store (dict). Thus by checking first if it's a file we escape the expensive exists check, which must scan all keys to check if the path is a prefix directory for some file.

Now the time to write a single file is roughly constant (instead of linear in the number of files), while the time to remove all files scales linearly with the number of files (instead of quadratically).

### Before:
![image](https://github.com/user-attachments/assets/c6608f67-be35-4947-9a11-1bb5c046f4a3)

### After:
![image](https://github.com/user-attachments/assets/970c6be1-6712-47b1-ba9c-39542b9f7810)

### Before:

![image](https://github.com/user-attachments/assets/c8f2f5a8-2cc2-4836-a41d-a245d8ddf31c)

$$10^{1.945\\, \log_{10}(N) - 6.5} = N^{1.945} / 3\times 10^6.$$

### After:

![image](https://github.com/user-attachments/assets/a858963f-8b48-4a91-9df1-bfaf23aff4fe)

$$10^{0.94\\, \log_{10}(N) - 5} = N^{0.945} / \times 10^5.$$
