### PR TITLE
Project metadata: Increase minimum Python version to say >=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "File-system specification"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 maintainers = [{ name = "Martin Durant", email = "mdurant@anaconda.com" }]
 keywords = ["file"]
 classifiers = [
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Problem

This error started happening on Python 3.8 using the new release.

```python
 >   MultiFetcher = Callable[list[[int, int]], bytes]  # Maps [(start, end)] to bytes
E   TypeError: 'type' object is not subscriptable

.venv/lib/python3.8/site-packages/fsspec/caching.py:40: TypeError
```
-- https://github.com/crate/sqlalchemy-cratedb/actions/runs/14162832181/job/39698544286#step:6:556

## Details

- Supports GH-1816.
