### PR TITLE
Use backport.zstd instead of zstandard

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -1,5 +1,6 @@
 """Helper functions for a standard streaming compression API"""
 
+import sys
 from zipfile import ZipFile
 
 import fsspec.utils
@@ -155,26 +156,14 @@ except ImportError:
     pass
 
 try:
-    # zstd in the standard library for python >= 3.14
-    from compression.zstd import ZstdFile
+    if sys.version_info >= (3, 14):
+        from compression import zstd
+    else:
+        from backports import zstd
 
-    register_compression("zstd", ZstdFile, "zst")
-
+    register_compression("zstd", zstd.ZstdFile, "zst")
 except ImportError:
-    try:
-        import zstandard as zstd
-
-        def zstandard_file(infile, mode="rb"):
-            if "r" in mode:
-                cctx = zstd.ZstdDecompressor()
-                return cctx.stream_reader(infile)
-            else:
-                cctx = zstd.ZstdCompressor(level=10)
-                return cctx.stream_writer(infile)
-
-        register_compression("zstd", zstandard_file, "zst")
-    except ImportError:
-        pass
+    pass
 
 
 def available_compressions():

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -1,4 +1,5 @@
 import pathlib
+import sys
 
 import pytest
 
@@ -95,11 +96,10 @@ def test_zstd_compression(tmpdir):
     """Infer zstd compression for .zst files if zstandard is available."""
     tmp_path = pathlib.Path(str(tmpdir))
 
-    try:
-        # zstd in the standard library for python >= 3.14
+    if sys.version_info >= (3, 14):
         from compression import zstd
-    except ImportError:
-        zstd = pytest.importorskip("zstandard")
+    else:
+        zstd = pytest.importorskip("backports.zstd")
 
     tmp_path.mkdir(exist_ok=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ test_full = [
     'tqdm',
     'urllib3',
     'zarr',
-    'zstandard; python_version < "3.14"',
+    'backports.zstd; python_version < "3.14"',
 ]
 test_downstream = [
     "dask[dataframe,test]",


### PR DESCRIPTION
For Python versions before 3.14, the Zstandard support is currently provided by the `zstandard` library (#1874). The API of `zstandard` is different from the one in the standard library ([`compression.zstd`](https://docs.python.org/3.14/library/compression.zstd.html)), which results in needing to implement an equivalent to `ZstdFile`.

This PR removes the `zstdandard` dependency in favor of the [backport of `compression.zstd`](https://github.com/Rogdham/backports.zstd).

I am conditioning the import based on the Python version instead of catching `ImportError` so that it will be picked up by linting tools (e.g. `ruff`) when you stop supporting 3.13. I also find it more readable.

_Side note: if you are interested, the backport also provides support for Zstandard in `tarfile` and `zipfile` modules (just like Python 3.14+ does). This could help with issues such as #1589._

_Full disclosure: I'm the author and maintainer of `backports.zstd`, and the maintainer of `pyzstd` (which code was used as a base for the integration into Python). I also helped with PEP-784 and its integration into CPython._