### PR TITLE
docs: add URL handling note to HTTPFileSystem class docstring

### DIFF
--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -41,9 +41,10 @@ class HTTPFileSystem(AsyncFileSystem):
     match on the result. If simple_link=True, anything of the form
     "http(s)://server.com/stuff?thing=other"; otherwise only links within
     HTML href tags will be used.
+
     URLs are passed unfiltered to aiohttp, so all addresses are accessible. Where URLs are
-    supplied by a user, the calling application may with to filter to prevent scanning.
-    """
+    supplied by a user, the calling application may wish to filter to prevent scanning.
+   """
 
     protocol = ("http", "https")
     sep = "/"

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -41,6 +41,21 @@ class HTTPFileSystem(AsyncFileSystem):
     match on the result. If simple_link=True, anything of the form
     "http(s)://server.com/stuff?thing=other"; otherwise only links within
     HTML href tags will be used.
+
+    Note on URL handling
+    --------------------
+    Like any HTTP client library, this class passes URLs directly to the
+    underlying ``aiohttp`` session without filtering or restricting the
+    target host. URLs pointing to loopback addresses (``127.x.x.x``),
+    link-local addresses (``169.254.x.x``, used by cloud Instance Metadata
+    Services), or private network ranges (RFC 1918) are therefore
+    reachable, which is intentional for use cases such as accessing
+    internal S3-compatible storage or local development servers.
+
+    Applications that construct URLs from user-supplied input are
+    responsible for validating those URLs before passing them to
+    ``HTTPFileSystem``. Failing to do so may expose the application to
+    Server-Side Request Forgery (SSRF).
     """
 
     protocol = ("http", "https")

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -41,21 +41,8 @@ class HTTPFileSystem(AsyncFileSystem):
     match on the result. If simple_link=True, anything of the form
     "http(s)://server.com/stuff?thing=other"; otherwise only links within
     HTML href tags will be used.
-
-    Note on URL handling
-    --------------------
-    Like any HTTP client library, this class passes URLs directly to the
-    underlying ``aiohttp`` session without filtering or restricting the
-    target host. URLs pointing to loopback addresses (``127.x.x.x``),
-    link-local addresses (``169.254.x.x``, used by cloud Instance Metadata
-    Services), or private network ranges (RFC 1918) are therefore
-    reachable, which is intentional for use cases such as accessing
-    internal S3-compatible storage or local development servers.
-
-    Applications that construct URLs from user-supplied input are
-    responsible for validating those URLs before passing them to
-    ``HTTPFileSystem``. Failing to do so may expose the application to
-    Server-Side Request Forgery (SSRF).
+    URLs are passed unfiltered to aiohttp, so all addresses are accessible. Where URLs are
+    supplied by a user, the calling application may with to filter to prevent scanning.
     """
 
     protocol = ("http", "https")


### PR DESCRIPTION
## Summary

Adds a "Note on URL handling" section to the `HTTPFileSystem` class docstring,
describing the URL-passthrough behaviour and noting that applications
constructing URLs from user input are responsible for their own validation.

This was discussed in security advisory GHSA-69jp-3788-fh27 and suggested
by the maintainer (martindurant).

## What changed

Added 14 lines to the `HTTPFileSystem` class docstring in
`fsspec/implementations/http.py`.

```
Note on URL handling
--------------------
Like any HTTP client library, this class passes URLs directly to the
underlying ``aiohttp`` session without filtering or restricting the
target host. URLs pointing to loopback addresses (``127.x.x.x``),
link-local addresses (``169.254.x.x``, used by cloud Instance Metadata
Services), or private network ranges (RFC 1918) are therefore
reachable, which is intentional for use cases such as accessing
internal S3-compatible storage or local development servers.

Applications that construct URLs from user-supplied input are
responsible for validating those URLs before passing them to
``HTTPFileSystem``. Failing to do so may expose the application to
Server-Side Request Forgery (SSRF).
```

## Tone

The note is intentionally neutral — it describes standard HTTP client
behaviour, not a warning, consistent with the maintainer's feedback.

## Related

- Security advisory: GHSA-69jp-3788-fh27
- `_pipe_file` encode_url fix: #2023