### PR TITLE
Add async wrapper for sync FS

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         PY:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -152,3 +152,37 @@ available as the attribute ``.loop``.
 
     <script data-goatcounter="https://fsspec.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+
+AsyncFileSystemWrapper
+----------------------
+
+The `AsyncFileSystemWrapper` class is an experimental feature that allows you to convert
+a synchronous filesystem into an asynchronous one. This is useful for quickly integrating
+synchronous filesystems into workflows that may expect `AsyncFileSystem` instances.
+
+Basic Usage
+~~~~~~~~~~~
+
+To use `AsyncFileSystemWrapper`, wrap any synchronous filesystem to work in an asynchronous context.
+In this example, the synchronous `LocalFileSystem` is wrapped, creating an `AsyncFileSystem` instance
+backed by the normal, synchronous methods of `LocalFileSystem`:
+
+.. code-block:: python
+
+    import asyncio
+    import fsspec
+    from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+
+    async def async_copy_file():
+        sync_fs = fsspec.filesystem('file')  # by-default synchronous, local filesystem
+        async_fs = AsyncFileSystemWrapper(sync_fs)
+        return await async_fs._copy('/source/file.txt', '/destination/file.txt')
+
+    asyncio.run(async_copy_file())
+
+Limitations
+-----------
+
+This is experimental. Users should not expect this wrapper to magically make things faster.
+It is primarily provided to allow usage of synchronous filesystems with interfaces that expect
+`AsyncFileSystem` instances.

--- a/fsspec/implementations/asyn_wrapper.py
+++ b/fsspec/implementations/asyn_wrapper.py
@@ -1,0 +1,80 @@
+import asyncio
+import functools
+from fsspec.asyn import AsyncFileSystem
+
+
+def async_wrapper(func, obj=None):
+    """
+    Wraps a synchronous function to make it awaitable.
+
+    Parameters
+    ----------
+    func : callable
+        The synchronous function to wrap.
+    obj : object, optional
+        The instance to bind the function to, if applicable.
+
+    Returns
+    -------
+    coroutine
+        An awaitable version of the function.
+    """
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        self = obj or args[0]
+        return await asyncio.to_thread(func, *args, **kwargs)
+    return wrapper
+
+
+class AsyncFileSystemWrapper(AsyncFileSystem):
+    """
+    A wrapper class to convert a synchronous filesystem into an asynchronous one.
+
+    This class takes an existing synchronous filesystem implementation and wraps all
+    its methods to provide an asynchronous interface.
+
+    Parameters
+    ----------
+    sync_fs : AbstractFileSystem
+        The synchronous filesystem instance to wrap.
+    """
+    def __init__(self, sync_fs, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fs = sync_fs
+        self._wrap_all_sync_methods()
+
+    def _wrap_all_sync_methods(self):
+        """
+        Wrap all synchronous methods of the underlying filesystem with asynchronous versions.
+        """
+        for method_name in dir(self.fs):
+            if method_name.startswith("_"):
+                continue
+            method = getattr(self.fs, method_name)
+            if callable(method) and not asyncio.iscoroutinefunction(method):
+                async_method = async_wrapper(method, obj=self)
+                setattr(self, f"_{method_name}", async_method)
+
+    @classmethod
+    def wrap_class(cls, sync_fs_class):
+        """
+        Create a new class that can be used to instantiate an AsyncFileSystemWrapper
+        with lazy instantiation of the underlying synchronous filesystem.
+
+        Parameters
+        ----------
+        sync_fs_class : type
+            The class of the synchronous filesystem to wrap.
+
+        Returns
+        -------
+        type
+            A new class that wraps the provided synchronous filesystem class.
+        """
+        class GeneratedAsyncFileSystemWrapper(cls):
+            def __init__(self, *args, **kwargs):
+                sync_fs = sync_fs_class(*args, **kwargs)
+                super().__init__(sync_fs)
+
+        GeneratedAsyncFileSystemWrapper.__name__ = f"Async{sync_fs_class.__name__}Wrapper"
+        return GeneratedAsyncFileSystemWrapper

--- a/fsspec/implementations/asyn_wrapper.py
+++ b/fsspec/implementations/asyn_wrapper.py
@@ -20,10 +20,11 @@ def async_wrapper(func, obj=None):
     coroutine
         An awaitable version of the function.
     """
+
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):
-        self = obj or args[0]
         return await asyncio.to_thread(func, *args, **kwargs)
+
     return wrapper
 
 
@@ -39,6 +40,7 @@ class AsyncFileSystemWrapper(AsyncFileSystem):
     sync_fs : AbstractFileSystem
         The synchronous filesystem instance to wrap.
     """
+
     def __init__(self, sync_fs, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.asynchronous = True
@@ -82,10 +84,13 @@ class AsyncFileSystemWrapper(AsyncFileSystem):
         type
             A new class that wraps the provided synchronous filesystem class.
         """
+
         class GeneratedAsyncFileSystemWrapper(cls):
             def __init__(self, *args, **kwargs):
                 sync_fs = sync_fs_class(*args, **kwargs)
                 super().__init__(sync_fs)
 
-        GeneratedAsyncFileSystemWrapper.__name__ = f"Async{sync_fs_class.__name__}Wrapper"
+        GeneratedAsyncFileSystemWrapper.__name__ = (
+            f"Async{sync_fs_class.__name__}Wrapper"
+        )
         return GeneratedAsyncFileSystemWrapper

--- a/fsspec/implementations/asyn_wrapper.py
+++ b/fsspec/implementations/asyn_wrapper.py
@@ -41,6 +41,7 @@ class AsyncFileSystemWrapper(AsyncFileSystem):
     """
     def __init__(self, sync_fs, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.asynchronous = True
         self.fs = sync_fs
         self._wrap_all_sync_methods()
 

--- a/fsspec/implementations/tests/test_asyn_wrapper.py
+++ b/fsspec/implementations/tests/test_asyn_wrapper.py
@@ -11,7 +11,7 @@ from .test_local import csv_files, filetexts
 def test_is_async():
     fs = fsspec.filesystem("file")
     async_fs = AsyncFileSystemWrapper(fs)
-    assert async_fs.async_impl == True
+    assert async_fs.async_impl
 
 
 def test_class_wrapper():
@@ -19,7 +19,7 @@ def test_class_wrapper():
     async_fs_cls = AsyncFileSystemWrapper.wrap_class(fs_cls)
     assert async_fs_cls.__name__ == "AsyncLocalFileSystemWrapper"
     async_fs = async_fs_cls()
-    assert async_fs.async_impl == True
+    assert async_fs.async_impl
 
 
 @pytest.mark.asyncio
@@ -27,11 +27,15 @@ async def test_cats():
     with filetexts(csv_files, mode="b"):
         fs = fsspec.filesystem("file")
         async_fs = AsyncFileSystemWrapper(fs)
-        
+
         result = await async_fs._cat(".test.fakedata.1.csv")
         assert result == b"a,b\n1,2\n"
 
-        out = set((await async_fs._cat([".test.fakedata.1.csv", ".test.fakedata.2.csv"])).values())
+        out = set(
+            (
+                await async_fs._cat([".test.fakedata.1.csv", ".test.fakedata.2.csv"])
+            ).values()
+        )
         assert out == {b"a,b\n1,2\n", b"a,b\n3,4\n"}
 
         result = await async_fs._cat(".test.fakedata.1.csv", None, None)
@@ -51,11 +55,14 @@ async def test_cats():
         assert result == b"a,b\n1,2\n"[1:-2]
 
         out = set(
-            (await async_fs._cat(
-                [".test.fakedata.1.csv", ".test.fakedata.2.csv"], start=1, end=-1
-            )).values()
+            (
+                await async_fs._cat(
+                    [".test.fakedata.1.csv", ".test.fakedata.2.csv"], start=1, end=-1
+                )
+            ).values()
         )
         assert out == {b"a,b\n1,2\n"[1:-1], b"a,b\n3,4\n"[1:-1]}
+
 
 @pytest.mark.asyncio
 async def test_basic_crud_operations():
@@ -76,6 +83,7 @@ async def test_basic_crud_operations():
         await async_fs._rm(".test.fakedata.1.csv")
         assert not await async_fs._exists(".test.fakedata.1.csv")
 
+
 @pytest.mark.asyncio
 async def test_error_handling():
     fs = fsspec.filesystem("file")
@@ -86,6 +94,7 @@ async def test_error_handling():
 
     with pytest.raises(FileNotFoundError):
         await async_fs._rm(".test.non_existent.csv")
+
 
 @pytest.mark.asyncio
 async def test_concurrent_operations():
@@ -99,10 +108,11 @@ async def test_concurrent_operations():
         results = await asyncio.gather(
             read_file(".test.fakedata.1.csv"),
             read_file(".test.fakedata.2.csv"),
-            read_file(".test.fakedata.1.csv")
+            read_file(".test.fakedata.1.csv"),
         )
 
         assert results == [b"a,b\n1,2\n", b"a,b\n3,4\n", b"a,b\n1,2\n"]
+
 
 @pytest.mark.asyncio
 async def test_directory_operations():
@@ -119,6 +129,7 @@ async def test_directory_operations():
         assert ".test.fakedata.1.csv" in filenames
         assert ".test.fakedata.2.csv" in filenames
         assert "new_directory" in filenames
+
 
 @pytest.mark.asyncio
 async def test_batch_operations():

--- a/fsspec/implementations/tests/test_asyn_wrapper.py
+++ b/fsspec/implementations/tests/test_asyn_wrapper.py
@@ -1,0 +1,131 @@
+import asyncio
+import pytest
+import os
+
+import fsspec
+from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+from fsspec.implementations.local import LocalFileSystem
+from .test_local import csv_files, filetexts
+
+
+def test_is_async():
+    fs = fsspec.filesystem("file")
+    async_fs = AsyncFileSystemWrapper(fs)
+    assert async_fs.async_impl == True
+
+
+def test_class_wrapper():
+    fs_cls = LocalFileSystem
+    async_fs_cls = AsyncFileSystemWrapper.wrap_class(fs_cls)
+    assert async_fs_cls.__name__ == "AsyncLocalFileSystemWrapper"
+    async_fs = async_fs_cls()
+    assert async_fs.async_impl == True
+
+
+@pytest.mark.asyncio
+async def test_cats():
+    with filetexts(csv_files, mode="b"):
+        fs = fsspec.filesystem("file")
+        async_fs = AsyncFileSystemWrapper(fs)
+        
+        result = await async_fs._cat(".test.fakedata.1.csv")
+        assert result == b"a,b\n1,2\n"
+
+        out = set((await async_fs._cat([".test.fakedata.1.csv", ".test.fakedata.2.csv"])).values())
+        assert out == {b"a,b\n1,2\n", b"a,b\n3,4\n"}
+
+        result = await async_fs._cat(".test.fakedata.1.csv", None, None)
+        assert result == b"a,b\n1,2\n"
+
+        result = await async_fs._cat(".test.fakedata.1.csv", start=1, end=6)
+        assert result == b"a,b\n1,2\n"[1:6]
+
+        result = await async_fs._cat(".test.fakedata.1.csv", start=-1)
+        assert result == b"a,b\n1,2\n"[-1:]
+
+        result = await async_fs._cat(".test.fakedata.1.csv", start=1, end=-2)
+        assert result == b"a,b\n1,2\n"[1:-2]
+
+        # test synchronous API is available as expected
+        result = async_fs.cat(".test.fakedata.1.csv", start=1, end=-2)
+        assert result == b"a,b\n1,2\n"[1:-2]
+
+        out = set(
+            (await async_fs._cat(
+                [".test.fakedata.1.csv", ".test.fakedata.2.csv"], start=1, end=-1
+            )).values()
+        )
+        assert out == {b"a,b\n1,2\n"[1:-1], b"a,b\n3,4\n"[1:-1]}
+
+@pytest.mark.asyncio
+async def test_basic_crud_operations():
+    with filetexts(csv_files, mode="b"):
+        fs = fsspec.filesystem("file")
+        async_fs = AsyncFileSystemWrapper(fs)
+
+        await async_fs._touch(".test.fakedata.3.csv")
+        assert await async_fs._exists(".test.fakedata.3.csv")
+
+        data = await async_fs._cat(".test.fakedata.1.csv")
+        assert data == b"a,b\n1,2\n"
+
+        await async_fs._pipe(".test.fakedata.1.csv", b"a,b\n5,6\n")
+        data = await async_fs._cat(".test.fakedata.1.csv")
+        assert data == b"a,b\n5,6\n"
+
+        await async_fs._rm(".test.fakedata.1.csv")
+        assert not await async_fs._exists(".test.fakedata.1.csv")
+
+@pytest.mark.asyncio
+async def test_error_handling():
+    fs = fsspec.filesystem("file")
+    async_fs = AsyncFileSystemWrapper(fs)
+
+    with pytest.raises(FileNotFoundError):
+        await async_fs._cat(".test.non_existent.csv")
+
+    with pytest.raises(FileNotFoundError):
+        await async_fs._rm(".test.non_existent.csv")
+
+@pytest.mark.asyncio
+async def test_concurrent_operations():
+    with filetexts(csv_files, mode="b"):
+        fs = fsspec.filesystem("file")
+        async_fs = AsyncFileSystemWrapper(fs)
+
+        async def read_file(file_path):
+            return await async_fs._cat(file_path)
+
+        results = await asyncio.gather(
+            read_file(".test.fakedata.1.csv"),
+            read_file(".test.fakedata.2.csv"),
+            read_file(".test.fakedata.1.csv")
+        )
+
+        assert results == [b"a,b\n1,2\n", b"a,b\n3,4\n", b"a,b\n1,2\n"]
+
+@pytest.mark.asyncio
+async def test_directory_operations():
+    with filetexts(csv_files, mode="b"):
+        fs = fsspec.filesystem("file")
+        async_fs = AsyncFileSystemWrapper(fs)
+
+        await async_fs._makedirs("new_directory")
+        assert await async_fs._isdir("new_directory")
+
+        files = await async_fs._ls(".")
+        filenames = [os.path.basename(file) for file in files]
+
+        assert ".test.fakedata.1.csv" in filenames
+        assert ".test.fakedata.2.csv" in filenames
+        assert "new_directory" in filenames
+
+@pytest.mark.asyncio
+async def test_batch_operations():
+    with filetexts(csv_files, mode="b"):
+        fs = fsspec.filesystem("file")
+        async_fs = AsyncFileSystemWrapper(fs)
+
+        await async_fs._rm([".test.fakedata.1.csv", ".test.fakedata.2.csv"])
+        assert not await async_fs._exists(".test.fakedata.1.csv")
+        assert not await async_fs._exists(".test.fakedata.2.csv")


### PR DESCRIPTION
This PR adds support for arbitrarily wrapping synchronous filesystems to make them compatible with interfaces which might expect `AsynchronousFileSystem` instances. Both instance and class-level wrapping behavior is provided and tested. This is a feature that will be of use downstream to enable kerchunk/zarr-python3 compatibility and is related to the efforts [here](https://github.com/fsspec/kerchunk/issues/514)

