### PR TITLE
Fix error message

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -768,7 +768,7 @@ class ReferenceFileSystem(AsyncFileSystem):
                 self.fss[k] = AsyncFileSystemWrapper(f, asynchronous=self.asynchronous)
             elif self.asynchronous ^ f.asynchronous:
                 raise ValueError(
-                    "Reference-FS's target filesystem must have same value"
+                    "Reference-FS's target filesystem must have same value "
                     "of asynchronous"
                 )
 


### PR DESCRIPTION
Currently this concatenates to `valueof` instead of `value of`.