### PR TITLE
Fix `_cat_file` / `_cat_ranges` not discoverable on `WholeFileCacheFileSystem` class

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -474,9 +474,12 @@ class CachingFileSystem(ChainedFileSystem):
         }:
             # all the methods defined in this class. Note `open` here, since
             # it calls `_open`, but is actually in superclass
-            return lambda *args, **kw: getattr(type(self), item).__get__(self)(
-                *args, **kw
-            )
+            if hasattr(type(self), item):
+                return lambda *args, **kw: getattr(type(self), item).__get__(self)(
+                    *args, **kw
+                )
+            # method is in the whitelist but not defined on this subclass;
+            # fall through to delegate to the wrapped filesystem below
         if item in ["__reduce_ex__"]:
             raise AttributeError
         if item in ["transaction"]:
@@ -744,6 +747,46 @@ class WholeFileCacheFileSystem(CachingFileSystem):
         }
         return LocalTempFile(self, path, mode=mode, fn=fn, **user_specified_kwargs)
 
+    async def _cat_file(self, path, start=None, end=None, **kwargs):
+        logger.debug("async cat_file %s", path)
+        path = self._strip_protocol(path)
+        sha = self._mapper(path)
+        fn = self._check_file(path)
+
+        if not fn:
+            fn = os.path.join(self.storage[-1], sha)
+            await self.fs._get_file(path, fn, **kwargs)
+
+        with open(fn, "rb") as f:  # noqa ASYNC230
+            if start:
+                f.seek(start)
+            size = -1 if end is None else end - f.tell()
+            return f.read(size)
+
+    async def _cat_ranges(
+        self, paths, starts, ends, max_gap=None, on_error="return", **kwargs
+    ):
+        logger.debug("async cat ranges %s", paths)
+        lpaths = []
+        rset = set()
+        download = []
+        rpaths = []
+        for p in paths:
+            fn = self._check_file(p)
+            if fn is None and p not in rset:
+                sha = self._mapper(p)
+                fn = os.path.join(self.storage[-1], sha)
+                download.append(fn)
+                rset.add(p)
+                rpaths.append(p)
+            lpaths.append(fn)
+        if download:
+            await self.fs._get(rpaths, download, on_error=on_error)
+
+        return LocalFileSystem().cat_ranges(
+            lpaths, starts, ends, max_gap=max_gap, on_error=on_error, **kwargs
+        )
+
 
 class SimpleCacheFileSystem(WholeFileCacheFileSystem):
     """Caches whole remote files on first access
@@ -847,46 +890,6 @@ class SimpleCacheFileSystem(WholeFileCacheFileSystem):
                 self.pipe_file(self._strip_protocol(k), v, **kwargs)
         else:
             raise ValueError("path must be str or dict")
-
-    async def _cat_file(self, path, start=None, end=None, **kwargs):
-        logger.debug("async cat_file %s", path)
-        path = self._strip_protocol(path)
-        sha = self._mapper(path)
-        fn = self._check_file(path)
-
-        if not fn:
-            fn = os.path.join(self.storage[-1], sha)
-            await self.fs._get_file(path, fn, **kwargs)
-
-        with open(fn, "rb") as f:  # noqa ASYNC230
-            if start:
-                f.seek(start)
-            size = -1 if end is None else end - f.tell()
-            return f.read(size)
-
-    async def _cat_ranges(
-        self, paths, starts, ends, max_gap=None, on_error="return", **kwargs
-    ):
-        logger.debug("async cat ranges %s", paths)
-        lpaths = []
-        rset = set()
-        download = []
-        rpaths = []
-        for p in paths:
-            fn = self._check_file(p)
-            if fn is None and p not in rset:
-                sha = self._mapper(p)
-                fn = os.path.join(self.storage[-1], sha)
-                download.append(fn)
-                rset.add(p)
-                rpaths.append(p)
-            lpaths.append(fn)
-        if download:
-            await self.fs._get(rpaths, download, on_error=on_error)
-
-        return LocalFileSystem().cat_ranges(
-            lpaths, starts, ends, max_gap=max_gap, on_error=on_error, **kwargs
-        )
 
     def cat_ranges(
         self, paths, starts, ends, max_gap=None, on_error="return", **kwargs

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -1440,3 +1440,21 @@ def test_simplecache_instance_cache(instance_caches):
         "file": 1,
         "http": 1,
     }
+
+
+@pytest.mark.parametrize(
+    "protocol", ["filecache", "simplecache"]
+)
+def test_class_has_cat_file_and_cat_ranges(tmp_path, protocol):
+    """Ensure _cat_file and _cat_ranges are available on the class, not just
+    instances, so that external code inspecting ``type(fs)`` (e.g.
+    universal_pathlib, zarr) can discover these capabilities.
+
+    Regression test for https://github.com/fsspec/filesystem_spec/issues/2009
+    """
+    fs = fsspec.filesystem(
+        protocol, target_protocol="memory", cache_storage=str(tmp_path)
+    )
+    for attr in ("_cat_file", "_cat_ranges"):
+        assert hasattr(fs, attr), f"instance missing {attr}"
+        assert hasattr(type(fs), attr), f"class missing {attr}"

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -1442,9 +1442,7 @@ def test_simplecache_instance_cache(instance_caches):
     }
 
 
-@pytest.mark.parametrize(
-    "protocol", ["filecache", "simplecache"]
-)
+@pytest.mark.parametrize("protocol", ["filecache", "simplecache"])
 def test_class_has_cat_file_and_cat_ranges(tmp_path, protocol):
     """Ensure _cat_file and _cat_ranges are available on the class, not just
     instances, so that external code inspecting ``type(fs)`` (e.g.


### PR DESCRIPTION
Fixes #2009

## Problem

`hasattr(type(fs), '_cat_file')` returns `False` for `WholeFileCacheFileSystem`, even though `hasattr(fs, '_cat_file')` returns `True`. This is because `CachingFileSystem.__getattribute__` intercepts attribute access at the instance level, but the method is never defined on the class itself.

Libraries like `universal_pathlib` and `zarr` inspect capabilities via `type(fs)` rather than the instance, which leads to `AttributeError`.

## Fix

Two changes:

1. **Move `_cat_file` and `_cat_ranges` from `SimpleCacheFileSystem` up to `WholeFileCacheFileSystem`.** Both classes use the same whole-file caching logic (check cache, download if missing, read locally). `SimpleCacheFileSystem` inherits them unchanged.

2. **Guard the whitelist in `__getattribute__`:** the whitelist is shared across the hierarchy, but some entries only exist on certain subclasses. When a whitelisted method is not on `type(self)`, we now fall through to the wrapped filesystem delegation instead of returning a lambda that would raise `AttributeError`.

## Note to maintainers

If this instance-only delegation is intentional by design, or if you'd prefer a different approach, happy to hear your guidance. We can adjust or close this accordingly.