### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling>=1.27.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -7,14 +7,14 @@ name = "fsspec"
 dynamic = ["version"]
 description = "File-system specification"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 maintainers = [{ name = "Martin Durant", email = "mdurant@anaconda.com" }]
 keywords = ["file"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Declare licenses using only these two fields, as per PEP 639:
* `license`:       SPDX license expression consisting of one or more license identifiers
* `license-files`: list of license file glob patterns

Supported by hatchling ≥ 1.27.0:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files