### PR TITLE
fix: use encode_url() in _pipe_file for consistency

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -560,7 +560,9 @@ class HTTPFileSystem(AsyncFileSystem):
 
         session = await self.set_session()
 
-        async with session.put(self.encode_url(url), data=value, headers=headers, **kwargs) as r:
+        async with session.put(
+            self.encode_url(url), data=value, headers=headers, **kwargs
+        ) as r:
             r.raise_for_status()
 
 

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -560,7 +560,7 @@ class HTTPFileSystem(AsyncFileSystem):
 
         session = await self.set_session()
 
-        async with session.put(url, data=value, headers=headers, **kwargs) as r:
+        async with session.put(self.encode_url(url), data=value, headers=headers, **kwargs) as r:
             r.raise_for_status()
 
 


### PR DESCRIPTION
`_pipe_file` passes the raw URL string directly to `session.put()`, while every
other HTTP method in `HTTPFileSystem` first normalises the URL through
`encode_url()`