### PR TITLE
Make WebHDFS ls() method compatible with superclass by supporting **kwargs

### DIFF
--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -268,7 +268,7 @@ class WebHDFS(AbstractFileSystem):
         info["name"] = path
         return self._process_info(info)
 
-    def ls(self, path, detail=False):
+    def ls(self, path, detail=False, **kwargs):
         out = self._call("LISTSTATUS", path=path)
         infos = out.json()["FileStatuses"]["FileStatus"]
         for info in infos:


### PR DESCRIPTION
The current WebHDFS.ls() implementation does not accept additional parameters, which breaks compatibility with newer versions of JupyterFS (e.g., jupyterfs==1.1.0).

Since we abstract filesystem interfaces, all common methods (such as ls, info, etc.) should accept **kwargs to ensure forward compatibility with upstream fsspec and JupyterFS expectations.

For example, JupyterFS 1.1.0 calls fs.ls(..., refresh=True) internally, which raises:

TypeError: WebHDFS.ls() got an unexpected keyword argument 'refresh'

Reference:
https://github.com/jpmorganchase/jupyter-fs/blob/6fac72f9a047871de48b757c5634317f88b5ac77/jupyterfs/manager/fsspec.py#L188

Proposed fix:
- Match the signature of the base class, which accepts **kwargs.
- ~~Update WebHDFS.ls() signature to accept **kwargs as it implemented for other filesystems (e.g. local)~~