### PR TITLE
Use official action to publish package in CI

### DIFF
--- a/.github/workflows/pypipublish.yaml
+++ b/.github/workflows/pypipublish.yaml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -17,10 +17,34 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install hatch twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      - name: Build
         run: |
           hatch build
-          twine upload dist/*
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: packages
+          path: dist/
+          if-no-files-found: error
+          compression-level: 0
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fsspec
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: packages
+          path: dist/
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true
+          verbose: true


### PR DESCRIPTION
This enables trusted publishing (with attestations). Workflow was split into build and deploy jobs (to minimise privileged token access).

Tasks a maintainer needs to do:

* Configure a [GitHub environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) called `pypi`
* Configure a [trusted PyPI publisher](https://docs.pypi.org/trusted-publishers/) for this GitHub repository and environment
* (Optional) remove `PYPI_PASSWORD` GitHub project secret
* (Optional) once this pull request is accepted, make a pre-release (eg `2025.12.1rc0`) to test the configuration

Resolves #1866