### PR TITLE
Fix Jupyter return error instead of raise

### DIFF
--- a/fsspec/implementations/jupyter.py
+++ b/fsspec/implementations/jupyter.py
@@ -42,7 +42,7 @@ class JupyterFileSystem(fsspec.AbstractFileSystem):
         path = self._strip_protocol(path)
         r = self.session.get(f"{self.url}/{path}")
         if r.status_code == 404:
-            return FileNotFoundError(path)
+            raise FileNotFoundError(path)
         r.raise_for_status()
         out = r.json()
 
@@ -63,7 +63,7 @@ class JupyterFileSystem(fsspec.AbstractFileSystem):
         path = self._strip_protocol(path)
         r = self.session.get(f"{self.url}/{path}")
         if r.status_code == 404:
-            return FileNotFoundError(path)
+            raise FileNotFoundError(path)
         r.raise_for_status()
         out = r.json()
         if out["format"] == "text":

--- a/fsspec/implementations/tests/test_jupyter.py
+++ b/fsspec/implementations/tests/test_jupyter.py
@@ -42,6 +42,11 @@ def test_simple(jupyter):
     fs = fsspec.filesystem("jupyter", url=url)
     assert fs.ls("") == []
 
+    with pytest.raises(FileNotFoundError):
+        fs.ls("not-exist")
+    with pytest.raises(FileNotFoundError):
+        fs.cat("not-exist")
+
     fs.pipe("afile", b"data")
     assert fs.cat("afile") == b"data"
     assert "afile" in os.listdir(d)


### PR DESCRIPTION
Currently, the `JupyterFileSystem` returns the error object instead of raising it, which can cause problems.