### PR TITLE
fix: Ensure kwargs passed via `expand_path`

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -892,7 +892,7 @@ class AbstractFileSystem(metaclass=_Cached):
         dict of {path: contents} if there are multiple paths
         or the path has been otherwise expanded
         """
-        paths = self.expand_path(path, recursive=recursive)
+        paths = self.expand_path(path, recursive=recursive, **kwargs)
         if (
             len(paths) > 1
             or isinstance(path, list)
@@ -972,7 +972,9 @@ class AbstractFileSystem(metaclass=_Cached):
             )
 
             source_is_str = isinstance(rpath, str)
-            rpaths = self.expand_path(rpath, recursive=recursive, maxdepth=maxdepth)
+            rpaths = self.expand_path(
+                rpath, recursive=recursive, maxdepth=maxdepth, **kwargs
+            )
             if source_is_str and (not recursive or maxdepth is not None):
                 # Non-recursive glob does not copy directories
                 rpaths = [p for p in rpaths if not (trailing_sep(p) or self.isdir(p))]
@@ -1060,7 +1062,9 @@ class AbstractFileSystem(metaclass=_Cached):
             if source_is_str:
                 lpath = make_path_posix(lpath)
             fs = LocalFileSystem()
-            lpaths = fs.expand_path(lpath, recursive=recursive, maxdepth=maxdepth)
+            lpaths = fs.expand_path(
+                lpath, recursive=recursive, maxdepth=maxdepth, **kwargs
+            )
             if source_is_str and (not recursive or maxdepth is not None):
                 # Non-recursive glob does not copy directories
                 lpaths = [p for p in lpaths if not (trailing_sep(p) or fs.isdir(p))]
@@ -1131,7 +1135,9 @@ class AbstractFileSystem(metaclass=_Cached):
             from .implementations.local import trailing_sep
 
             source_is_str = isinstance(path1, str)
-            paths1 = self.expand_path(path1, recursive=recursive, maxdepth=maxdepth)
+            paths1 = self.expand_path(
+                path1, recursive=recursive, maxdepth=maxdepth, **kwargs
+            )
             if source_is_str and (not recursive or maxdepth is not None):
                 # Non-recursive glob does not copy directories
                 paths1 = [p for p in paths1 if not (trailing_sep(p) or self.isdir(p))]
@@ -1172,7 +1178,7 @@ class AbstractFileSystem(metaclass=_Cached):
             raise ValueError("maxdepth must be at least 1")
 
         if isinstance(path, (str, os.PathLike)):
-            out = self.expand_path([path], recursive, maxdepth)
+            out = self.expand_path([path], recursive, maxdepth, **kwargs)
         else:
             out = set()
             path = [self._strip_protocol(p) for p in path]

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -1403,19 +1403,6 @@ def test_get_wildcard_path_passthrough_kwargs_to_ls(tmpfs, tmpdir):
     assert len(dest.listdir()) == 2
 
 
-@pytest.mark.xfail(
-    reason=(
-        "`put` initialises its own LocalFileSystem inline, so custom `ls` "
-        "implementation is not called"
-    )
-)
-def test_put_wildcard_path_passthrough_kwargs_to_ls(tmpfs, tmpdir):
-    dest = tmpdir / "dest"
-    tmpfs.put(tmpdir / "*", str(dest), limit=2)
-
-    assert len(dest.listdir()) == 2
-
-
 def test_copy_wildcard_path_passthrough_kwargs_to_ls(tmpfs, tmpdir):
     dest = tmpdir / "dest"
     tmpfs.copy(tmpdir / "*", str(dest), limit=2)

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -1375,3 +1375,65 @@ def test_glob_posix_rules(path, expected, glob_fs):
     detailed_output = glob_fs.glob(path=f"mock://{path}", detail=True)
     for name, info in _clean_paths(detailed_output).items():
         assert info == glob_fs[name]
+
+
+class CustomLocalFS(LocalFileSystem):
+    def ls(self, *args, **kwargs):
+        files = super().ls(*args, **kwargs)
+        limit = kwargs.pop("limit", None)
+
+        return files[:limit] if limit else files
+
+
+def test_cat_wildcard_path_passthrough_kwargs_to_ls(tmpdir):
+    test_fs = CustomLocalFS()
+    get_files(tmpdir)
+
+    file_contents = test_fs.cat(tmpdir / "*", limit=2)
+
+    assert len(file_contents) == 2
+
+
+def test_get_wildcard_path_passthrough_kwargs_to_ls(tmpdir):
+    test_fs = CustomLocalFS(auto_mkdir=True)
+    dest = tmpdir / "dest"
+    get_files(tmpdir)
+
+    test_fs.get(tmpdir / "*", str(dest), limit=2)
+
+    assert len(dest.listdir()) == 2
+
+
+@pytest.mark.xfail(
+    reason=(
+        "`put` initialises its own LocalFileSystem inline, so custom `ls` "
+        "implementation is not called"
+    )
+)
+def test_put_wildcard_path_passthrough_kwargs_to_ls(tmpdir):
+    test_fs = CustomLocalFS(auto_mkdir=True)
+    dest = tmpdir / "dest"
+    get_files(tmpdir)
+
+    test_fs.put(tmpdir / "*", str(dest), limit=2)
+
+    assert len(dest.listdir()) == 2
+
+
+def test_copy_wildcard_path_passthrough_kwargs_to_ls(tmpdir):
+    test_fs = CustomLocalFS(auto_mkdir=True)
+    dest = tmpdir / "dest"
+    get_files(tmpdir)
+
+    test_fs.copy(tmpdir / "*", str(dest), limit=2)
+
+    assert len(dest.listdir()) == 2
+
+
+def test_expand_path_wildcard_path_passthrough_kwargs_to_ls(tmpdir):
+    test_fs = CustomLocalFS()
+    get_files(tmpdir)
+
+    expanded_paths = test_fs.expand_path(tmpdir / "*", limit=2)
+
+    assert len(expanded_paths) == 2


### PR DESCRIPTION
Pass through kwargs to `expand_path` calls where possible to ensure they are propagated to `ls` implementation by default. 