### PR TITLE
Update dirfs.py: propagate transaction context to underlying filesystem

### DIFF
--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -12,6 +12,19 @@ class DirFileSystem(AsyncFileSystem):
 
     protocol = "dir"
 
+    # ----------------------------------------------------------------
+    # Transaction delegation: use the wrapped FS’s transaction
+    transaction_type = property(lambda self: self.fs.transaction_type)
+
+    @property
+    def transaction(self):
+        """
+        Delegate `with fs.transaction:` to the underlying filesystem
+        so that dir:// writes participate in the base FS’s transaction.
+        """
+        return self.fs.transaction
+    # ----------------------------------------------------------------    
+
     def __init__(
         self,
         path=None,


### PR DESCRIPTION
DirFileSystem now delegates its `transaction` and `transaction_type` to the wrapped filesystem, ensuring that `with fs.transaction:` on a `dir://` instance correctly toggles the underlying `file://` transaction. This restores atomic write semantics when using the directory wrapper.

Closes #1823