### PR TITLE
Add newline inclusive disclaimer

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -2131,7 +2131,7 @@ class AbstractBufferedFile(io.IOBase):
         return b"".join(out)
 
     def readline(self):
-        """Read until first occurrence of newline character
+        """Read until and including the first occurrence of newline character
 
         Note that, because of character encoding, this is not necessarily a
         true line ending.
@@ -2148,7 +2148,7 @@ class AbstractBufferedFile(io.IOBase):
         return self
 
     def readlines(self):
-        """Return all data, split by the newline character"""
+        """Return all data, split by the newline character, including the newline character"""
         data = self.read()
         lines = data.split(b"\n")
         out = [l + b"\n" for l in lines[:-1]]


### PR DESCRIPTION
Hi, I got confused due to some ambiguity with the readline and readlines function.
I propose adding a disclaimer that the newline character is also included.

Some extra references about similar functions within Python

`splitlines` has the argument `keeplinebreaks` to make this choice for including or excluding newlines explicit. It defaults to removing the newline.
https://www.w3schools.com/python/ref_string_splitlines.asp

The documentation of `readlines` also doesn't state anything about including or excluding the newlines. It defaults to keeping the newline: similar to the fsspec implementation.
https://www.w3schools.com/python/ref_file_readlines.asp


