### PR TITLE
Use standard library compression.zstd on python >= 3.14

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -155,19 +155,26 @@ except ImportError:
     pass
 
 try:
-    import zstandard as zstd
+    # zstd in the standard library for python >= 3.14
+    from compression.zstd import ZstdFile
 
-    def zstandard_file(infile, mode="rb"):
-        if "r" in mode:
-            cctx = zstd.ZstdDecompressor()
-            return cctx.stream_reader(infile)
-        else:
-            cctx = zstd.ZstdCompressor(level=10)
-            return cctx.stream_writer(infile)
+    register_compression("zstd", ZstdFile, "zst")
 
-    register_compression("zstd", zstandard_file, "zst")
 except ImportError:
-    pass
+    try:
+        import zstandard as zstd
+
+        def zstandard_file(infile, mode="rb"):
+            if "r" in mode:
+                cctx = zstd.ZstdDecompressor()
+                return cctx.stream_reader(infile)
+            else:
+                cctx = zstd.ZstdCompressor(level=10)
+                return cctx.stream_writer(infile)
+
+        register_compression("zstd", zstandard_file, "zst")
+    except ImportError:
+        pass
 
 
 def available_compressions():

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -95,7 +95,11 @@ def test_zstd_compression(tmpdir):
     """Infer zstd compression for .zst files if zstandard is available."""
     tmp_path = pathlib.Path(str(tmpdir))
 
-    zstd = pytest.importorskip("zstandard")
+    try:
+        # zstd in the standard library for python >= 3.14
+        from compression import zstd
+    except ImportError:
+        zstd = pytest.importorskip("zstandard")
 
     tmp_path.mkdir(exist_ok=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ test_full = [
     'tqdm',
     'urllib3',
     'zarr',
-    'zstandard',
+    'zstandard; python_version < "3.14"',
 ]
 test_downstream = [
     "dask[dataframe,test]",


### PR DESCRIPTION
[PEP 748](https://peps.python.org/pep-0784/) adds zstandard compression to the standard library from version 3.14 (currently in beta). This PR changes the import behaviour for std to try compression.zstd first before trying to import zstandard. The test dependency on zstandard is restricted to python_version < '3.14'.