### PR TITLE
dirfs: reject paths that escape the root via ".."

### DIFF
--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -1,6 +1,7 @@
 from .. import filesystem
 from ..asyn import AsyncFileSystem
 from .chained import ChainedFileSystem
+from .local import LocalFileSystem
 
 
 def _escapes_root(path):
@@ -68,7 +69,10 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
             if not path:
                 return self.path
             path = self._strip_protocol(path)
-            if _escapes_root(path):
+            # ".." only navigates above the root on filesystems that resolve it
+            # against a real directory tree; on object stores it is a literal
+            # path part, so only guard the local case here.
+            if isinstance(self.fs, LocalFileSystem) and _escapes_root(path):
                 raise ValueError(
                     f"path {path!r} escapes the {self.path!r} root of the filesystem"
                 )

--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -3,6 +3,19 @@ from ..asyn import AsyncFileSystem
 from .chained import ChainedFileSystem
 
 
+def _escapes_root(path):
+    """Whether a relative path would resolve above its root via ".." segments."""
+    depth = 0
+    for part in path.split("/"):
+        if part == "..":
+            depth -= 1
+            if depth < 0:
+                return True
+        elif part and part != ".":
+            depth += 1
+    return False
+
+
 class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
     """Directory prefix filesystem
 
@@ -54,7 +67,12 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
                 return path
             if not path:
                 return self.path
-            return self.fs.sep.join((self.path, self._strip_protocol(path)))
+            path = self._strip_protocol(path)
+            if _escapes_root(path):
+                raise ValueError(
+                    f"path {path!r} escapes the {self.path!r} root of the filesystem"
+                )
+            return self.fs.sep.join((self.path, path))
         if isinstance(path, dict):
             return {self._join(_path): value for _path, value in path.items()}
         return [self._join(_path) for _path in path]

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -2,6 +2,7 @@ import pytest
 
 from fsspec.asyn import AsyncFileSystem
 from fsspec.implementations.dirfs import DirFileSystem
+from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 
 PATH = "path/to/dir"
@@ -108,24 +109,24 @@ def test_path_no_leading_slash(fs, root, rel, full):
     "path",
     ["..", "../", "../secret", "foo/../..", "foo/../../secret", "/../secret"],
 )
-def test_join_rejects_escape(fs, path):
-    dirfs = DirFileSystem("root", fs)
+def test_join_rejects_escape_local(tmp_path, path):
+    dirfs = DirFileSystem(str(tmp_path), LocalFileSystem())
     with pytest.raises(ValueError):
         dirfs._join(path)
 
 
-@pytest.mark.parametrize(
-    "path, full",
-    [
-        ("foo", "root/foo"),
-        ("foo/bar", "root/foo/bar"),
-        ("./foo", "root/./foo"),
-        ("foo/../bar", "root/foo/../bar"),
-    ],
-)
-def test_join_allows_internal(fs, path, full):
+@pytest.mark.parametrize("path", ["foo", "foo/bar", "foo/../bar"])
+def test_join_allows_internal_local(tmp_path, path):
+    dirfs = DirFileSystem(str(tmp_path), LocalFileSystem())
+    assert dirfs._join(path) == f"{dirfs.path}/{path}"
+
+
+@pytest.mark.parametrize("path", ["../secret", "foo/../../secret", ".."])
+def test_join_keeps_dotdot_for_non_local(fs, path):
+    # ".." is only special on local-style filesystems; elsewhere it is a
+    # legitimate path part and must not be rejected.
     dirfs = DirFileSystem("root", fs)
-    assert dirfs._join(path) == full
+    assert dirfs._join(path) == f"root/{path}"
 
 
 def test_sep(mocker, dirfs):

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -104,6 +104,30 @@ def test_path_no_leading_slash(fs, root, rel, full):
     assert dirfs._relpath(full) == rel
 
 
+@pytest.mark.parametrize(
+    "path",
+    ["..", "../", "../secret", "foo/../..", "foo/../../secret", "/../secret"],
+)
+def test_join_rejects_escape(fs, path):
+    dirfs = DirFileSystem("root", fs)
+    with pytest.raises(ValueError):
+        dirfs._join(path)
+
+
+@pytest.mark.parametrize(
+    "path, full",
+    [
+        ("foo", "root/foo"),
+        ("foo/bar", "root/foo/bar"),
+        ("./foo", "root/./foo"),
+        ("foo/../bar", "root/foo/../bar"),
+    ],
+)
+def test_join_allows_internal(fs, path, full):
+    dirfs = DirFileSystem("root", fs)
+    assert dirfs._join(path) == full
+
+
 def test_sep(mocker, dirfs):
     sep = mocker.Mock()
     dirfs.fs.sep = sep


### PR DESCRIPTION
1. DirFileSystem is meant to keep every operation under its configured path, but _join only concatenates the prefix with the caller-supplied path and never inspects ".." segments.
2. a relative path such as "../secret" therefore resolves above the root, and since reads and writes both funnel through _join an untrusted name escapes the directory entirely (confirmed by reading and writing a file outside the root over LocalFileSystem).

Reject in _join when the path would climb above the root; ".." that stays within the prefix is still allowed, so existing in-tree paths are unaffected.