### PR TITLE
Prevent attribute error by checking for 'forced' attribute before flushing cache

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -2222,11 +2222,7 @@ class AbstractBufferedFile(io.IOBase):
             if self.mode == "rb":
                 self.cache = None
             else:
-                if not hasattr(self, "forced"):
-                    # the field is not available if NotImplementedError is thrown in constructor
-                    return
-
-                if not self.forced:
+                if not getattr(self, "forced", True):
                     self.flush(force=True)
 
                 if self.fs is not None:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -2222,6 +2222,10 @@ class AbstractBufferedFile(io.IOBase):
             if self.mode == "rb":
                 self.cache = None
             else:
+                if not hasattr(self, "forced"):
+                    # the field is not available if NotImplementedError is thrown in constructor
+                    return
+
                 if not self.forced:
                     self.flush(force=True)
 


### PR DESCRIPTION
This is not a critical bug; however, if a `NotImplementedError` is raised during initialization due to an invalid mode, attributes such as forced are not created.
Consequently, subsequent cleanup operations (e.g., close or delete) may raise an `AttributeError`.
While this exception is typically suppressed, it may still be exposed in some scenarios.
This PR adds safeguards to prevent such cases and avoid unnecessary visual clutter.