### PR TITLE
restrict cache storage directory permissions to owner

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -137,7 +137,7 @@ class CachingFileSystem(ChainedFileSystem):
                 storage = [cache_storage]
             else:
                 storage = cache_storage
-        os.makedirs(storage[-1], exist_ok=True)
+        os.makedirs(storage[-1], exist_ok=True, mode=0o700)
         self.storage = storage
         self.kwargs = target_options or {}
         self.cache_check = cache_check
@@ -185,7 +185,7 @@ class CachingFileSystem(ChainedFileSystem):
             pass
 
     def _mkcache(self):
-        os.makedirs(self.storage[-1], exist_ok=True)
+        os.makedirs(self.storage[-1], exist_ok=True, mode=0o700)
 
     def cache_size(self):
         """Return size of cache in bytes.
@@ -815,7 +815,7 @@ class SimpleCacheFileSystem(WholeFileCacheFileSystem):
         super().__init__(**kw)
         for storage in self.storage:
             if not os.path.exists(storage):
-                os.makedirs(storage, exist_ok=True)
+                os.makedirs(storage, exist_ok=True, mode=0o700)
 
     def _check_file(self, path):
         self._check_cache()

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -76,6 +76,7 @@ class CachingFileSystem(ChainedFileSystem):
         same_names: bool | None = None,
         compression=None,
         cache_mapper: AbstractCacheMapper | None = None,
+        cache_storage_mode=None,
         **kwargs,
     ):
         """
@@ -118,6 +119,13 @@ class CachingFileSystem(ChainedFileSystem):
         cache_mapper: AbstractCacheMapper (optional)
             The object use to map from original filenames to cached filenames.
             Only one of this and ``same_names`` should be specified.
+        cache_storage_mode: int (optional)
+            Permission mode used when creating the cache storage directory,
+            e.g. ``0o700``. The default of ``None`` leaves the directory at
+            the system default (governed by the umask), which is the existing
+            behaviour. Pass an octal mode such as ``0o700`` to keep the cache
+            directory, and so the cached data files within it, readable by the
+            owner only.
         """
         super().__init__(**kwargs)
         if fs is None and target_protocol is None:
@@ -137,7 +145,8 @@ class CachingFileSystem(ChainedFileSystem):
                 storage = [cache_storage]
             else:
                 storage = cache_storage
-        os.makedirs(storage[-1], exist_ok=True, mode=0o700)
+        self.cache_storage_mode = cache_storage_mode
+        self._makedirs(storage[-1])
         self.storage = storage
         self.kwargs = target_options or {}
         self.cache_check = cache_check
@@ -184,8 +193,14 @@ class CachingFileSystem(ChainedFileSystem):
         except Exception:
             pass
 
+    def _makedirs(self, path):
+        if self.cache_storage_mode is None:
+            os.makedirs(path, exist_ok=True)
+        else:
+            os.makedirs(path, exist_ok=True, mode=self.cache_storage_mode)
+
     def _mkcache(self):
-        os.makedirs(self.storage[-1], exist_ok=True, mode=0o700)
+        self._makedirs(self.storage[-1])
 
     def cache_size(self):
         """Return size of cache in bytes.
@@ -452,6 +467,7 @@ class CachingFileSystem(ChainedFileSystem):
             "isdir",
             "_check_file",
             "_check_cache",
+            "_makedirs",
             "_mkcache",
             "clear_cache",
             "clear_expired_cache",
@@ -815,7 +831,7 @@ class SimpleCacheFileSystem(WholeFileCacheFileSystem):
         super().__init__(**kw)
         for storage in self.storage:
             if not os.path.exists(storage):
-                os.makedirs(storage, exist_ok=True, mode=0o700)
+                self._makedirs(storage)
 
     def _check_file(self, path):
         self._check_cache()

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -174,14 +174,17 @@ def test_constructor_kwargs(tmpdir):
 
 @pytest.mark.skipif(win, reason="POSIX file permissions")
 @pytest.mark.parametrize("protocol", ["filecache", "simplecache", "blockcache"])
-def test_cache_storage_not_world_readable(tmp_path, protocol):
+def test_cache_storage_mode(tmp_path, protocol):
     import stat
 
     cache = tmp_path / "cache"  # does not exist yet, fsspec must create it
     old = os.umask(0o022)
     try:
         fsspec.filesystem(
-            protocol, target_protocol="file", cache_storage=str(cache)
+            protocol,
+            target_protocol="file",
+            cache_storage=str(cache),
+            cache_storage_mode=0o700,
         )
     finally:
         os.umask(old)

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -172,6 +172,24 @@ def test_constructor_kwargs(tmpdir):
         )
 
 
+@pytest.mark.skipif(win, reason="POSIX file permissions")
+@pytest.mark.parametrize("protocol", ["filecache", "simplecache", "blockcache"])
+def test_cache_storage_not_world_readable(tmp_path, protocol):
+    import stat
+
+    cache = tmp_path / "cache"  # does not exist yet, fsspec must create it
+    old = os.umask(0o022)
+    try:
+        fsspec.filesystem(
+            protocol, target_protocol="file", cache_storage=str(cache)
+        )
+    finally:
+        os.umask(old)
+
+    mode = stat.S_IMODE(os.stat(cache).st_mode)
+    assert mode & (stat.S_IRWXG | stat.S_IRWXO) == 0, oct(mode)
+
+
 def test_idempotent():
     import pickle
 


### PR DESCRIPTION
While looking at how `filecache`/`blockcache`/`simplecache` persist downloaded data, I noticed an inconsistency in the permissions they leave behind. The cache metadata file ends up `0o600` because it goes through `atomic_write`, which creates its temporary via `mkstemp`, but the cache directory and the cached data files inside it do not. `CachingFileSystem.__init__`, `_mkcache` and `SimpleCacheFileSystem.__init__` each create the storage directory with a bare `os.makedirs(..., exist_ok=True)`, so under a normal `0o022` umask the directory comes out `0o755` and the cached files `0o644`. When `cache_storage` points at a persistent location (the documented way to keep a cache between runs), any other local user can traverse the directory and read another user's cached content, which for the http/s3/gcs backends is data that was fetched with that user's credentials.

The change sets `mode=0o700` on the three `os.makedirs` calls that create the cache storage directory, so the directory fsspec owns becomes owner-only and the data files within inherit that protection whichever backend wrote them. Keeping it at the directory-creation point rather than chmod-ing each cached file individually puts the guard in one place and covers all three cache implementations and every write path through them; directories fsspec did not create are left as they are. I have added a parametrised regression test over filecache/simplecache/blockcache that fails on the current tree (the directory is `0o755`) and passes once the mode is applied.