### PR TITLE
Reflect async _walk correctly

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -128,7 +128,10 @@ def async_gen_wrapper(func, obj=None):
         self = obj or args[0]
         gen = func(*args, **kwargs)
         while True:
-            yield sync(self.loop, gen.__anext__)
+            try:
+                yield sync(self.loop, gen.__anext__)
+            except StopAsyncIteration:
+                break
 
     return wrapper
 
@@ -982,7 +985,7 @@ def mirror_sync_methods(obj):
             is_default = unsync is getattr(AbstractFileSystem, smethod, "")
             if isco and is_default:
                 mth = sync_wrapper(getattr(obj, method), obj=obj)
-            elif inspect.isasyncgenfunction(getattr(obj, method, None)):
+            elif inspect.isasyncgenfunction(getattr(obj, method, None)) and is_default:
                 mth = async_gen_wrapper(getattr(obj, method), obj=obj)
             else:
                 continue

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -959,12 +959,13 @@ def mirror_sync_methods(obj):
     """
     from fsspec import AbstractFileSystem
 
-    for method in async_methods + dir(AsyncFileSystem):
+    for method in set(async_methods + dir(AsyncFileSystem)):
         if not method.startswith("_"):
             continue
         smethod = method[1:]
         if private.match(method):
             isco = inspect.iscoroutinefunction(getattr(obj, method, None))
+            isco = isco or inspect.isasyncgenfunction(getattr(obj, method, None))
             unsync = getattr(getattr(obj, smethod, False), "__func__", None)
             is_default = unsync is getattr(AbstractFileSystem, smethod, "")
             if isco and is_default:

--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -120,6 +120,19 @@ def sync_wrapper(func, obj=None):
     return wrapper
 
 
+def async_gen_wrapper(func, obj=None):
+    """Given a async generator, make so can be called in blocking contexts"""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        self = obj or args[0]
+        gen = func(*args, **kwargs)
+        while True:
+            yield sync(self.loop, gen.__anext__)
+
+    return wrapper
+
+
 def get_loop():
     """Create or return the default fsspec IO loop
 
@@ -965,16 +978,19 @@ def mirror_sync_methods(obj):
         smethod = method[1:]
         if private.match(method):
             isco = inspect.iscoroutinefunction(getattr(obj, method, None))
-            isco = isco or inspect.isasyncgenfunction(getattr(obj, method, None))
             unsync = getattr(getattr(obj, smethod, False), "__func__", None)
             is_default = unsync is getattr(AbstractFileSystem, smethod, "")
             if isco and is_default:
                 mth = sync_wrapper(getattr(obj, method), obj=obj)
-                setattr(obj, smethod, mth)
-                if not mth.__doc__:
-                    mth.__doc__ = getattr(
-                        getattr(AbstractFileSystem, smethod, None), "__doc__", ""
-                    )
+            elif inspect.isasyncgenfunction(getattr(obj, method, None)):
+                mth = async_gen_wrapper(getattr(obj, method), obj=obj)
+            else:
+                continue
+            setattr(obj, smethod, mth)
+            if not mth.__doc__:
+                mth.__doc__ = getattr(
+                    getattr(AbstractFileSystem, smethod, None), "__doc__", ""
+                )
 
 
 class FSSpecCoroutineCancel(Exception):

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -394,9 +394,13 @@ async def test_async_walk(adirfs, mocker):
 
 
 def test_walk(dirfs):
-    dirfs.fs.walk.return_value = iter(
-        [(f"{PATH}/root", ["foo", "bar"], ["baz", "qux"])]
-    )
+    if dirfs.fs.async_impl:
+        pytest.skip()
+    else:
+        dirfs.fs.walk.return_value = iter(
+            [(f"{PATH}/root", ["foo", "bar"], ["baz", "qux"])]
+        )
+
     assert list(dirfs.walk("root", *ARGS, **KWARGS)) == [
         ("root", ["foo", "bar"], ["baz", "qux"])
     ]

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -16,7 +16,14 @@ def test_sync_methods():
     assert hasattr(inst, "info")
     assert inst.info.__qualname__ == "AsyncFileSystem._info"
     assert not inspect.iscoroutinefunction(inst.info)
+
+
+def test_async_gen():
+    inst = fsspec.asyn.AsyncFileSystem()
     assert inst.walk is not fsspec.AbstractFileSystem.walk
+    gen = inst.walk("path")  # does not raise yet
+    with pytest.raises(NotImplementedError):
+        list(gen)
 
 
 def test_when_sync_methods_are_disabled():

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -16,6 +16,7 @@ def test_sync_methods():
     assert hasattr(inst, "info")
     assert inst.info.__qualname__ == "AsyncFileSystem._info"
     assert not inspect.iscoroutinefunction(inst.info)
+    assert inst.walk is not fsspec.AbstractFileSystem.walk
 
 
 def test_when_sync_methods_are_disabled():


### PR DESCRIPTION
Fixes #2002

@dAnjou , sorry for the slow response.
The issue was, that ._walk is not a coroutine function, but a coroutine generator function, and the wrapping code didn't consider this case.