### PR TITLE
Directly move Jupyter file

### DIFF
--- a/fsspec/implementations/jupyter.py
+++ b/fsspec/implementations/jupyter.py
@@ -98,6 +98,11 @@ class JupyterFileSystem(fsspec.AbstractFileSystem):
         }
         self.session.put(f"{self.url}/{path}", json=json)
 
+    def mv(self, path1, path2, recursive=False, maxdepth=None, **kwargs):
+        if path1 == path2:
+            return
+        self.session.patch(f"{self.url}/{path1}", json={"path": path2})
+
     def _rm(self, path):
         path = self._strip_protocol(path)
         self.session.delete(f"{self.url}/{path}")

--- a/fsspec/implementations/tests/test_jupyter.py
+++ b/fsspec/implementations/tests/test_jupyter.py
@@ -55,3 +55,7 @@ def test_simple(jupyter):
     fs.rm("afile")
 
     assert "afile" not in os.listdir(d)
+
+    fs.mv("bfile", "cfile")
+    assert "cfile" in os.listdir(d)
+    assert "bfile" not in os.listdir(d)


### PR DESCRIPTION
Jupyter has an API to move files directly, instead of the default implementation which does copy and delete.