### PR TITLE
Fix parsing s3 accesspoint url

### DIFF
--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -209,7 +209,13 @@ def test_infer_options():
     # - The bucket is included in path
     for protocol in ["s3", "s3a", "gcs", "gs"]:
         options = infer_storage_options(f"{protocol}://Bucket-name.com/test.csv")
+        assert options["host"] == "Bucket-name.com"
         assert options["path"] == "Bucket-name.com/test.csv"
+
+    for protocol in ["s3", "s3a"]:
+        options = infer_storage_options(f"{protocol}://arn:aws:s3:us-west-2:1234:accesspoint/abc/test.csv")
+        assert options["host"] == "arn:aws:s3:us-west-2:1234:accesspoint"
+        assert options["path"] == "arn:aws:s3:us-west-2:1234:accesspoint/abc/test.csv"
 
     with pytest.raises(KeyError):
         infer_storage_options("file:///bucket/file.csv", {"path": "collide"})

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -213,7 +213,9 @@ def test_infer_options():
         assert options["path"] == "Bucket-name.com/test.csv"
 
     for protocol in ["s3", "s3a"]:
-        options = infer_storage_options(f"{protocol}://arn:aws:s3:us-west-2:1234:accesspoint/abc/test.csv")
+        options = infer_storage_options(
+            f"{protocol}://arn:aws:s3:us-west-2:1234:accesspoint/abc/test.csv"
+        )
         assert options["host"] == "arn:aws:s3:us-west-2:1234:accesspoint"
         assert options["path"] == "arn:aws:s3:us-west-2:1234:accesspoint/abc/test.csv"
 


### PR DESCRIPTION
Parsing S3 access point URI, like s3://arn:aws:s3:us-west-2:1234:accesspoint/abc/123.jpg, causes problems in `infer_storage_options` for the `:accesspoint` was parsed as port number. This PR addresses that.