### PR TITLE
updates ci to install underlying systems like gcsfs to generate dynamic version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -154,5 +154,6 @@ jobs:
         shell: bash -l {0}
         run: |
           cd ${{ matrix.FRIEND }}
+          pip install -e . --no-deps
           pytest -v -W ignore::pytest.PytestRemovedIn9Warning --ignore=gcsfs/tests/perf
           cd ..


### PR DESCRIPTION
- Recent changes in `gcsfs` [PR #809](https://github.com/fsspec/gcsfs/pull/809) migrated the package build system from setuptools to hatch, removing the static `versioneer` script. 
- The `_version.py` file is now generated dynamically during package installation by `hatch-vcs`.
- Updates the CI to generate dynamic version before starting the test 