### PR TITLE
fix: missing support for `update_cond='never'` condition in fsspec.generic.rsync

### DIFF
--- a/fsspec/generic.py
+++ b/fsspec/generic.py
@@ -119,6 +119,8 @@ def rsync(
         if otherfile in otherfiles:
             if update_cond == "always":
                 allfiles[k] = otherfile
+            elif update_cond == "never":
+                allfiles.pop(k)
             elif update_cond == "different":
                 inf1 = source_field(v) if callable(source_field) else v[source_field]
                 v2 = otherfiles[otherfile]


### PR DESCRIPTION
The `update_cond='never'` was missing in the `if-else` block, this PR add support of that