### PR TITLE
Updating `adl` error message

### DIFF
--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -67,8 +67,9 @@ known_implementations = {
     "adl": {
         "class": "adlfs.AzureDatalakeFileSystem",
         "err": (
-            "ADLS Gen1 is no longer supported. Please install adlfs and use the "
-            "`az` protocol for Azure Datalake Gen2 and Azure Blob Storage."
+            "Azure Data Lake Storage Gen1 is retired and no longer supported. Please "
+            "install adlfs and use the `az://` protocol to access Azure Blob Storage "
+            "and Azure Data Lake Storage Gen2 instead."
         ),
     },
     "arrow_hdfs": {

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -66,7 +66,10 @@ known_implementations = {
     },
     "adl": {
         "class": "adlfs.AzureDatalakeFileSystem",
-        "err": "Install adlfs to access Azure Datalake Gen1",
+        "err": (
+            "ADLS Gen1 is no longer supported. Please install adlfs and use the "
+            "`az` protocol for Azure Datalake Gen2 and Azure Blob Storage."
+        ),
     },
     "arrow_hdfs": {
         "class": "fsspec.implementations.arrow.HadoopFileSystem",


### PR DESCRIPTION
We are removing support for ADLS Gen1 in this [PR](https://github.com/fsspec/adlfs/pull/545), so users will no longer be able to use the `AzureDatalakeFileSystem` class. This PR is for updating the `adl://` protocol error message to instruct users to use the `az://` protocol for Azure Blob Storage and Azure Data Lake Storage Gen2.