### PR TITLE
Ensure reference FS wraps any sync filesystems

### DIFF
--- a/fsspec/implementations/asyn_wrapper.py
+++ b/fsspec/implementations/asyn_wrapper.py
@@ -46,6 +46,7 @@ class AsyncFileSystemWrapper(AsyncFileSystem):
         super().__init__(*args, **kwargs)
         self.asynchronous = True
         self.fs = sync_fs
+        self.protocol = self.fs.protocol
         self._wrap_all_sync_methods()
 
     @property

--- a/fsspec/implementations/asyn_wrapper.py
+++ b/fsspec/implementations/asyn_wrapper.py
@@ -45,27 +45,27 @@ class AsyncFileSystemWrapper(AsyncFileSystem):
     def __init__(self, sync_fs, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.asynchronous = True
-        self.fs = sync_fs
-        self.protocol = self.fs.protocol
+        self.sync_fs = sync_fs
+        self.protocol = self.sync_fs.protocol
         self._wrap_all_sync_methods()
 
     @property
     def fsid(self):
-        return f"async_{self.fs.fsid}"
+        return f"async_{self.sync_fs.fsid}"
 
     def _wrap_all_sync_methods(self):
         """
         Wrap all synchronous methods of the underlying filesystem with asynchronous versions.
         """
-        for method_name in dir(self.fs):
+        for method_name in dir(self.sync_fs):
             if method_name.startswith("_"):
                 continue
 
-            attr = inspect.getattr_static(self.fs, method_name)
+            attr = inspect.getattr_static(self.sync_fs, method_name)
             if isinstance(attr, property):
                 continue
 
-            method = getattr(self.fs, method_name)
+            method = getattr(self.sync_fs, method_name)
             if callable(method) and not asyncio.iscoroutinefunction(method):
                 async_method = async_wrapper(method, obj=self)
                 setattr(self, f"_{method_name}", async_method)

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -458,7 +458,8 @@ def test_fss_has_defaults(m):
     assert fs.fss["memory"].protocol == "memory"
 
     fs = fsspec.filesystem("reference", fs=m, fo={})
-    assert fs.fss[None] is m
+    # Default behavior here wraps synchronous filesystems to enable the async API
+    assert fs.fss[None].sync_fs is m
 
     fs = fsspec.filesystem("reference", fs={"memory": m}, fo={})
     assert fs.fss["memory"] is m


### PR DESCRIPTION
This PR guards against the possibility (and likelihood, as `LocalFileSystem` is the default value here) that non-async filesystems are used in `ReferenceFileSystem`. This is important, as `ReferenceFileSystem` is, itself, an `AsyncFileSystem` and it is currently failing to provide functional methods required by that interface (cf. https://github.com/fsspec/filesystem_spec/blob/master/fsspec/implementations/reference.py#L809)