### PR TITLE
Create an event loop if it doesn't exist

### DIFF
--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -443,7 +443,11 @@ def test_docstring():
 def test_async_other_thread(server):
     import threading
 
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:  # Python 3.14+ codepath
+        loop = asyncio.new_event_loop()
+
     th = threading.Thread(target=loop.run_forever)
 
     th.daemon = True


### PR DESCRIPTION
Python 3.14 has removed the implicit event loop creation. I was running the test suite in Fedora test environment (copr) and in the buildsystem, with varying results: sometimes the tests passed, more often they didn't. I think that if the tests are run in parallel, sometimes they reuse an event loop created for another test case. This ensures that if no event loop is present, a new one will be created.