### PR TITLE
add positional argument

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -155,6 +155,11 @@ class LocalFileSystem(AbstractFileSystem):
         return self.cp_file(path1, path2, **kwargs)
 
     def mv(self, path1, path2, recursive: bool = True, **kwargs):
+        """Move files/directories
+        
+        For the specific case of local, all ops on directories are recursive and
+        the recursive= kwarg is ignored.
+        """
         path1 = self._strip_protocol(path1)
         path2 = self._strip_protocol(path2)
         shutil.move(path1, path2)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -154,7 +154,7 @@ class LocalFileSystem(AbstractFileSystem):
     def put_file(self, path1, path2, callback=None, **kwargs):
         return self.cp_file(path1, path2, **kwargs)
 
-    def mv(self, path1, path2, **kwargs):
+    def mv(self, path1, path2, recursive: bool = True, **kwargs):
         path1 = self._strip_protocol(path1)
         path2 = self._strip_protocol(path2)
         shutil.move(path1, path2)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -156,7 +156,6 @@ class LocalFileSystem(AbstractFileSystem):
 
     def mv(self, path1, path2, recursive: bool = True, **kwargs):
         """Move files/directories
-        
         For the specific case of local, all ops on directories are recursive and
         the recursive= kwarg is ignored.
         """


### PR DESCRIPTION
# Fix compatibility issue with PyTorch Geometric

The current implementation of LocalFileSystem.mv() was causing "TypeError: takes 3 positional arguments but 4 were given" when called from PyTorch Geometric's fs.py. 

This PR explicitly adds the `recursive` parameter to the method signature, allowing it to be properly called with this parameter without causing positional argument errors.