### PR TITLE
fix: pass on_error when mv calls copy

### DIFF
--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -112,6 +112,18 @@ def test_mv_same_paths(m):
     assert m.exists("src/file.txt")
 
 
+def test_mv_recursive_propagates_cp_file_errors(m, monkeypatch):
+    m.pipe("/src/a.txt", b"hello")
+
+    def failing_cp_file(path1, path2, **kwargs):
+        raise FileNotFoundError(path1)
+
+    monkeypatch.setattr(m, "cp_file", failing_cp_file)
+
+    with pytest.raises(FileNotFoundError):
+        m.mv("/src", "/dst", recursive=True)
+
+
 def test_rm_no_pseudo_dir(m):
     m.touch("/dir1/dir2/file")
     m.rm("/dir1", recursive=True)

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -113,7 +113,8 @@ def test_mv_same_paths(m):
 
 
 def test_mv_recursive_propagates_cp_file_errors(m, monkeypatch):
-    m.pipe("/src/a.txt", b"hello")
+    m.mkdir("src")
+    m.touch("src/file.txt")
 
     def failing_cp_file(path1, path2, **kwargs):
         raise FileNotFoundError(path1)
@@ -122,6 +123,7 @@ def test_mv_recursive_propagates_cp_file_errors(m, monkeypatch):
 
     with pytest.raises(FileNotFoundError):
         m.mv("/src", "/dst", recursive=True)
+    assert m.exists("/src/file.txt")
 
 
 def test_rm_no_pseudo_dir(m):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1230,7 +1230,7 @@ class AbstractFileSystem(metaclass=_Cached):
         else:
             # explicitly raise exception to prevent data corruption
             self.copy(
-                path1, path2, recursive=recursive, maxdepth=maxdepth, onerror="raise"
+                path1, path2, recursive=recursive, maxdepth=maxdepth, on_error="raise"
             )
             self.rm(path1, recursive=recursive)
 


### PR DESCRIPTION
#1576 added an explicit `on_error="raise"` to the internal `copy()` call inside `mv()` so that a failing recursive copy would not be followed by deleting the source. The keyword was misspelled as `onerror`, so it was silently absorbed by `**kwargs` and `copy()` fell back to its default — which for recursive calls is `on_error="ignore"`. 

The tests added in #1576 didn't catch this because they only ran against `LocalFileSystem`, whose `mv()` override calls `shutil.move()` directly and never reaches the patched line.