### PR TITLE
Mark dir, async wrapper fs as chained

### DIFF
--- a/fsspec/implementations/asyn_wrapper.py
+++ b/fsspec/implementations/asyn_wrapper.py
@@ -5,6 +5,8 @@ import inspect
 import fsspec
 from fsspec.asyn import AsyncFileSystem, running_async
 
+from .chained import ChainedFileSystem
+
 
 def async_wrapper(func, obj=None, semaphore=None):
     """
@@ -35,7 +37,7 @@ def async_wrapper(func, obj=None, semaphore=None):
     return wrapper
 
 
-class AsyncFileSystemWrapper(AsyncFileSystem):
+class AsyncFileSystemWrapper(AsyncFileSystem, ChainedFileSystem):
     """
     A wrapper class to convert a synchronous filesystem into an asynchronous one.
 

--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -1,8 +1,9 @@
 from .. import filesystem
 from ..asyn import AsyncFileSystem
+from .chained import ChainedFileSystem
 
 
-class DirFileSystem(AsyncFileSystem):
+class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
     """Directory prefix filesystem
 
     The DirFileSystem is a filesystem-wrapper. It assumes every path it is dealing with

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -72,6 +72,9 @@ known_implementations = {
         "class": "fsspec.implementations.arrow.HadoopFileSystem",
         "err": "pyarrow and local java libraries required for HDFS",
     },
+    "async_wrapper": {
+        "class": "fsspec.implementations.asyn_wrapper.AsyncFileSystemWrapper",
+    },
     "asynclocal": {
         "class": "morefs.asyn_local.AsyncLocalFileSystem",
         "err": "Install 'morefs[asynclocalfs]' to use AsyncLocalFileSystem",


### PR DESCRIPTION
- `async_wrapper` was missing from known implementations and wrongly detected by regex logic in core
- dirfs and async_wrapper marked as chained, chaining detection logic updated to pass in `bit` if its being used (in which case you need to pass args in via open)

I am validating largely by testing https://github.com/1kbgz/fsspec-union/blob/544723c93bc6d72071494c040d0c28edda5ee088/fsspec_union/tests/conftest.py#L10
which uses (abuses?) chaining to construct a read-through cache, and https://github.com/1kbgz/fsspec-python/blob/216dee3f3b95cd944910acca8b98626d4795ca9a/fsspec_python/tests/conftest.py#L63 which uses chaining to mount the fs as an import path. 

