### PR TITLE
Do not strip trailing slashes from data URIs

### DIFF
--- a/fsspec/implementations/data.py
+++ b/fsspec/implementations/data.py
@@ -3,6 +3,7 @@ import io
 from urllib.parse import unquote
 
 from fsspec import AbstractFileSystem
+from fsspec.utils import stringify_path
 
 
 class DataFileSystem(AbstractFileSystem):
@@ -22,6 +23,19 @@ class DataFileSystem(AbstractFileSystem):
     def __init__(self, **kwargs):
         """No parameters for this filesystem"""
         super().__init__(**kwargs)
+
+    @classmethod
+    def _strip_protocol(cls, path):
+        if isinstance(path, list):
+            return [cls._strip_protocol(p) for p in path]
+        path = stringify_path(path)
+        if path.startswith("data://"):
+            path = path[7:]
+        elif path.startswith("data:"):
+            path = path[5:]
+        # Do NOT strip trailing slashes, as they may be meaningful base64 characters
+        # or percent-encoded data content
+        return path
 
     def cat_file(self, path, start=None, end=None, **kwargs):
         pref, data = path.split(",", 1)

--- a/fsspec/implementations/tests/test_data.py
+++ b/fsspec/implementations/tests/test_data.py
@@ -8,6 +8,13 @@ def test_1():
     with fsspec.open("data:,Hello%2C%20World%21") as f:
         assert f.read() == b"Hello, World!"
 
+    # Trailing slashed should not be stripped
+    with fsspec.open("data:text/plain;base64,YWI/") as f:
+        assert f.read() == b"ab?"
+
+    with fsspec.open("data:text/plain,/") as f:
+        assert f.read() == b"/"
+
 
 def test_info():
     fs = fsspec.filesystem("data")


### PR DESCRIPTION
Trailing slashes are incorrectly stripped from data URIs, resulting in incorrect decoding.

The fix is to override the `_strip_protocol` class method for the `DataFileSystem` to not strip trailing slashes.

Without the fix:
```python
>>> from fsspec.core import url_to_fs
>>> from base64 import b64encode
>>> value = b"ab?"
>>> uri = "data:text/plain;base64," + b64encode(value)
>>> uri
'data:text/plain;base64,YWI/'
>>> fs, fs_url = url_to_fs(uri)
>>> fs_url
... # Trailing slash is stripped
'data:text/plain;base64,YWI'
>>> fs.cat(fs_url)
... # Value is wrong
b'ab' 
>>> fs.cat("data:text/plain,/")
''
```

With the fix:
```python
>>> from fsspec.core import url_to_fs
>>> fs, fs_uri = url_to_fs("data:text/plain;base64,YWI/")
>>> fs.cat(fs_uri)
b'ab?'
>>> fs.cat("data:text/plain,/")
'/'
```