### PR TITLE
Remove use of asyncio API deprecated in python 3.14

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -7,7 +7,6 @@ import numbers
 import os
 import re
 import threading
-from contextlib import contextmanager
 from glob import has_magic
 from typing import TYPE_CHECKING, Iterable
 

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -120,18 +120,6 @@ def sync_wrapper(func, obj=None):
     return wrapper
 
 
-@contextmanager
-def _selector_policy():
-    original_policy = asyncio.get_event_loop_policy()
-    try:
-        if os.name == "nt" and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
-        yield
-    finally:
-        asyncio.set_event_loop_policy(original_policy)
-
-
 def get_loop():
     """Create or return the default fsspec IO loop
 
@@ -142,8 +130,7 @@ def get_loop():
             # repeat the check just in case the loop got filled between the
             # previous two calls from another thread
             if loop[0] is None:
-                with _selector_policy():
-                    loop[0] = asyncio.new_event_loop()
+                loop[0] = asyncio.new_event_loop()
                 th = threading.Thread(target=loop[0].run_forever, name="fsspecIO")
                 th.daemon = True
                 th.start()

--- a/fsspec/implementations/asyn_wrapper.py
+++ b/fsspec/implementations/asyn_wrapper.py
@@ -82,7 +82,7 @@ class AsyncFileSystemWrapper(AsyncFileSystem):
                 continue
 
             method = getattr(self.sync_fs, method_name)
-            if callable(method) and not asyncio.iscoroutinefunction(method):
+            if callable(method) and not inspect.iscoroutinefunction(method):
                 async_method = async_wrapper(method, obj=self)
                 setattr(self, f"_{method_name}", async_method)
 

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -131,25 +131,6 @@ def test_run_coros_in_chunks(monkeypatch):
     assert sum(asyncio.run(main())) == 32  # override
 
 
-@pytest.mark.skipif(os.name != "nt", reason="only for windows")
-def test_windows_policy():
-    from asyncio.windows_events import SelectorEventLoop
-
-    loop = fsspec.asyn.get_loop()
-    policy = asyncio.get_event_loop_policy()
-
-    # Ensure that the created loop always uses selector policy
-    assert isinstance(loop, SelectorEventLoop)
-
-    # Ensure that the global policy is not changed and it is
-    # set to the default one. This is important since the
-    # get_loop() method will temporarily override the policy
-    # with the one which uses selectors on windows, so this
-    # check ensures that we are restoring the old policy back
-    # after our change.
-    assert isinstance(policy, asyncio.DefaultEventLoopPolicy)
-
-
 def test_running_async():
     assert not fsspec.asyn.running_async()
 

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import io
-import os
 import time
 
 import pytest


### PR DESCRIPTION
~At this moment this also adds python 3.14-dev testing.~ EDIT: This was removed

This remove the use of deprecated asyncio policies.

During local testing with python 3.14 another deprecation was found for `asyncio.iscoroutinefunction`:
https://docs.python.org/3.14/whatsnew/3.14.html#deprecated

This was replaced with `inspect.iscoroutinefunction`.

Fixes: https://github.com/fsspec/filesystem_spec/issues/1861