### PR TITLE
fix(url_to_fs): mangle arg to avoid collision with kwargs

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -366,13 +366,13 @@ def _un_chain(path, kwargs):
     return out
 
 
-def url_to_fs(url, **kwargs):
+def url_to_fs(_url, **kwargs):
     """
     Turn fully-qualified and potentially chained URL into filesystem instance
 
     Parameters
     ----------
-    url : str
+    _url : str
         The fsspec-compatible URL
     **kwargs: dict
         Extra options that make sense to a particular storage connection, e.g.


### PR DESCRIPTION
Fixes https://github.com/iterative/dvc/issues/10700

[dvc_fs](https://dvc.org/doc/api-reference/dvcfilesystem) is using url as an fs config option. So, it now collides in the url_to_fs with the main argument.

We can do urlpath for consistency, like we do in get_fs_token_paths, but _url feels a bit safer for the future? Let me know if you have any preferences folks.