### PR TITLE
Fix HTTPFileSystem isdir downloads the whole file issue

### DIFF
--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -139,6 +139,11 @@ def test_glob_return_subfolders(server):
 
 
 def test_isdir(server):
+    h = fsspec.filesystem("http", headers={"give_mimetype": "true"})
+    assert h.isdir(server.address + "/index/")
+    assert not h.isdir(server.realfile)
+    assert not h.isdir(server.address + "doesnotevenexist")
+
     h = fsspec.filesystem("http")
     assert h.isdir(server.address + "/index/")
     assert not h.isdir(server.realfile)


### PR DESCRIPTION
Method _ls_real tries to download the whole r.text() of a link regardless of the type of HTML content. Prevent this download in all cases except when Content-Type header is not set, or it is set to text/html