### PR TITLE
SFTPFile methods that override the AbstractFilesystem methods now strip protocol from path

### DIFF
--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -174,6 +174,7 @@ class SFTPFileSystem(AbstractFileSystem):
 
     def mv(self, old, new):
         new = self._strip_protocol(new)
+        old = self._strip_protocol(old)
         logger.debug("Renaming %s into %s", old, new)
         self.ftp.posix_rename(old, new)
 


### PR DESCRIPTION
Closes https://github.com/fsspec/filesystem_spec/issues/1938