### PR TITLE
No need for `license-files` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dynamic = ["version"]
 description = "File-system specification"
 readme = "README.md"
 license = "BSD-3-Clause"
-license-files = ["LICENSE"]
 requires-python = ">=3.9"
 maintainers = [{ name = "Martin Durant", email = "mdurant@anaconda.com" }]
 keywords = ["file"]


### PR DESCRIPTION
The default glob is `LICEN[CS]E*` and covers `LICENSE`.

[**hatch/backend/src/hatchling/metadata/core.py**](https://github.com/pypa/hatch/blob/28f233c535508247ffa9a40dab82c1d1cb2b700b/backend/src/hatchling/metadata/core.py#L746)
Line 746 in https://github.com/pypa/hatch/commit/28f233c535508247ffa9a40dab82c1d1cb2b700b
```python
                globs = ['LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*']
```