### PR TITLE
Fix broken async reference file system `_cat_file` method

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -803,7 +803,7 @@ class ReferenceFileSystem(AsyncFileSystem):
             return part_or_url[start:end]
         protocol, _ = split_protocol(part_or_url)
         try:
-            return await self.fss[protocol]._cat_file(part_or_url, start=start, end=end)
+            return await self.fss[protocol]._cat_file(part_or_url, start=start0, end=end0)
         except Exception as e:
             raise ReferenceNotReachable(path, part_or_url) from e
 

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -803,7 +803,9 @@ class ReferenceFileSystem(AsyncFileSystem):
             return part_or_url[start:end]
         protocol, _ = split_protocol(part_or_url)
         try:
-            return await self.fss[protocol]._cat_file(part_or_url, start=start0, end=end0)
+            return await self.fss[protocol]._cat_file(
+                part_or_url, start=start0, end=end0
+            )
         except Exception as e:
             raise ReferenceNotReachable(path, part_or_url) from e
 

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -803,7 +803,7 @@ class ReferenceFileSystem(AsyncFileSystem):
             return part_or_url[start:end]
         protocol, _ = split_protocol(part_or_url)
         try:
-            await self.fss[protocol]._cat_file(part_or_url, start=start, end=end)
+            return await self.fss[protocol]._cat_file(part_or_url, start=start, end=end)
         except Exception as e:
             raise ReferenceNotReachable(path, part_or_url) from e
 

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -513,6 +513,28 @@ def test_cat_file_ranges(m):
     assert fs.cat_file("d", 1, -3) == other[4:10][1:-3]
 
 
+@pytest.mark.asyncio
+async def test_async_cat_file_ranges():
+    fs = fsspec.filesystem(
+        "reference",
+        fo={
+            "version": 1,
+            "refs": {
+                "reference_time/0": [
+                    "http://noaa-nwm-retro-v2-0-pds.s3.amazonaws.com/full_physics/2017/201704010000.CHRTOUT_DOMAIN1.comp",
+                    39783,
+                    12,
+                ],
+            },
+        },
+        remote_protocol="http",
+        remote_options={"asynchronous": True},
+        asynchronous=True,
+    )
+
+    assert await fs._cat_file("reference_time/0") == b'x^K0\xa9d\x04\x00\x03\x13\x01\x0f'
+
+
 @pytest.mark.parametrize(
     "fo",
     [

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -530,11 +530,13 @@ async def test_async_cat_file_ranges():
                 ],
             },
         },
-        fs={'https': fss},
+        fs={"https": fss},
         asynchronous=True,
     )
 
-    assert await fs._cat_file("reference_time/0") == b'x^K0\xa9d\x04\x00\x03\x13\x01\x0f'
+    assert (
+        await fs._cat_file("reference_time/0") == b"x^K0\xa9d\x04\x00\x03\x13\x01\x0f"
+    )
     await session.close()
 
 

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -515,7 +515,7 @@ def test_cat_file_ranges(m):
 
 @pytest.mark.asyncio
 async def test_async_cat_file_ranges():
-    fss = fsspec.filesystem("http", asynchronous=True)
+    fss = fsspec.filesystem("https", asynchronous=True)
     session = await fss.set_session()
 
     fs = fsspec.filesystem(
@@ -531,6 +531,7 @@ async def test_async_cat_file_ranges():
             },
         },
         fs={"https": fss},
+        remote_protocol="https",
         asynchronous=True,
     )
 

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -524,13 +524,13 @@ async def test_async_cat_file_ranges():
             "version": 1,
             "refs": {
                 "reference_time/0": [
-                    "http://noaa-nwm-retro-v2-0-pds.s3.amazonaws.com/full_physics/2017/201704010000.CHRTOUT_DOMAIN1.comp",
+                    "https://noaa-nwm-retro-v2-0-pds.s3.amazonaws.com/full_physics/2017/201704010000.CHRTOUT_DOMAIN1.comp",
                     39783,
                     12,
                 ],
             },
         },
-        fs=fss,
+        fs={'https': fss},
         asynchronous=True,
     )
 

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -515,6 +515,9 @@ def test_cat_file_ranges(m):
 
 @pytest.mark.asyncio
 async def test_async_cat_file_ranges():
+    fss = fsspec.filesystem("http", asynchronous=True)
+    session = await fss.set_session()
+
     fs = fsspec.filesystem(
         "reference",
         fo={
@@ -527,12 +530,13 @@ async def test_async_cat_file_ranges():
                 ],
             },
         },
-        remote_protocol="http",
-        remote_options={"asynchronous": True},
+        fs=fss,
         asynchronous=True,
     )
 
+    
     assert await fs._cat_file("reference_time/0") == b'x^K0\xa9d\x04\x00\x03\x13\x01\x0f'
+    await session.close()
 
 
 @pytest.mark.parametrize(

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -534,7 +534,6 @@ async def test_async_cat_file_ranges():
         asynchronous=True,
     )
 
-    
     assert await fs._cat_file("reference_time/0") == b'x^K0\xa9d\x04\x00\x03\x13\x01\x0f'
     await session.close()
 

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -515,6 +515,7 @@ def test_cat_file_ranges(m):
 
 @pytest.mark.asyncio
 async def test_async_cat_file_ranges():
+    fsspec.get_filesystem_class("http").clear_instance_cache()
     fss = fsspec.filesystem("https", asynchronous=True)
     session = await fss.set_session()
 


### PR DESCRIPTION
Adds missing return in `_cat_file` method of `ReferenceFileSystem`

Im not sure how to best test this because i dont think any of the tests from test_reference use an async filesystem and s3 maybe shouldnt be tested here? 

Closes https://github.com/fsspec/filesystem_spec/issues/1735