### PR TITLE
Async subinterpreters experiment

### DIFF
--- a/fsspec/async_interps.py
+++ b/fsspec/async_interps.py
@@ -1,0 +1,54 @@
+import asyncio
+import concurrent.interpreters
+from collections.abc import Callable
+from typing import Any
+
+
+async def one():
+    # test function
+    print("one")
+    return 1
+
+
+class SubinterpreterAsyncWorker:
+    def __init__(
+        self, qin: concurrent.interpreters.Queue, qout: concurrent.interpreters.Queue
+    ):
+        self.qin = qin
+        self.qout = qout
+        self.loop = None
+        try:
+            # creates in-thread-interpreter loop
+            asyncio.run(self.wait())
+        finally:
+            self.loop.close()
+            qout.put(None)
+
+    async def wait(self):
+        self.loop = asyncio.get_running_loop()
+        # simulate run_forever and allow debug/liveness
+        while True:
+            batch = self.qin.get()
+            if batch is None:
+                # poison
+                break
+            assert isinstance(batch, list)
+            self.qout.put(await self.run_batch(batch))
+
+    async def run_batch(self, batch: list[tuple[Callable, Any]]) -> list:
+        return await asyncio.gather(
+            *[_[0](*_[1:]) for _ in batch], return_exceptions=True
+        )
+
+
+def run_worker(qin, qout):
+    SubinterpreterAsyncWorker(qin, qout)
+    return True
+
+
+def spawn():
+    inter = concurrent.interpreters.create()
+    qin = concurrent.interpreters.create_queue()
+    qout = concurrent.interpreters.create_queue()
+    inter.call_in_thread(run_worker, qin, qout)
+    return qin, qout

--- a/fsspec/generic.py
+++ b/fsspec/generic.py
@@ -374,6 +374,7 @@ async def copy_file_op(
         for o in out:
             if isinstance(o, Exception):
                 raise o
+        return out
 
 
 async def _copy_file_op(fs1, url1, fs2, url2, local, on_error="ignore"):


### PR DESCRIPTION
Since "subinterpreters" is now mainline as concurrent.interpreter in py3.14 (and reachable since 3.12, apparently), we can have true parallelism notwithstanding the GIL - especially since memoryview objects are uniquely zero-cost to transfer.

This PR will experiment with a new way to run batches of coroutines in async loops running in one subinterpreter in one thread each. This could increase throughput by something like 4x for the extremely high-bandwith case, where stream decoding (decrypt and decompress) makes IO CPU-bound.