### PR TITLE
Fix referenceFS for new zarr and pandas

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -188,7 +188,7 @@ class LazyReferenceMapper(collections.abc.MutableMapping):
             data = io.BytesIO(self.fs.cat_file(path))
             try:
                 df = self.pd.read_parquet(data, engine=self.engine)
-                refs = {c: df[c].to_numpy() for c in df.columns}
+                refs = {c: df[c].to_numpy(copy=True) for c in df.columns}
             except OSError:
                 refs = None
             return refs

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -857,7 +857,7 @@ def test_deep_parq(m, engine):
     pytest.importorskip("kerchunk")
     zarr = pytest.importorskip("zarr")
     skip_zarr_2()
-    if zarr.__version__.split() >= ["3", "2"]:
+    if zarr.__version__.split(".") >= ["3", "2"]:
         kw = {}
     else:
         kw = {"zarr_version": 2}

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -808,7 +808,7 @@ def lazy_refs(m):
         zarr_format=2,
         mode="w",
     )
-    g.create_dataset(name="data", shape=(100,), chunks=(10,), dtype="int64")
+    g.create_array(name="data", shape=(100,), chunks=(10,), dtype="int64")
     g.store.fs.references.flush()
     return l
 
@@ -857,6 +857,10 @@ def test_deep_parq(m, engine):
     pytest.importorskip("kerchunk")
     zarr = pytest.importorskip("zarr")
     skip_zarr_2()
+    if zarr.__version__.split() >= ["3", "2"]:
+        kw = {}
+    else:
+        kw = {"zarr_version": 2}
 
     lz = fsspec.implementations.reference.LazyReferenceMapper.create(
         "memory://out.parq",
@@ -867,11 +871,11 @@ def test_deep_parq(m, engine):
         "reference://",
         mode="w",
         storage_options={"fo": "memory://out.parq", "remote_protocol": "memory"},
-        zarr_version=2,
+        **kw,
     )
 
     g2 = g.create_group("instant")
-    arr = g2.create_dataset(name="one", shape=(3,), dtype="int64")
+    arr = g2.create_array(name="one", shape=(3,), dtype="int64")
     arr[:] = [1, 2, 3]
     g.store.fs.references.flush()
     lz.flush()
@@ -920,7 +924,7 @@ def test_parquet_no_data(m):
         zarr_format=2,
         mode="w",
     )
-    arr = g.create_dataset(
+    arr = g.create_array(
         name="one",
         dtype="int32",
         shape=(10,),
@@ -950,7 +954,7 @@ def test_parquet_no_references(m):
         zarr_format=2,
         mode="w",
     )
-    arr = g.create_dataset(
+    arr = g.create_array(
         name="one",
         dtype="int32",
         shape=(),

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -860,7 +860,7 @@ def test_deep_parq(m, engine):
     if zarr.__version__.split(".") >= ["3", "2"]:
         kw = {}
     else:
-        kw = {"zarr_version": 2}
+        kw = {"zarr_format": 2}
 
     lz = fsspec.implementations.reference.LazyReferenceMapper.create(
         "memory://out.parq",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ test_full = [
     'python-snappy',
     'tqdm',
     'urllib3',
-    'zarr',
+    'zarr <3.2.0',
     'backports.zstd; python_version < "3.14"',
     'zstandard; python_version < "3.14"',
 ]


### PR DESCRIPTION
(tests explicitly use older zarr, but this is for dataset creation)