### PR TITLE
bits

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -237,6 +237,7 @@ documentation carefully before using any particular package.
 - `p9fs`_ for 9P (Plan 9 Filesystem Protocol) servers
 - `PyAthena`_ for S3 access to Amazon Athena, with protocol "s3://" or "s3a://"
 - `PyDrive2`_ for Google Drive access
+- `fsspec-proxy`_ for "pyscript:" URLs via a proxy server
 - `s3fs`_ for Amazon S3 and other compatible stores, with protocol "s3://"
 - `sshfs`_ for access to SSH servers, with protocol "ssh://" or "sftp://"
 - `swiftspec`_ for OpenStack SWIFT, with protocol "swift://"
@@ -254,6 +255,7 @@ documentation carefully before using any particular package.
 .. _dropbox: https://github.com/fsspec/dropboxdrivefs
 .. _dvc: https://github.com/iterative/dvc
 .. _fsspec-encrypted: https://github.com/thevgergroup/fsspec-encrypted
+.. _fsspec-proxy: https://github.com/fsspec/fsspec-proxy
 .. _gcsfs: https://gcsfs.readthedocs.io/en/latest/
 .. _gdrive: https://github.com/fsspec/gdrivefs
 .. _git: https://github.com/iterative/scmrepo

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -1,5 +1,3 @@
-from importlib.metadata import entry_points
-
 from . import caching
 from ._version import __version__  # noqa: F401
 from .callbacks import Callback
@@ -38,6 +36,10 @@ __all__ = [
 
 
 def process_entries():
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:
+        return
     if entry_points is not None:
         try:
             eps = entry_points()

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -180,6 +180,10 @@ known_implementations = {
         "class": "ossfs.OSSFileSystem",
         "err": "Install ossfs to access Alibaba Object Storage System",
     },
+    "pyscript": {
+        "class": "pyscript_fsspec_client.client.PyscriptFileSystem",
+        "err": "Install requests (cpython) or run in pyscript",
+    },
     "reference": {"class": "fsspec.implementations.reference.ReferenceFileSystem"},
     "root": {
         "class": "fsspec_xrootd.XRootDFileSystem",

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -72,12 +72,12 @@ known_implementations = {
         "class": "fsspec.implementations.arrow.HadoopFileSystem",
         "err": "pyarrow and local java libraries required for HDFS",
     },
-    "async_wrapper": {
-        "class": "fsspec.asyn_wrapper.AsyncWrapperFileSystem",
-    },
     "asynclocal": {
         "class": "morefs.asyn_local.AsyncLocalFileSystem",
         "err": "Install 'morefs[asynclocalfs]' to use AsyncLocalFileSystem",
+    },
+    "asyncwrapper": {
+        "class": "fsspec.implementations.asyn_wrapper.AsyncFileSystemWrapper",
     },
     "az": {
         "class": "adlfs.AzureBlobFileSystem",


### PR DESCRIPTION
- make existence of entrypoints optional (for pyscript)
- rename to asyncwrapper for use with URL chaining
- add "pyscript:" known implementation