### PR TITLE
Fix lazy reference handling for .parquet/.parq files

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -22,7 +22,11 @@ from fsspec.asyn import AsyncFileSystem
 from fsspec.callbacks import DEFAULT_CALLBACK
 from fsspec.core import filesystem, open, split_protocol
 from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
-from fsspec.utils import get_file_extension, isfilelike, merge_offset_ranges, other_paths
+from fsspec.utils import (
+    isfilelike,
+    merge_offset_ranges,
+    other_paths,
+)
 
 logger = logging.getLogger("fsspec.reference")
 
@@ -698,7 +702,9 @@ class ReferenceFileSystem(AsyncFileSystem):
                 **(ref_storage_args or target_options or {}), protocol=target_protocol
             )
             ref_fs, fo2 = fsspec.core.url_to_fs(fo, **dic)
-            if get_file_extension(fo2) in {"parq", "parquet"}:
+            if ".json" not in fo2 and (
+                fo.endswith(("parq", "parquet", "/")) or ref_fs.isdir(fo2)
+            ):
                 # Lazy parquet refs
                 logger.info("Open lazy reference dict from URL %s", fo)
                 self.references = LazyReferenceMapper(

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -338,6 +338,7 @@ def test_get_protocol(par):
     url, outcome = par
     assert get_protocol(url) == outcome
 
+
 @pytest.mark.parametrize(
     ["url", "expected"],
     (
@@ -347,12 +348,13 @@ def test_get_protocol(par):
         ("file:///home/user/no_extension", ""),
         ("/local/path/to/file.json", "json"),
         ("relative/path/file.yaml", "yaml"),
-    )
+    ),
 )
 def test_get_file_extension(url, expected):
     actual = get_file_extension(url)
 
     assert actual == expected
+
 
 @pytest.mark.parametrize(
     "par",

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -437,9 +437,10 @@ def get_protocol(url: str) -> str:
         return parts[0]
     return "file"
 
+
 def get_file_extension(url: str) -> str:
     url = stringify_path(url)
-    ext_parts = url.rsplit(".", 1) 
+    ext_parts = url.rsplit(".", 1)
     if len(ext_parts) > 1:
         return ext_parts[-1]
     return ""


### PR DESCRIPTION
fix: only treat .parquet/.parq files as lazy reference dicts

- Add utility get_file_extension() to extract extension from URL/path  
- Update condition to `ref_fs.isfile(fo2) and ext in {"parq","parquet"}`  
- Prevent misinterpretation of parquet ref files as JSON  
- Add unit tests 

- closes #1919 