### PR TITLE
Delegate DirFileSystem delete and write_text

### DIFF
--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -97,6 +97,11 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
     def rm(self, path, *args, **kwargs):
         return self.fs.rm(self._join(path), *args, **kwargs)
 
+    def delete(self, path, recursive=False, maxdepth=None):
+        return self.fs.delete(
+            self._join(path), recursive=recursive, maxdepth=maxdepth
+        )
+
     async def _cp_file(self, path1, path2, **kwargs):
         return await self.fs._cp_file(self._join(path1), self._join(path2), **kwargs)
 
@@ -136,6 +141,16 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
 
     def pipe_file(self, path, *args, **kwargs):
         return self.fs.pipe_file(self._join(path), *args, **kwargs)
+
+    def write_text(self, path, value, encoding=None, errors=None, newline=None, **kwargs):
+        return self.fs.write_text(
+            self._join(path),
+            value,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+            **kwargs,
+        )
 
     async def _cat_file(self, path, *args, **kwargs):
         return await self.fs._cat_file(self._join(path), *args, **kwargs)

--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -98,9 +98,7 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
         return self.fs.rm(self._join(path), *args, **kwargs)
 
     def delete(self, path, recursive=False, maxdepth=None):
-        return self.fs.delete(
-            self._join(path), recursive=recursive, maxdepth=maxdepth
-        )
+        return self.fs.delete(self._join(path), recursive=recursive, maxdepth=maxdepth)
 
     async def _cp_file(self, path1, path2, **kwargs):
         return await self.fs._cp_file(self._join(path1), self._join(path2), **kwargs)
@@ -142,7 +140,9 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
     def pipe_file(self, path, *args, **kwargs):
         return self.fs.pipe_file(self._join(path), *args, **kwargs)
 
-    def write_text(self, path, value, encoding=None, errors=None, newline=None, **kwargs):
+    def write_text(
+        self, path, value, encoding=None, errors=None, newline=None, **kwargs
+    ):
         return self.fs.write_text(
             self._join(path),
             value,

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -141,6 +141,13 @@ def test_rm(dirfs):
     dirfs.fs.rm.assert_called_once_with("path/to/dir/file", *ARGS, **KWARGS)
 
 
+def test_delete(dirfs):
+    dirfs.delete("file", recursive=True, maxdepth=2)
+    dirfs.fs.delete.assert_called_once_with(
+        "path/to/dir/file", recursive=True, maxdepth=2
+    )
+
+
 @pytest.mark.asyncio
 async def test_async_cp_file(adirfs):
     await adirfs._cp_file("one", "two", **KWARGS)
@@ -190,6 +197,13 @@ async def test_async_pipe_file(adirfs):
 def test_pipe_file(dirfs):
     dirfs.pipe_file("file", *ARGS, **KWARGS)
     dirfs.fs.pipe_file.assert_called_once_with(f"{PATH}/file", *ARGS, **KWARGS)
+
+
+def test_write_text(dirfs):
+    dirfs.write_text("file", "value", encoding="utf-8", newline="\n")
+    dirfs.fs.write_text.assert_called_once_with(
+        "path/to/dir/file", "value", encoding="utf-8", errors=None, newline="\n"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- delegate `DirFileSystem.delete()` to the wrapped filesystem instead of inheriting the base alias path
- delegate `DirFileSystem.write_text()` so wrapper filesystems can enforce their own write behavior
- add focused regression tests for both methods

Closes #1997.

## Validation
- E1 baseline repro exists: yes
  - The issue's reproduction on baseline allowed both `fs.write_text('bar', 'lorem ipsum')` and `fs.delete('bar')` to succeed instead of raising from the wrapped filesystem.
- E2 new regression tests fail on baseline: yes
  - In a temporary `HEAD` worktree with only the new tests applied:
  - `.venv/bin/python -m pytest fsspec/implementations/tests/test_dirfs.py -k 'delete or write_text' -q`
  - Result: `4 failed, 134 deselected`
- E3 regression tests pass after fix: yes
  - `.venv/bin/python -m pytest fsspec/implementations/tests/test_dirfs.py -q`
  - Result: `138 passed`
- E4 direct issue repro matches expected behavior after fix: yes
  - The issue script now raises `NotImplementedError` for both `write_text` and `delete`, proving delegation reaches the wrapped filesystem.
- E5 diff stays localized: yes
  - Changes are limited to `fsspec/implementations/dirfs.py` and `fsspec/implementations/tests/test_dirfs.py`.
