### PR TITLE
Avoid warning with ruff 0.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,8 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.14.3
     hooks:
-      # Run the linter.
       - id: ruff-check
         args: [ --fix, "--show-fixes"]
       - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,8 +220,6 @@ ignore = [
     "SIM115",
     "SIM117",
     "TC003",
-    # https://github.com/astral-sh/ruff/issues/7871
-    "UP038",
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "W191",
     "E111",


### PR DESCRIPTION
```
warning: The following rules have been removed and ignoring them has no effect:
    - UP038
```