### PR TITLE
Expose connection errors in HTTPFileSystem._exists

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -319,14 +319,11 @@ class HTTPFileSystem(AsyncFileSystem):
     async def _exists(self, path, **kwargs):
         kw = self.kwargs.copy()
         kw.update(kwargs)
-        try:
-            logger.debug(path)
-            session = await self.set_session()
-            r = await session.get(self.encode_url(path), **kw)
-            async with r:
-                return r.status < 400
-        except aiohttp.ClientError:
-            return False
+        logger.debug(path)
+        session = await self.set_session()
+        r = await session.get(self.encode_url(path), **kw)
+        async with r:
+            return r.status < 400
 
     async def _isfile(self, path, **kwargs):
         return await self._exists(path, **kwargs)


### PR DESCRIPTION
I can't see why blanket-catching all types of network and client-side issues here would be a good thing to do here; the git history doesn't explain it, and `test_http` passes for me locally with this change. Encountering an error during `session.get` doesn't imply the file doesn't exist, so it generally seems wrong to return False here.

I'm running into this issue because I want to implement retrying if the connection drops or times out. With the current implementation, I can't distinguish whether the server actually doesn't have the file vs. the user's mobile data reception being terrible.