### PR TITLE
Fix closing contexts of tar and zip files and add test 3.14t in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linux:
-    name: ${{ matrix.PY }}-pytest
+    name: ${{ matrix.PY }}${{ matrix.FREETHREADING && 't' || '' }}-pytest
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -19,6 +19,11 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+        FREETHREADING:
+          - false
+        include:
+          - PY: "3.14"
+            FREETHREADING: true
 
     env:
       CIRUN: true
@@ -28,6 +33,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Patch env file to use freethreaded Python
+        if: fromJSON(matrix.FREETHREADING)
+        run: echo "  - python-freethreading" >> ci/environment-linux.yml
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/fsspec/implementations/tar.py
+++ b/fsspec/implementations/tar.py
@@ -122,3 +122,14 @@ class TarFileSystem(AbstractArchiveFileSystem):
         if details["type"] != "file":
             raise ValueError("Can only handle regular files")
         return self.tar.extractfile(path)
+
+    def close(self):
+        """Commits any write changes to the file. Done on ``del`` too."""
+        self.tar.close()
+
+    def __del__(self):
+        if hasattr(self, "tar"):
+            self.close()
+            del self.tar
+        if hasattr(self, "of") and hasattr(self.of, "__exit__"):
+            self.of.__exit__(None, None, None)

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -78,6 +78,8 @@ class ZipFileSystem(AbstractArchiveFileSystem):
         if hasattr(self, "zip"):
             self.close()
             del self.zip
+        if hasattr(self, "of") and hasattr(self.of, "__exit__"):
+            self.of.__exit__(None, None, None)
 
     def close(self):
         """Commits any write changes to the file. Done on ``del`` too."""


### PR DESCRIPTION
I ran into an issue while testing Uproot with Python 3.14t in this PR https://github.com/scikit-hep/uproot5/pull/1619. Since garbage collection on freethreaded mode is a bit looser, it doesn't end up immediately closing contexts when an object is dropped, and you end up with warnings like `ResourceWarning: unclosed file ...`. To solve this, we can explicitly call `__exit__` in `__del__`. I also added `close()` to the tar implementation, since it was missing.