### PR TITLE
fix: keep same permissions when using transaction

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -417,6 +417,13 @@ class LocalFileOpener(io.IOBase):
         if self.autocommit:
             raise RuntimeError("Can only commit if not already set to autocommit")
         shutil.move(self.temp, self.path)
+        try:
+            # Get the current umask and set it temporarily to 0o666.
+            umask = os.umask(0o666)
+            os.umask(umask)
+            os.chmod(self.path, 0o666 & ~umask)
+        except RuntimeError:
+            pass
 
     def discard(self):
         if self.autocommit:

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -508,6 +508,19 @@ def test_commit_discard(tmpdir):
         assert not fs.exists(tmpdir + "/bfile")
 
 
+def test_same_permissions_with_and_without_transaction(tmpdir):
+    tmpdir = str(tmpdir)
+
+    with fsspec.open(tmpdir + "/afile", 'wb') as f:
+        f.write(b'data')
+
+    fs, urlpath = fsspec.core.url_to_fs(tmpdir + "/bfile")
+    with fs.transaction, fs.open(urlpath, 'wb') as f:
+        f.write(b'data')
+    
+    assert fs.info(tmpdir + "/afile")["mode"] == fs.info(tmpdir + "/bfile")["mode"]
+
+
 def test_make_path_posix():
     cwd = os.getcwd()
     if WIN:


### PR DESCRIPTION
Uses https://stackoverflow.com/a/44130549 to check the current umask, temporarily (one line) change it to 0o666, and apply the permission modification.

Fixes #1797 

I'm not sure if this is the right approach, but it passes the test on my machine.