### PR TITLE
feat: Allow specifying SSL/TLS protocol version for FTP-TLS connections.

### DIFF
--- a/fsspec/implementations/tests/ftp_tlsv12.py
+++ b/fsspec/implementations/tests/ftp_tlsv12.py
@@ -1,0 +1,43 @@
+import os
+import ssl
+
+from pyftpdlib.authorizers import DummyAuthorizer
+from pyftpdlib.handlers import FTPHandler
+from pyftpdlib.servers import FTPServer
+
+
+def ftp():
+    """Script to run FTP server that accepts TLS v1.2 implicitly"""
+    # Set up FTP server parameters
+    FTP_HOST = "localhost"
+    FTP_PORT = 2122
+    FTP_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+
+    # Instantiate a dummy authorizer
+    authorizer = DummyAuthorizer()
+    authorizer.add_user(
+        "user",
+        "pass",
+        FTP_DIRECTORY,
+        "elradfmwMT",
+    )
+    authorizer.add_anonymous(FTP_DIRECTORY)
+
+    # Instantiate FTPHandler for implicit TLS
+    handler = FTPHandler
+    handler.authorizer = authorizer
+
+    # Instantiate FTP server
+    server = FTPServer((FTP_HOST, FTP_PORT), handler)
+
+    # Wrap socket for implicit TLS
+    certfile = os.path.join(os.path.dirname(__file__), "keycert.pem")
+    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+    context.load_cert_chain(certfile)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    ftp()


### PR DESCRIPTION
This change introduces support for implicit FTPS connections in the FTPFileSystem. Previously, only explicit FTPS was supported.

A new parameter security tls has been added to the FTPFileSystem constructor. This parameter allows users to specify the SSL/TLS protocol to be used for implicit FTPS connections,
such as TLSv1.2.

Key changes:
- Introduced ImplicitFTPTLS class to handle automatic SSL wrapping for implicit FTPS.
- Added security tls parameter to FTPFileSystem to allow selection of SSL/TLS protocols (e.g., "tlsv1_2").
- Updated the connection logic to differentiate between explicit and implicit FTPS based on the security tls parameter.

This enhancement provides greater flexibility and compatibility for connecting to various FTP servers requiring implicit FTPS with specific security protocols.