### PR TITLE
Forward kwargs from cat_ranges to cat_file (#2016)

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -874,7 +874,7 @@ class AbstractFileSystem(metaclass=_Cached):
         out = []
         for p, s, e in zip(paths, starts, ends):
             try:
-                out.append(self.cat_file(p, s, e))
+                out.append(self.cat_file(p, s, e, **kwargs))
             except Exception as e:
                 if on_error == "return":
                     out.append(e)

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -1456,3 +1456,21 @@ def test_expand_path_with_magic_input():
         "bucket/file?.txt",
     ]
     assert sorted(paths) == sorted(expected)
+
+
+def test_cat_ranges_forwards_kwargs():
+    # See GH#2016: cat_ranges must forward **kwargs to cat_file, otherwise
+    # parameters such as a cache's block_size are silently dropped.
+    received = []
+
+    class RecordingFS(AbstractFileSystem):
+        cachable = False
+
+        def cat_file(self, path, start=None, end=None, **kwargs):
+            received.append(kwargs)
+            return b""
+
+    fs = RecordingFS()
+    fs.cat_ranges(["a", "b"], [0, 0], [1, 1], block_size=42)
+
+    assert received == [{"block_size": 42}, {"block_size": 42}]


### PR DESCRIPTION
## Summary

Fixes #2016.

`AbstractFileSystem.cat_ranges` accepts `**kwargs` but did not forward them when calling `cat_file`:

```python
out.append(self.cat_file(p, s, e))   # kwargs silently dropped
```

As reported, this means parameters such as a cache's `block_size` are lost, so `cat_ranges` bypasses an on-disk cache and goes out to the underlying (remote) filesystem on every call. The async `AsyncFileSystem._cat_ranges` already forwards `**kwargs` to `_cat_file`, so this just brings the sync path in line.

@martindurant confirmed in the issue: *"I'd be happy to see kwargs passed through as you suggest for part 1 of this issue."* This PR is scoped to that part 1.

## Change

```python
out.append(self.cat_file(p, s, e, **kwargs))
```

## Test plan

- Added `test_cat_ranges_forwards_kwargs` in `fsspec/tests/test_spec.py` (a recording filesystem asserts the kwarg reaches `cat_file`).
- `pytest fsspec/tests/test_spec.py` — 120 passed.
- `ruff check` / `ruff format --check` — clean.
