### PR TITLE
fix: add tos scheme to registry

### DIFF
--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -213,11 +213,11 @@ known_implementations = {
         "err": 'SFTPFileSystem requires "paramiko" to be installed',
     },
     "tar": {"class": "fsspec.implementations.tar.TarFileSystem"},
-    "tosfs": {
+    "tos": {
         "class": "tosfs.TosFileSystem",
         "err": "Install tosfs to access ByteDance volcano engine Tinder Object Storage",
     },
-    "tos": {
+    "tosfs": {
         "class": "tosfs.TosFileSystem",
         "err": "Install tosfs to access ByteDance volcano engine Tinder Object Storage",
     },

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -217,6 +217,10 @@ known_implementations = {
         "class": "tosfs.TosFileSystem",
         "err": "Install tosfs to access ByteDance volcano engine Tinder Object Storage",
     },
+    "tos": {
+        "class": "tosfs.TosFileSystem",
+        "err": "Install tosfs to access ByteDance volcano engine Tinder Object Storage",
+    },
     "wandb": {"class": "wandbfs.WandbFS", "err": "Install wandbfs to access wandb"},
     "webdav": {
         "class": "webdav4.fsspec.WebdavFileSystem",


### PR DESCRIPTION
The `tosfs` is a wrong scheme. The right scheme is `tos`