### PR TITLE
rework github _open() implementation to support LFS

### DIFF
--- a/fsspec/implementations/github.py
+++ b/fsspec/implementations/github.py
@@ -1,6 +1,6 @@
-import requests
+import base64
 
-import fsspec
+import requests
 
 from ..spec import AbstractFileSystem
 from ..utils import infer_storage_options
@@ -36,7 +36,7 @@ class GithubFileSystem(AbstractFileSystem):
     """
 
     url = "https://api.github.com/repos/{org}/{repo}/git/trees/{sha}"
-    rurl = "https://raw.githubusercontent.com/{org}/{repo}/{sha}/{path}"
+    content_url = "https://api.github.com/repos/{org}/{repo}/contents/{path}?ref={sha}"
     protocol = "github"
     timeout = (60, 60)  # connect, read timeouts
 
@@ -219,21 +219,35 @@ class GithubFileSystem(AbstractFileSystem):
     ):
         if mode != "rb":
             raise NotImplementedError
-        url = self.rurl.format(
+
+        # construct a url to hit the GitHub API's repo contents API
+        url = self.content_url.format(
             org=self.org, repo=self.repo, path=path, sha=sha or self.root
         )
+
+        # make a request to this API, and parse the response as JSON
         r = requests.get(url, timeout=self.timeout, **self.kw)
         if r.status_code == 404:
             raise FileNotFoundError(path)
         r.raise_for_status()
-        return MemoryFile(None, None, r.content)
+        content_json = r.json()
 
-    def cat(self, path, recursive=False, on_error="raise", **kwargs):
-        paths = self.expand_path(path, recursive=recursive)
-        urls = [
-            self.rurl.format(org=self.org, repo=self.repo, path=u, sha=self.root)
-            for u, sh in paths
-        ]
-        fs = fsspec.filesystem("http")
-        data = fs.cat(urls, on_error="return")
-        return {u: v for ((k, v), u) in zip(data.items(), urls)}
+        # if the response's content key is not empty, try to parse it as base64
+        if content_json["content"]:
+            content = base64.b64decode(content_json["content"])
+
+            # as long as the content does not start with the string
+            # "version https://git-lfs.github.com/"
+            # then it is probably not a git-lfs pointer and we can just return
+            # the content directly
+            if not content.startswith(b"version https://git-lfs.github.com/"):
+                return MemoryFile(None, None, content)
+
+        # we land here if the content was not present in the first response
+        # (regular file over 1MB or git-lfs tracked file)
+        # in this case, we get the content from the download_url
+        r = requests.get(content_json["download_url"], timeout=self.timeout, **self.kw)
+        if r.status_code == 404:
+            raise FileNotFoundError(path)
+        r.raise_for_status()
+        return MemoryFile(None, None, r.content)

--- a/fsspec/implementations/github.py
+++ b/fsspec/implementations/github.py
@@ -2,8 +2,10 @@ import base64
 
 import requests
 
+from ..asyn import get_loop, sync
 from ..spec import AbstractFileSystem
 from ..utils import infer_storage_options
+from .http import HTTPFile, HTTPFileSystem
 from .memory import MemoryFile
 
 # TODO: add GIST backend, would be very similar
@@ -63,6 +65,11 @@ class GithubFileSystem(AbstractFileSystem):
 
         self.root = sha
         self.ls("")
+
+        # prepare elements needed to return HTTPFile
+        self.http_fs = HTTPFileSystem(**kwargs)
+        self.loop = get_loop()
+        self.session = sync(self.loop, self.http_fs.set_session)
 
     @property
     def kw(self):
@@ -245,9 +252,16 @@ class GithubFileSystem(AbstractFileSystem):
 
         # we land here if the content was not present in the first response
         # (regular file over 1MB or git-lfs tracked file)
-        # in this case, we get the content from the download_url
-        r = requests.get(content_json["download_url"], timeout=self.timeout, **self.kw)
-        if r.status_code == 404:
-            raise FileNotFoundError(path)
-        r.raise_for_status()
-        return MemoryFile(None, None, r.content)
+        # in this case, we get return an HTTPFile object wrapping the
+        # download_url
+        return HTTPFile(
+            self.http_fs,
+            content_json["download_url"],
+            session=self.session,
+            block_size=block_size,
+            autocommit=autocommit,
+            cache_options=cache_options,
+            size=content_json["size"],
+            loop=self.loop,
+            **kwargs,
+        )

--- a/fsspec/implementations/github.py
+++ b/fsspec/implementations/github.py
@@ -255,7 +255,7 @@ class GithubFileSystem(AbstractFileSystem):
         # in this case, we get let the HTTPFileSystem handle the download
         if self.http_fs is None:
             raise ImportError(
-                "Please install fsspec[http] to acccess github files >1 MB "
+                "Please install fsspec[http] to access github files >1 MB "
                 "or git-lfs tracked files."
             )
         return self.http_fs.open(

--- a/fsspec/implementations/github.py
+++ b/fsspec/implementations/github.py
@@ -16,8 +16,10 @@ class GithubFileSystem(AbstractFileSystem):
     repository. You may specify a point in the repos history, by SHA, branch
     or tag (default is current master).
 
-    Given that code files tend to be small, and that github does not support
-    retrieving partial content, we always fetch whole files.
+    For files less than 1 MB in size, file content is returned directly in a
+    MemoryFile. For larger files, or for files tracked by git-lfs, file content
+    is returned as an HTTPFile wrapping the ``download_url`` provided by the
+    GitHub API.
 
     When using fsspec.open, allows URIs of the form:
 

--- a/fsspec/implementations/tests/test_github.py
+++ b/fsspec/implementations/tests/test_github.py
@@ -9,8 +9,14 @@ def test_github_open_small_file():
 
 def test_github_open_large_file():
     # test opening a large file >1 MB
-    with fsspec.open("github://mwaskom:seaborn-data@83bfba7/brain_networks.csv") as f:
-        assert f.readline().startswith(b"network,1,1,2,2")
+    # use block_size=0 to get a streaming interface to the file, ensuring that
+    # we fetch only the parts we need instead of downloading the full file all
+    # at once
+    with fsspec.open(
+        "github://mwaskom:seaborn-data@83bfba7/brain_networks.csv", block_size=0
+    ) as f:
+        # read only the first 20 bytes of the file
+        assert f.read(20).startswith(b"network,1,1,2,2,3,3,")
 
 
 def test_github_open_lfs_file():

--- a/fsspec/implementations/tests/test_github.py
+++ b/fsspec/implementations/tests/test_github.py
@@ -16,7 +16,7 @@ def test_github_open_large_file():
         "github://mwaskom:seaborn-data@83bfba7/brain_networks.csv", block_size=0
     ) as f:
         # read only the first 20 bytes of the file
-        assert f.read(20).startswith(b"network,1,1,2,2,3,3,")
+        assert f.read(20) == b"network,1,1,2,2,3,3,"
 
 
 def test_github_open_lfs_file():
@@ -25,7 +25,7 @@ def test_github_open_lfs_file():
         "github://cBioPortal:datahub@55cd360"
         "/public/acc_2019/data_gene_panel_matrix.txt",
     ) as f:
-        assert f.readline().startswith(b"SAMPLE_ID\tmutations")
+        assert f.read(19) == b"SAMPLE_ID\tmutations"
 
 
 def test_github_cat():

--- a/fsspec/implementations/tests/test_github.py
+++ b/fsspec/implementations/tests/test_github.py
@@ -24,6 +24,7 @@ def test_github_open_lfs_file():
     with fsspec.open(
         "github://cBioPortal:datahub@55cd360"
         "/public/acc_2019/data_gene_panel_matrix.txt",
+        block_size=0,
     ) as f:
         assert f.read(19) == b"SAMPLE_ID\tmutations"
 

--- a/fsspec/implementations/tests/test_github.py
+++ b/fsspec/implementations/tests/test_github.py
@@ -1,0 +1,41 @@
+import fsspec
+
+
+def test_github_open_small_file():
+    # test opening a small file <1 MB
+    with fsspec.open("github://mwaskom:seaborn-data@4e06bf0/penguins.csv") as f:
+        assert f.readline().startswith(b"species,island")
+
+
+def test_github_open_large_file():
+    # test opening a large file >1 MB
+    with fsspec.open("github://mwaskom:seaborn-data@83bfba7/brain_networks.csv") as f:
+        assert f.readline().startswith(b"network,1,1,2,2")
+
+
+def test_github_open_lfs_file():
+    # test opening a git-lfs tracked file
+    with fsspec.open(
+        "github://cBioPortal:datahub@55cd360"
+        "/public/acc_2019/data_gene_panel_matrix.txt",
+    ) as f:
+        assert f.readline().startswith(b"SAMPLE_ID\tmutations")
+
+
+def test_github_cat():
+    # test using cat to fetch the content of multiple files
+    fs = fsspec.filesystem("github", org="mwaskom", repo="seaborn-data")
+    paths = ["penguins.csv", "mpg.csv"]
+    cat_result = fs.cat(paths)
+    assert set(cat_result.keys()) == {"penguins.csv", "mpg.csv"}
+    assert cat_result["penguins.csv"].startswith(b"species,island")
+    assert cat_result["mpg.csv"].startswith(b"mpg,cylinders")
+
+
+def test_github_ls():
+    # test using ls to list the files in a resository
+    fs = fsspec.filesystem("github", org="mwaskom", repo="seaborn-data")
+    ls_result = set(fs.ls(""))
+    expected = {"brain_networks.csv", "mpg.csv", "penguins.csv", "README.md", "raw"}
+    # check if the result is a subset of the expected files
+    assert expected.issubset(ls_result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ full = [
 fuse = ["fusepy"]
 gcs = ["gcsfs"]
 git = ["pygit2"]
-github = ["requests"]
+github = ["fsspec[http]", "requests"]
 gs = ["gcsfs"]
 gui = ["panel"]
 hdfs = ["pyarrow >= 1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ full = [
 fuse = ["fusepy"]
 gcs = ["gcsfs"]
 git = ["pygit2"]
-github = ["fsspec[http]", "requests"]
+github = ["requests"]
 gs = ["gcsfs"]
 gui = ["panel"]
 hdfs = ["pyarrow >= 1"]


### PR DESCRIPTION
#1438 raised the question of whether it should be possible to read Git LFS files from GitHub via the github implementation.

This PR is an unsolicited proposal of one possible path forward to supporting Git LFS files hosted on GitHub via the github implementation. It reworks the way the github implementation accesses content from github repos, enabling Git LFS file support in the process.

Before this PR, the content of github files was always fetched using the `rurl` (the https://raw.githubusercontent.com/ URL). This URL works well for fetching normal files tracked by Git, but does not work for Git LFS files.

In this PR, the `_open()` function in the github implementation is reworked to instead use the GitHub API to fetch the content. This API endpoint is documented in the GitHub API docs [here](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content).

The way this API works is unfortunately more complicated than the `rurl`. For files <1MB in size, the file's contents will be base64 encoded and included in the JSON response under the `content` key. For files >1MB in size, the `content` key will have an empty string value, and the only way to get its content is to make an additional GET request to a specific URL provided under the `download_url` key of the JSON response.

The downsides of the new reworked implementation of `_open()` are
1. More logic is required - sometimes the content can be found in `content` and other times we need to use `download_url`
2. Two requests are needed for files >1MB in size (one to the content API and another to hit `download_url`)

The upside is that the `download_url` points to the actual file contents for files tracked by Git LFS. This means that the same github implementation will work for normal files (both smaller and larger than 1MB) and also for Git LFS files.

I would be happy to take feedback on whether or not these downsides are worth the improved support for LFS, or if this should be moved to a new, separate "github_lfs" implementation to avoid complicating the current github implementation.

In addition to reworking the `_open()` function, I also removed the implementation of `cat()`, which was also referencing `rurl`. I am not super familiar with why `cat()` was overridden in the github implementation. I believe that if we still want to use the http implementation of `cat()` here, then that should still be possible. Let me know if this would be required to move forward with this PR.

Finally, I've added a few basic tests to cover the added/modified functionality. These tests interact with the real GitHub API, so it may not be desirable to leave them in the test suite as-is - let me know what would be preferred here and I would be happy to adjust.