### PR TITLE
Add _pipe_file and test to http

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -543,7 +543,7 @@ class HTTPFileSystem(AsyncFileSystem):
 
         session = await self.get_session()
 
-        async with self.session.put(url, data=value, headers=headers, **kwargs) as r:
+        async with session.put(url, data=value, headers=headers, **kwargs) as r:
             r.raise_for_status()
 
 

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -525,7 +525,7 @@ class HTTPFileSystem(AsyncFileSystem):
     async def _pipe_file(self, path, value, mode="overwrite", **kwargs):
         """
         Write bytes to a remote file over HTTP.
-        
+
         Parameters
         ----------
         path : str
@@ -538,13 +538,14 @@ class HTTPFileSystem(AsyncFileSystem):
             Additional parameters to pass to the HTTP request
         """
         url = self._strip_protocol(path)
-        headers = kwargs.pop('headers', {})
-        headers['Content-Length'] = str(len(value))
-        
-        if not hasattr(self, 'session'):
+        headers = kwargs.pop("headers", {})
+        headers["Content-Length"] = str(len(value))
+
+        if not hasattr(self, "session"):
             import aiohttp
+
             self.session = aiohttp.ClientSession()
-            
+
         async with self.session.put(url, data=value, headers=headers, **kwargs) as r:
             r.raise_for_status()
         return True

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -541,10 +541,7 @@ class HTTPFileSystem(AsyncFileSystem):
         headers = kwargs.pop("headers", {})
         headers["Content-Length"] = str(len(value))
 
-        if not hasattr(self, "session"):
-            import aiohttp
-
-            self.session = aiohttp.ClientSession()
+        session = await self.get_session()
 
         async with self.session.put(url, data=value, headers=headers, **kwargs) as r:
             r.raise_for_status()

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -545,7 +545,6 @@ class HTTPFileSystem(AsyncFileSystem):
 
         async with self.session.put(url, data=value, headers=headers, **kwargs) as r:
             r.raise_for_status()
-        return True
 
 
 class HTTPFile(AbstractBufferedFile):

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -522,6 +522,33 @@ class HTTPFileSystem(AsyncFileSystem):
         except (FileNotFoundError, ValueError):
             return False
 
+    async def _pipe_file(self, path, value, mode="overwrite", **kwargs):
+        """
+        Write bytes to a remote file over HTTP.
+        
+        Parameters
+        ----------
+        path : str
+            Target URL where the data should be written
+        value : bytes
+            Data to be written
+        mode : str
+            How to write to the file - 'overwrite' or 'append'
+        **kwargs : dict
+            Additional parameters to pass to the HTTP request
+        """
+        url = self._strip_protocol(path)
+        headers = kwargs.pop('headers', {})
+        headers['Content-Length'] = str(len(value))
+        
+        if not hasattr(self, 'session'):
+            import aiohttp
+            self.session = aiohttp.ClientSession()
+            
+        async with self.session.put(url, data=value, headers=headers, **kwargs) as r:
+            r.raise_for_status()
+        return True
+
 
 class HTTPFile(AbstractBufferedFile):
     """

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -586,6 +586,7 @@ async def test_async_walk(server):
 def test_pipe_file(server, tmpdir, reset_files):
     """Test that the pipe_file method works correctly."""
     import io
+
     import fsspec
 
     # Create test data

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -587,31 +587,35 @@ def test_pipe_file(server, tmpdir, reset_files):
     """Test that the pipe_file method works correctly."""
     import io
     import fsspec
-    
+
     # Create test data
     test_content = b"This is test data to pipe to a file"
-    
+
     # Initialize filesystem
     fs = fsspec.filesystem("http", headers={"accept_put": "true"})
-    
+
     # Test that the file doesn't exist yet
     with pytest.raises(FileNotFoundError):
         fs.info(server.address + "/piped_file")
-    
+
     # Pipe data to the file
     fs.pipe_file(server.address + "/piped_file", test_content)
-    
+
     # Verify the file exists now
     assert fs.exists(server.address + "/piped_file")
-    
+
     # Verify content
     assert fs.cat(server.address + "/piped_file") == test_content
-    
+
     # Test with different modes and headers
-    fs.pipe_file(server.address + "/piped_file2", test_content, 
-                mode="overwrite", headers={"Content-Type": "text/plain"})
+    fs.pipe_file(
+        server.address + "/piped_file2",
+        test_content,
+        mode="overwrite",
+        headers={"Content-Type": "text/plain"},
+    )
     assert fs.cat(server.address + "/piped_file2") == test_content
-    
+
     # Test with byte-like object
     bytesio = io.BytesIO(b"BytesIO content")
     fs.pipe_file(server.address + "/piped_bytes", bytesio.getvalue())


### PR DESCRIPTION
This adds a `_pipe_file` implementation to `HTTPFileSystem`. This was necessary for write support of http filesystems for writing zarr image data in https://github.com/copick/copick-server.