### PR TITLE
Add support for rm_file in GitHubFileSystem implementation

### DIFF
--- a/fsspec/implementations/tests/test_github.py
+++ b/fsspec/implementations/tests/test_github.py
@@ -60,4 +60,4 @@ def test_github_rm():
         "github", org="mwaskom", repo="seaborn-data", username="user", token="token"
     )
     with pytest.raises(FileNotFoundError):
-        fs.rm("/this-file-doesnt-exist")
+        fs.rm("/this-file-doesnt-exist", branch="master", message="Delete my file")

--- a/fsspec/implementations/tests/test_github.py
+++ b/fsspec/implementations/tests/test_github.py
@@ -1,4 +1,5 @@
 import fsspec
+import pytest
 
 
 def test_github_open_small_file():
@@ -46,3 +47,17 @@ def test_github_ls():
     expected = {"brain_networks.csv", "mpg.csv", "penguins.csv", "README.md", "raw"}
     # check if the result is a subset of the expected files
     assert expected.issubset(ls_result)
+
+
+def test_github_rm():
+    # trying to remove a file without passing authentication should raise ValueError
+    fs = fsspec.filesystem("github", org="mwaskom", repo="seaborn-data")
+    with pytest.raises(ValueError):
+        fs.rm("mpg.csv")
+
+    # trying to remove a file which doesn't exist should raise FineNotFoundError
+    fs = fsspec.filesystem(
+        "github", org="mwaskom", repo="seaborn-data", username="user", token="token"
+    )
+    with pytest.raises(FileNotFoundError):
+        fs.rm("/this-file-doesnt-exist")

--- a/fsspec/implementations/tests/test_github.py
+++ b/fsspec/implementations/tests/test_github.py
@@ -1,5 +1,6 @@
-import fsspec
 import pytest
+
+import fsspec
 
 
 def test_github_open_small_file():
@@ -60,4 +61,4 @@ def test_github_rm():
         "github", org="mwaskom", repo="seaborn-data", username="user", token="token"
     )
     with pytest.raises(FileNotFoundError):
-        fs.rm("/this-file-doesnt-exist", branch="master", message="Delete my file")
+        fs.rm("/this-file-doesnt-exist")


### PR DESCRIPTION
This PR adds support for the `rm_file` method in the `GitHubFileSystem` implementation of fsspec, enabling file deletion using the GitHub REST API.

The [GitHub API](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents) for managing file contents requires:

- A commit message for each action (add/update/delete), similar to editing files via the GitHub web interface.
- The SHA of the target file’s latest version when deleting or updating, to avoid race conditions.

This implementation adheres to those requirements, making rm_file work reliably for GitHub-backed filesystems.

Note: This PR focuses solely on file deletion. I plan to follow up with a separate PR to implement the remaining methods and functionality (e.g., adding file, updating file, etc.) for full `GitHubFileSystem` support.

Fixes https://github.com/fsspec/filesystem_spec/issues/1836