### PR TITLE
ci: fix test collection in fsspec_friends job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -155,5 +155,5 @@ jobs:
         run: |
           cd ${{ matrix.FRIEND }}
           pip install -e . --no-deps
-          pytest -v -W ignore::pytest.PytestRemovedIn10Warning --ignore=gcsfs/tests/perf
+          pytest -v -W ignore::pytest.PytestRemovedIn10Warning --ignore=${{ matrix.FRIEND }}/tests/perf ${{ matrix.FRIEND }}
           cd ..


### PR DESCRIPTION
This PR fixes a test collection failure in the `fsspec_friends` CI job.

### Cause of Failure
The `fsspec_friends` job clones `gcsfs` and runs `pytest` from the root of the cloned repository. Because no target directory was specified, `pytest` scanned the entire repo and tried to run macrobenchmark tests in the `gcsfs/cloudbuild/` directory. These benchmarks require `numpy` (and other specific tools) which are not installed in this CI environment.

### Solution
Restricted `pytest` in the `fsspec_friends` job to target the package directory (`${{ matrix.FRIEND }}`) instead of the repo root. 
