### PR TITLE
asyn_wrapper: avoid creating async version of open method

### DIFF
--- a/fsspec/implementations/asyn_wrapper.py
+++ b/fsspec/implementations/asyn_wrapper.py
@@ -57,8 +57,9 @@ class AsyncFileSystemWrapper(AsyncFileSystem):
         """
         Wrap all synchronous methods of the underlying filesystem with asynchronous versions.
         """
+        excluded_methods = {"open"}
         for method_name in dir(self.sync_fs):
-            if method_name.startswith("_"):
+            if method_name.startswith("_") or method_name in excluded_methods:
                 continue
 
             attr = inspect.getattr_static(self.sync_fs, method_name)


### PR DESCRIPTION
The `_open` method is part of an `AbstractFileSystem` interface, and is supposed to be synchronous.