### PR TITLE
FTP: preserve filenames containing whitespace in _mlsd2

### DIFF
--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -416,16 +416,21 @@ def _mlsd2(ftp, path="."):
     minfo = []
     ftp.dir(path, lines.append)
     for line in lines:
-        split_line = line.split()
+        split_line = line.split(maxsplit=8)
         if len(split_line) < 9:
             continue
+        name = split_line[8]
+        unix_mode = split_line[0]
+        if unix_mode[0] == "l" and " -> " in name:
+            # Symbolic link: "<name> -> <target>"; keep only the link name.
+            name = name.split(" -> ", 1)[0]
         this = (
-            split_line[-1],
+            name,
             {
                 "modify": " ".join(split_line[5:8]),
                 "unix.owner": split_line[2],
                 "unix.group": split_line[3],
-                "unix.mode": split_line[0],
+                "unix.mode": unix_mode,
                 "size": split_line[4],
             },
         )

--- a/fsspec/implementations/tests/test_ftp.py
+++ b/fsspec/implementations/tests/test_ftp.py
@@ -8,7 +8,7 @@ import pytest
 
 import fsspec
 from fsspec import open_files
-from fsspec.implementations.ftp import FTPFileSystem, ImplicitFTPTLS
+from fsspec.implementations.ftp import FTPFileSystem, ImplicitFTPTLS, _mlsd2
 
 ftplib = pytest.importorskip("ftplib")
 here = os.path.dirname(os.path.abspath(__file__))
@@ -246,3 +246,85 @@ def test_rm_get_recursive(ftp_writable, tmpdir):
 
     fs.rm("/tmp/topdir", recursive=True)
     assert not fs.exists("/tmp/topdir")
+
+
+class _FakeDirFTP:
+    """Minimal stand-in for ftplib.FTP whose .dir(path, callback) replays
+    a canned `ls -l` style listing — enough to exercise the _mlsd2 parser
+    without needing an FTP server that disables MLSD."""
+
+    def __init__(self, lines):
+        self._lines = lines
+
+    def dir(self, path, callback):
+        for line in self._lines:
+            callback(line)
+
+
+def test_mlsd2_parses_filename_without_spaces():
+    ftp = _FakeDirFTP(["-rw-r--r-- 1 owner group 38283 Jan 12 07:08 plain.pdf"])
+    out = _mlsd2(ftp, "/data")
+    assert out == [
+        (
+            "plain.pdf",
+            {
+                "modify": "Jan 12 07:08",
+                "unix.owner": "owner",
+                "unix.group": "group",
+                "unix.mode": "-rw-r--r--",
+                "size": "38283",
+                "type": "file",
+            },
+        )
+    ]
+
+
+def test_mlsd2_parses_filename_with_spaces():
+    # Regression test: when the FTP server doesn't support MLSD, _mlsd2 falls
+    # back to parsing `dir` output. Previously it took split_line[-1] as the
+    # filename, which truncated names containing whitespace.
+    ftp = _FakeDirFTP(
+        [
+            "-rw-r--r-- 1 owner group 38283 Jan 12 07:08 my file.pdf",
+            "drwxr-xr-x 2 owner group  4096 Mar 15 10:30 a dir with spaces",
+            "-rw-r--r-- 1 owner group   100 Feb  3 09:15 trailing   spaces.txt",
+        ]
+    )
+    out = _mlsd2(ftp, "/data")
+    names = [name for name, _ in out]
+    assert names == [
+        "my file.pdf",
+        "a dir with spaces",
+        "trailing   spaces.txt",
+    ]
+    assert out[0][1]["type"] == "file"
+    # _mlsd2 itself reports "dir"; ls() promotes it to "directory" later.
+    assert out[1][1]["type"] == "dir"
+    assert out[2][1]["size"] == "100"
+
+
+def test_mlsd2_parses_symlink_name_without_target():
+    # `ls -l` formats symlinks as "<name> -> <target>". Only the link's own
+    # name should be returned; the previous parser took split_line[-1] and so
+    # returned the target instead of the name.
+    ftp = _FakeDirFTP(
+        ["lrwxrwxrwx 1 owner group 10 Jan 12 07:08 link name -> some/target"]
+    )
+    out = _mlsd2(ftp, "/data")
+    assert len(out) == 1
+    name, info = out[0]
+    assert name == "link name"
+    assert info["unix.mode"].startswith("l")
+
+
+def test_mlsd2_skips_short_lines():
+    # The `total N` summary line emitted by some servers has fewer than 9
+    # fields and should be ignored.
+    ftp = _FakeDirFTP(
+        [
+            "total 4",
+            "-rw-r--r-- 1 owner group 1 Jan 12 07:08 keep.txt",
+        ]
+    )
+    out = _mlsd2(ftp, "/data")
+    assert [name for name, _ in out] == ["keep.txt"]


### PR DESCRIPTION
Fixes #1970.

When the FTP server does not support `MLSD`, `FTPFileSystem.ls()` falls back to parsing the output of `DIR`, via `_mlsd2`. That parser used `line.split()` and took `split_line[-1]` as the filename, so any name containing whitespace was truncated to its last whitespace-separated token. The example in the issue:

```
-rw-r--r-- 1 owner group 38283 Jan 12 07:08 my file.pdf
```

would split into 10 fields and be returned as `file.pdf` instead of `my file.pdf`.

### Fix

`_mlsd2` now does `line.split(maxsplit=8)`, which produces the first eight fixed fields (mode, link count, owner, group, size, month, day, time-or-year) plus the remainder of the line as a single string. The remainder is the filename, with any internal whitespace preserved as-is. This matches the approach suggested by the maintainer in the issue thread.

Symlink entries in `ls -l` output have the form `<name> -> <target>`, so for lines whose mode starts with `l` the trailing `" -> <target>"` is stripped to keep only the link's own name. (Previously the parser returned `<target>` as the entry name, since `split_line[-1]` picked the last token.)

### Tests

Added four unit tests in `fsspec/implementations/tests/test_ftp.py` driving `_mlsd2` with a small fake FTP object that replays a canned `dir` listing. This exercises the parser directly without needing an FTP server that disables `MLSD`:

- `test_mlsd2_parses_filename_without_spaces` — sanity check that a plain filename still parses correctly.
- `test_mlsd2_parses_filename_with_spaces` — the regression case, covering both files and directories, and also a filename with multiple consecutive internal spaces.
- `test_mlsd2_parses_symlink_name_without_target` — verifies the link name (not the target) is returned for symlink entries.
- `test_mlsd2_skips_short_lines` — confirms the existing skip for lines with fewer than 9 fields still discards the `total N` summary header some servers emit.

All four new tests pass. The full `fsspec/tests/` and `fsspec/implementations/tests/` suites continue to pass on this branch; the pre-existing `test_ftp.py` failures involving the pyftpdlib TLS test server fail identically on `master` on this machine and are unrelated to this change.
