### PR TITLE
dirfs: Ensures consistency of details returned by the “ls” and “info” methods.

### DIFF
--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -231,10 +231,16 @@ class DirFileSystem(AsyncFileSystem):
         return self.fs.exists(self._join(path))
 
     async def _info(self, path, **kwargs):
-        return await self.fs._info(self._join(path), **kwargs)
+        info = await self.fs._info(self._join(path), **kwargs)
+        info = info.copy()
+        info["name"] = self._relpath(info["name"])
+        return info
 
     def info(self, path, **kwargs):
-        return self.fs.info(self._join(path), **kwargs)
+        info = self.fs.info(self._join(path), **kwargs)
+        info = info.copy()
+        info["name"] = self._relpath(info["name"])
+        return info
 
     async def _ls(self, path, detail=True, **kwargs):
         ret = (await self.fs._ls(self._join(path), detail=detail, **kwargs)).copy()

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -327,12 +327,14 @@ def test_exists(dirfs):
 
 @pytest.mark.asyncio
 async def test_async_info(adirfs):
-    assert await adirfs._info("file", **KWARGS) == adirfs.fs._info.return_value
+    adirfs.fs._info.return_value = {"name": f"{PATH}/file", "foo": "bar"}
+    assert await adirfs._info("file", **KWARGS) == {"name": "file", "foo": "bar"}
     adirfs.fs._info.assert_called_once_with(f"{PATH}/file", **KWARGS)
 
 
 def test_info(dirfs):
-    assert dirfs.info("file", **KWARGS) == dirfs.fs.info.return_value
+    dirfs.fs.info.return_value = {"name": f"{PATH}/file", "foo": "bar"}
+    assert dirfs.info("file", **KWARGS) == {"name": "file", "foo": "bar"}
     dirfs.fs.info.assert_called_once_with(f"{PATH}/file", **KWARGS)
 
 


### PR DESCRIPTION
Before this changes, the name field into the information returned by the 'info' method was an absolute path while the name for the same entry returned by the 'ls' method was a relative path. As a result, the name in the info of the 'info' method was unusable for api calls.