### PR TITLE
Recover the support of the zstandard

### DIFF
--- a/fsspec/compression.py
+++ b/fsspec/compression.py
@@ -163,6 +163,20 @@ try:
 
     register_compression("zstd", zstd.ZstdFile, "zst")
 except ImportError:
+    try:
+        import zstandard as zstd
+
+        def zstandard_file(infile, mode="rb"):
+            if "r" in mode:
+                cctx = zstd.ZstdDecompressor()
+                return cctx.stream_reader(infile)
+            else:
+                cctx = zstd.ZstdCompressor(level=10)
+                return cctx.stream_writer(infile)
+
+        register_compression("zstd", zstandard_file, "zst")
+    except ImportError:
+        pass
     pass
 
 

--- a/fsspec/tests/test_compression.py
+++ b/fsspec/tests/test_compression.py
@@ -96,10 +96,13 @@ def test_zstd_compression(tmpdir):
     """Infer zstd compression for .zst files if zstandard is available."""
     tmp_path = pathlib.Path(str(tmpdir))
 
-    if sys.version_info >= (3, 14):
-        from compression import zstd
-    else:
-        zstd = pytest.importorskip("backports.zstd")
+    try:
+        if sys.version_info >= (3, 14):
+            from compression import zstd
+        else:
+            zstd = pytest.importorskip("backports.zstd")
+    except ImportError:
+        zstd = pytest.importorskip("zstandard")
 
     tmp_path.mkdir(exist_ok=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ test_full = [
     'urllib3',
     'zarr',
     'backports.zstd; python_version < "3.14"',
+    'zstandard; python_version < "3.14"',
 ]
 test_downstream = [
     "dask[dataframe,test]",
@@ -135,7 +136,7 @@ Homepage = "https://github.com/fsspec/filesystem_spec"
 
 [tool.hatch.version]
 source = "vcs"
-raw-options = {'version_scheme'='post-release'}
+raw-options = { 'version_scheme' = 'post-release' }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "fsspec/_version.py"
@@ -186,14 +187,14 @@ select = [
     "UP",
 ]
 ignore = [
-	# Loop control variable `loop` not used within loop body
-	"B007",
-	# Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-	"B019",
-	# Star-arg unpacking after a keyword argument is strongly discouraged
-	"B026",
-	# No explicit `stacklevel` keyword argument found
-	"B028",
+    # Loop control variable `loop` not used within loop body
+    "B007",
+    # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
+    "B019",
+    # Star-arg unpacking after a keyword argument is strongly discouraged
+    "B026",
+    # No explicit `stacklevel` keyword argument found
+    "B028",
     # `zip` without explicit `strict` keyword
     "B905",
     # Assigning lambda expression


### PR DESCRIPTION
Fixes #1986, try to support not only `backport.zstd`  but also `zstandard`.