### PR TITLE
Use list form of `fs.put()` in LocalTempFile to avoid `isdir()` checks

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -984,7 +984,9 @@ class LocalTempFile:
         os.remove(self.fn)
 
     def commit(self):
-        self.fs.put(self.fn, self.path, **self.kwargs)
+        # calling put() with list arguments avoids path expansion and additional operations
+        # like isdir()
+        self.fs.put([self.fn], [self.path], **self.kwargs)
         # we do not delete the local copy, it's still in the cache.
 
     @property

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -1342,3 +1342,19 @@ def test_filecache_write(tmpdir, m):
 def test_cache_protocol_is_preserved():
     fs = fsspec.filesystem("filecache", target_protocol="file")
     assert fs.protocol == "filecache"
+
+
+@pytest.mark.parametrize("protocol", ["simplecache", "filecache"])
+def test_local_temp_file_put_by_list2(protocol, mocker, tmp_path) -> None:
+    fs = fsspec.filesystem(protocol, target_protocol="memory")
+
+    spy_put = mocker.spy(fs.fs, "put")
+    spy_isdir = mocker.spy(fs.fs, "isdir")
+
+    with fs.open("memory://some/file.txt", mode="wb") as file:
+        file.write(b"hello")
+
+    # passed by list
+    spy_put.assert_called_once_with([file.name], ["/some/file.txt"])
+    # which avoids isdir() check
+    spy_isdir.assert_not_called()

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -289,4 +289,4 @@ def test_cache_kwargs(mocker):
     # We don't care about the first parameter, just retrieve its expected value.
     # It is a random location that cannot be predicted.
     # The important thing is the 'overwrite' kwarg
-    fs.fs.put.assert_called_with(fs.fs.put.call_args[0][0], "/test", overwrite=True)
+    fs.fs.put.assert_called_with(fs.fs.put.call_args[0][0], ["/test"], overwrite=True)


### PR DESCRIPTION
Calling put with lists like `put([a], [b])` avoids the expensive path expansion in AbstractFileSystem/AsyncFileSystem https://github.com/fsspec/filesystem_spec/blob/7aa982abdbf358001beab3059c5f761f02a48a04/fsspec/spec.py#L1049-L1051

In particular this avoids [calling `isdir()`](https://github.com/fsspec/filesystem_spec/blob/7aa982abdbf358001beab3059c5f761f02a48a04/fsspec/spec.py#L1070) which can be really expensive in object stores like `gcsfs`. Concretely it saves 3 GET requests in each commit through a simplecache chained to gcsfs. See https://github.com/fsspec/gcsfs/issues/702 for additional context.