### PR TITLE
MemoryFileSystem: create the file when appending to a missing path

### DIFF
--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -197,6 +197,13 @@ class MemoryFileSystem(AbstractFileSystem):
                     # position at the beginning of file
                     f.seek(0)
                 return f
+            elif "a" in mode:
+                # append modes create the file if it does not exist, matching
+                # builtin open() and LocalFileSystem
+                m = MemoryFile(self, path, kwargs.get("data"))
+                if not self._intrans:
+                    m.commit()
+                return m
             else:
                 raise FileNotFoundError(path)
         elif mode in {"wb", "w+b", "xb", "x+b"}:

--- a/fsspec/implementations/memory.py
+++ b/fsspec/implementations/memory.py
@@ -203,6 +203,8 @@ class MemoryFileSystem(AbstractFileSystem):
                 m = MemoryFile(self, path, kwargs.get("data"))
                 if not self._intrans:
                     m.commit()
+                # position at the end of file, like the existing-file path above
+                m.seek(0, 2)
                 return m
             else:
                 raise FileNotFoundError(path)

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -177,6 +177,17 @@ def test_no_rewind_append_mode(m):
         assert f.tell() == 7
 
 
+@pytest.mark.parametrize("mode", ["a", "ab", "a+b"])
+def test_append_creates_missing_file(m, mode):
+    # append modes create the file if it does not exist, matching builtin
+    # open() and LocalFileSystem
+    filename = "newfile.txt"
+    assert not m.exists(filename)
+    with m.open(filename, mode) as f:
+        f.write(b"data" if "b" in mode else "data")
+    assert m.cat(filename) == b"data"
+
+
 def test_moves(m):
     m.touch("source.txt")
     m.mv("source.txt", "target.txt")

--- a/fsspec/implementations/tests/test_memory.py
+++ b/fsspec/implementations/tests/test_memory.py
@@ -184,6 +184,8 @@ def test_append_creates_missing_file(m, mode):
     filename = "newfile.txt"
     assert not m.exists(filename)
     with m.open(filename, mode) as f:
+        # append mode must position at the end of the (newly created) file
+        assert f.tell() == f.seek(0, 2)
         f.write(b"data" if "b" in mode else "data")
     assert m.cat(filename) == b"data"
 


### PR DESCRIPTION
Opening a path that doesn't exist yet in append mode behaves differently on MemoryFileSystem than on LocalFileSystem and the builtin `open`:

```python
import fsspec
fsspec.filesystem("file").open("/tmp/new.txt", "ab")   # creates the file
fsspec.filesystem("memory").open("/new.txt", "ab")     # FileNotFoundError
```

open(path, "ab") creates the file if it's missing, and LocalFileSystem inherits that, so having the memory backend raise FileNotFoundError here is surprising. This makes _open create an empty file when the path isn't in the store yet for append modes (a/ab/a+b), then position at the end as before. Read modes (rb/r+b) are unchanged and still raise.

Added a regression test covering the three append modes.