### PR TITLE
x for abstract file

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1740,7 +1740,7 @@ class AbstractBufferedFile(io.IOBase):
 
         self.kwargs = kwargs
 
-        if mode not in {"ab", "rb", "wb"}:
+        if mode not in {"ab", "rb", "wb", "xb"}:
             raise NotImplementedError("File mode not supported")
         if mode == "rb":
             if size is not None:


### PR DESCRIPTION
Missed from #1749 , needed for downstream libs like s3fs