### PR TITLE
Fix infinite recursion in expand_path when resolving paths with glob magic characters (#2036)

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -892,7 +892,7 @@ class AsyncFileSystem(AbstractFileSystem):
         else:
             return {name: out[name] for name in names}
 
-    async def _expand_path(self, path, recursive=False, maxdepth=None):
+    async def _expand_path(self, path, recursive=False, maxdepth=None, assume_literal=False):
         if maxdepth is not None and maxdepth < 1:
             raise ValueError("maxdepth must be at least 1")
 
@@ -902,7 +902,7 @@ class AsyncFileSystem(AbstractFileSystem):
             out = set()
             path = [self._strip_protocol(p) for p in path]
             for p in path:  # can gather here
-                if has_magic(p):
+                if not assume_literal and has_magic(p):
                     bit = set(await self._glob(p, maxdepth=maxdepth))
                     out |= bit
                     if recursive:
@@ -916,6 +916,7 @@ class AsyncFileSystem(AbstractFileSystem):
                                 list(bit),
                                 recursive=recursive,
                                 maxdepth=maxdepth - 1 if maxdepth is not None else None,
+                                assume_literal=True,
                             )
                         )
                     continue

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -892,7 +892,9 @@ class AsyncFileSystem(AbstractFileSystem):
         else:
             return {name: out[name] for name in names}
 
-    async def _expand_path(self, path, recursive=False, maxdepth=None, assume_literal=False):
+    async def _expand_path(
+        self, path, recursive=False, maxdepth=None, assume_literal=False
+    ):
         if maxdepth is not None and maxdepth < 1:
             raise ValueError("maxdepth must be at least 1")
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1175,7 +1175,9 @@ class AbstractFileSystem(metaclass=_Cached):
                 if on_error == "raise":
                     raise
 
-    def expand_path(self, path, recursive=False, maxdepth=None, assume_literal=False, **kwargs):
+    def expand_path(
+        self, path, recursive=False, maxdepth=None, assume_literal=False, **kwargs
+    ):
         """Turn one or more globs or directories into a list of all matching paths
         to files or directories.
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1175,7 +1175,7 @@ class AbstractFileSystem(metaclass=_Cached):
                 if on_error == "raise":
                     raise
 
-    def expand_path(self, path, recursive=False, maxdepth=None, **kwargs):
+    def expand_path(self, path, recursive=False, maxdepth=None, assume_literal=False, **kwargs):
         """Turn one or more globs or directories into a list of all matching paths
         to files or directories.
 
@@ -1191,7 +1191,7 @@ class AbstractFileSystem(metaclass=_Cached):
             out = set()
             path = [self._strip_protocol(p) for p in path]
             for p in path:
-                if has_magic(p):
+                if not assume_literal and has_magic(p):
                     bit = set(self.glob(p, maxdepth=maxdepth, **kwargs))
                     out |= bit
                     if recursive:
@@ -1205,6 +1205,7 @@ class AbstractFileSystem(metaclass=_Cached):
                                 list(bit),
                                 recursive=recursive,
                                 maxdepth=maxdepth - 1 if maxdepth is not None else None,
+                                assume_literal=True,
                                 **kwargs,
                             )
                         )

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -270,22 +270,23 @@ class _PrefixCapturingFS(fsspec.asyn.AsyncFileSystem):
 
     protocol = "prefixmock"
 
-    def __init__(self, **kwargs):
+    def __init__(self, fs_files=None, **kwargs):
         super().__init__(**kwargs)
         self.find_calls = []
+        self.fs_files = fs_files if fs_files is not None else _GLOB_PREFIX_FILES
 
     async def _find(self, path, maxdepth=None, withdirs=False, detail=False, **kwargs):
         self.find_calls.append({"path": path, "kwargs": dict(kwargs)})
         root = (path.rstrip("/") + "/") if path else ""
         results = {
             f: {"name": f, "type": "file", "size": 0}
-            for f in _GLOB_PREFIX_FILES
+            for f in self.fs_files
             if f.startswith(root)
         }
         return results if detail else list(results)
 
     async def _info(self, path, **kwargs):
-        for f in _GLOB_PREFIX_FILES:
+        for f in self.fs_files:
             if f == path:
                 return {"name": f, "type": "file", "size": 0}
         raise FileNotFoundError(path)
@@ -366,3 +367,39 @@ def test_glob_prefix_hint(prefix_fs, pattern, expected_results, expected_prefix)
             f"expected prefix={expected_prefix!r} for pattern {pattern!r}, "
             f"got {forwarded.get('prefix')!r}"
         )
+
+
+@pytest.mark.asyncio
+async def test_expand_path_special_characters_async():
+    fs_files = [
+        "bucket",
+        "bucket/file[1].txt",
+        "bucket/file?.txt",
+        "bucket/normal.txt",
+    ]
+    fs = _PrefixCapturingFS(fs_files=fs_files)
+    paths = await fs._expand_path("bucket", recursive=True)
+    expected = [
+        "bucket",
+        "bucket/file[1].txt",
+        "bucket/file?.txt",
+        "bucket/normal.txt",
+    ]
+    assert sorted(paths) == sorted(expected)
+
+
+@pytest.mark.asyncio
+async def test_expand_path_with_magic_input_async():
+    fs_files = [
+        "bucket",
+        "bucket/file[1].txt",
+        "bucket/file?.txt",
+        "bucket/normal.txt",
+    ]
+    fs = _PrefixCapturingFS(fs_files=fs_files)
+    paths = await fs._expand_path("bucket/file*.txt", recursive=True)
+    expected = [
+        "bucket/file[1].txt",
+        "bucket/file?.txt",
+    ]
+    assert sorted(paths) == sorted(expected)

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -1422,3 +1422,37 @@ def test_copy_wildcard_path_passthrough_kwargs_to_ls(tmpfs, tmpdir):
 def test_expand_path_wildcard_path_passthrough_kwargs_to_ls(tmpfs, tmpdir):
     expanded_paths = tmpfs.expand_path(tmpdir / "*", limit=2)
     assert len(expanded_paths) == 2
+
+
+def test_expand_path_special_characters():
+    fs_contents = (
+        {"name": "bucket", "type": "directory"},
+        {"name": "bucket/file[1].txt", "type": "file", "size": 100},
+        {"name": "bucket/file?.txt", "type": "file", "size": 100},
+        {"name": "bucket/normal.txt", "type": "file", "size": 100},
+    )
+    fs = DummyTestFS(fs_content=fs_contents)
+    paths = fs.expand_path("bucket", recursive=True)
+    expected = [
+        "bucket",
+        "bucket/file[1].txt",
+        "bucket/file?.txt",
+        "bucket/normal.txt",
+    ]
+    assert sorted(paths) == sorted(expected)
+
+
+def test_expand_path_with_magic_input():
+    fs_contents = (
+        {"name": "bucket", "type": "directory"},
+        {"name": "bucket/file[1].txt", "type": "file", "size": 100},
+        {"name": "bucket/file?.txt", "type": "file", "size": 100},
+        {"name": "bucket/normal.txt", "type": "file", "size": 100},
+    )
+    fs = DummyTestFS(fs_content=fs_contents)
+    paths = fs.expand_path("bucket/file*.txt", recursive=True)
+    expected = [
+        "bucket/file[1].txt",
+        "bucket/file?.txt",
+    ]
+    assert sorted(paths) == sorted(expected)


### PR DESCRIPTION
When calling expand_path(or the async _expand_path) with recursive=True on paths that resolve to filenames containing glob magic characters (such as [ or ?), the method would incorrectly treat these resolved paths as new glob patterns in the next recursive step. This led to either infinite recursion or unexpected FileNotFoundError when the characters were interpreted as character classes (e.g., file[1].txt searching for file1.txt).

To prevent this, assume_literal parameter is introduced to both expand_path and _expand_path:

- By default, it is False.
- When the method calls itself recursively on resolved paths (which we know are literals because they came from glob or find), it passes assume_literal=True.
- This bypasses the has_magic check and ensures the paths are treated as literals, stopping the infinite recursion and preventing false glob interpretations.

Fixes https://github.com/fsspec/filesystem_spec/issues/2036