### PR TITLE
FIX: Use st_birthtime for 'created' field in LocalFileSystem.info()

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -109,11 +109,19 @@ class LocalFileSystem(AbstractFileSystem):
                 t = "file"
             else:
                 t = "other"
+
+        # Check for the 'st_birthtime' attribute, which is not always present.
+        if hasattr(out, 'st_birthtime'):
+            created_time = out.st_birthtime
+        else:
+            # Fallback to 'st_ctime' for systems without birth time support.
+            created_time = out.st_ctime
+
         result = {
             "name": path,
             "size": size,
             "type": t,
-            "created": out.st_ctime,
+            "created": created_time,
             "islink": link,
         }
         for field in ["mode", "uid", "gid", "mtime", "ino", "nlink"]:


### PR DESCRIPTION
**Problem:**

Currently, the `LocalFileSystem.info()` method returns `os.stat_result.st_ctime` (the inode change time) for the `'created'` field in its output dictionary. On modern Unix-like systems (including Linux with newer filesystems like ext4, and macOS) that support it, this is incorrect and can be misleading. These systems provide a more accurate `st_birthtime` attribute that reflects the true creation time of a file.

For example, modifying a file's permissions will update its `ctime`, making the file appear to have been "created" more recently than it actually was, which is counterintuitive and can cause issues for applications relying on accurate creation timestamps.

**Solution:**

This patch modifies the `LocalFileSystem.info()` method to provide a more accurate `'created'` timestamp while maintaining backward compatibility.

The new logic is as follows:

1. It checks if the `os.stat_result` object has the `st_birthtime` attribute.

2. If `st_birthtime` exists, its value is used for the `'created'` field.

3. If `st_birthtime` does not exist (on older filesystems or operating systems), the implementation gracefully falls back to using the existing `st_ctime` value.

This ensures that users on supported systems get the most accurate creation time possible without breaking compatibility for others.

**Benefits:**

* **Increased Accuracy:** Provides the true file creation time on modern Linux, macOS, and other systems that support `birthtime`.

* **Improved User Experience:** The `'created'` field now behaves as users would expect, aligning with the "Birth" time seen in tools like `stat`.

* **Backward Compatible:** The fallback to `ctime` ensures no functionality is lost on systems where `birthtime` is not available.