### PR TITLE
tar: make members with duplicate slashes reachable via ls/find/glob (#1947)

### DIFF
--- a/fsspec/implementations/tar.py
+++ b/fsspec/implementations/tar.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import tarfile
 
 import fsspec
@@ -9,6 +10,19 @@ from fsspec.utils import infer_compression
 typemap = {b"0": "file", b"5": "directory"}
 
 logger = logging.getLogger("tar")
+
+
+def _collapse_slashes(name):
+    """Collapse runs of consecutive slashes in a tar member name.
+
+    Some tar archives contain members with redundant duplicate slashes
+    (e.g. ``"a/b//c.txt"``). Left as-is these break the derived directory
+    structure: ``_parent("a/b//c.txt")`` yields ``"a/b/"`` (trailing slash),
+    so the entry becomes unreachable through ``ls``/``find``/``glob``/``walk``
+    even though it can be opened by its exact name. Normalising the
+    filesystem-facing name keeps ``"a/b//c.txt"`` reachable as ``"a/b/c.txt"``.
+    """
+    return re.sub("/+", "/", name)
 
 
 class TarFileSystem(AbstractArchiveFileSystem):
@@ -94,8 +108,13 @@ class TarFileSystem(AbstractArchiveFileSystem):
         for ti in self.tar:
             info = ti.get_info()
             info["type"] = typemap.get(info["type"], "file")
-            name = ti.get_info()["name"].rstrip("/")
-            out[name] = (info, ti.offset_data)
+            # Keep the original member name for extraction, but normalise the
+            # filesystem-facing name so members with duplicate slashes stay
+            # reachable through the directory listing (see _collapse_slashes).
+            orig_name = ti.get_info()["name"].rstrip("/")
+            name = _collapse_slashes(orig_name)
+            info["name"] = name
+            out[name] = (info, ti.offset_data, orig_name)
 
         self.index = out
         # TODO: save index to self.index_store here, if set
@@ -107,21 +126,25 @@ class TarFileSystem(AbstractArchiveFileSystem):
         # This enables ls to get directories as children as well as files
         self.dir_cache = {
             dirname: {"name": dirname, "size": 0, "type": "directory"}
-            for dirname in self._all_dirnames(self.tar.getnames())
+            for dirname in self._all_dirnames(
+                [_collapse_slashes(name) for name in self.tar.getnames()]
+            )
         }
         for member in self.tar.getmembers():
             info = member.get_info()
-            info["name"] = info["name"].rstrip("/")
+            info["name"] = _collapse_slashes(info["name"].rstrip("/"))
             info["type"] = typemap.get(info["type"], "file")
             self.dir_cache[info["name"]] = info
 
     def _open(self, path, mode="rb", **kwargs):
         if mode != "rb":
             raise ValueError("Read-only filesystem implementation")
-        details, offset = self.index[path]
+        details, offset, orig_name = self.index[_collapse_slashes(path)]
         if details["type"] != "file":
             raise ValueError("Can only handle regular files")
-        return self.tar.extractfile(path)
+        # Extract using the original member name, which may contain the
+        # duplicate slashes that were normalised away in the index key.
+        return self.tar.extractfile(orig_name)
 
     def close(self):
         """Commits any write changes to the file. Done on ``del`` too."""

--- a/fsspec/implementations/tar.py
+++ b/fsspec/implementations/tar.py
@@ -12,19 +12,6 @@ typemap = {b"0": "file", b"5": "directory"}
 logger = logging.getLogger("tar")
 
 
-def _collapse_slashes(name):
-    """Collapse runs of consecutive slashes in a tar member name.
-
-    Some tar archives contain members with redundant duplicate slashes
-    (e.g. ``"a/b//c.txt"``). Left as-is these break the derived directory
-    structure: ``_parent("a/b//c.txt")`` yields ``"a/b/"`` (trailing slash),
-    so the entry becomes unreachable through ``ls``/``find``/``glob``/``walk``
-    even though it can be opened by its exact name. Normalising the
-    filesystem-facing name keeps ``"a/b//c.txt"`` reachable as ``"a/b/c.txt"``.
-    """
-    return re.sub("/+", "/", name)
-
-
 class TarFileSystem(AbstractArchiveFileSystem):
     """Compressed Tar archives as a file-system (read-only)
 
@@ -108,11 +95,9 @@ class TarFileSystem(AbstractArchiveFileSystem):
         for ti in self.tar:
             info = ti.get_info()
             info["type"] = typemap.get(info["type"], "file")
-            # Keep the original member name for extraction, but normalise the
-            # filesystem-facing name so members with duplicate slashes stay
-            # reachable through the directory listing (see _collapse_slashes).
-            orig_name = ti.get_info()["name"].rstrip("/")
-            name = _collapse_slashes(orig_name)
+            orig_name = info["name"].rstrip("/")
+            # Collapse duplicate slashes in the filesystem-facing name.
+            name = re.sub("/+", "/", orig_name)
             info["name"] = name
             out[name] = (info, ti.offset_data, orig_name)
 
@@ -126,24 +111,20 @@ class TarFileSystem(AbstractArchiveFileSystem):
         # This enables ls to get directories as children as well as files
         self.dir_cache = {
             dirname: {"name": dirname, "size": 0, "type": "directory"}
-            for dirname in self._all_dirnames(
-                [_collapse_slashes(name) for name in self.tar.getnames()]
-            )
+            for dirname in self._all_dirnames(self.index)
         }
-        for member in self.tar.getmembers():
-            info = member.get_info()
-            info["name"] = _collapse_slashes(info["name"].rstrip("/"))
-            info["type"] = typemap.get(info["type"], "file")
-            self.dir_cache[info["name"]] = info
+        self.dir_cache.update(
+            {info["name"]: info for info, _, _ in self.index.values()}
+        )
 
     def _open(self, path, mode="rb", **kwargs):
         if mode != "rb":
             raise ValueError("Read-only filesystem implementation")
-        details, offset, orig_name = self.index[_collapse_slashes(path)]
+        # Accept paths containing the archive's duplicate slashes too.
+        path = re.sub("/+", "/", path)
+        details, _, orig_name = self.index[path]
         if details["type"] != "file":
             raise ValueError("Can only handle regular files")
-        # Extract using the original member name, which may contain the
-        # duplicate slashes that were normalised away in the index key.
         return self.tar.extractfile(orig_name)
 
     def close(self):

--- a/fsspec/implementations/tests/test_tar.py
+++ b/fsspec/implementations/tests/test_tar.py
@@ -244,3 +244,50 @@ def test_ls_with_folders(compression: str, tmp_path: Path):
             "d/e/f.pdf",
             "d/g.pdf",
         ]
+
+
+@pytest.mark.parametrize(
+    "compression", ["", "gz", "bz2", "xz"], ids=["tar", "tar-gz", "tar-bz2", "tar-xz"]
+)
+def test_ls_with_duplicate_slashes(compression: str, tmp_path: Path):
+    """
+    Members whose names contain redundant duplicate slashes (e.g.
+    ``"a/b//c.txt"``) must still be reachable through the directory listing
+    and openable, rather than becoming silently invisible to
+    ``find``/``glob``/``ls``/``walk``. Regression test for
+    https://github.com/fsspec/filesystem_spec/issues/1947.
+    """
+    tar_data: dict[str, bytes] = {
+        "path/with/extra/slash//test.txt": b"Hello slash!",
+        "regular/file.txt": b"Hello regular!",
+    }
+    if compression:
+        temp_archive_file = tmp_path / f"test_tar_file.tar.{compression}"
+    else:
+        temp_archive_file = tmp_path / "test_tar_file.tar"
+    with open(temp_archive_file, "wb") as fd:
+        with tarfile.open(fileobj=fd, mode=f"w:{compression}") as tf:
+            for tar_file_path, data in tar_data.items():
+                info = tarfile.TarInfo(name=tar_file_path)
+                info.size = len(data)
+                tf.addfile(info, BytesIO(data))
+
+    with open(temp_archive_file, "rb") as fd:
+        fs = TarFileSystem(fd)
+
+        # The duplicate-slash member is discoverable with its slashes collapsed.
+        assert fs.find("/") == [
+            "path/with/extra/slash/test.txt",
+            "regular/file.txt",
+        ]
+        assert fs.glob("path/**/*.txt") == ["path/with/extra/slash/test.txt"]
+        assert fs.ls("path/with/extra/slash", detail=False) == [
+            "path/with/extra/slash/test.txt"
+        ]
+
+        # The intermediate directory is inferred without a trailing slash.
+        assert fs.isdir("path/with/extra/slash")
+
+        # It can be opened both by its normalised name and its original name.
+        assert fs.cat("path/with/extra/slash/test.txt") == b"Hello slash!"
+        assert fs.cat("path/with/extra/slash//test.txt") == b"Hello slash!"


### PR DESCRIPTION
## Summary

Fixes #1947.

A tar member whose name contains **redundant consecutive slashes** (e.g. `path/with/extra/slash//test.txt`) was silently invisible to `ls`, `find`, `glob` and `walk`. As a result `fsspec.open_files("tar://**/*::archive.tar")` returned **zero** files for such archives, even though the file could be opened by its exact name.

## Reproducer (from the issue)

```python
import fsspec, tarfile

with tarfile.open("test_w_extraslash.tar", "w") as tar:
    tar.add("test.txt", arcname="path/with/extra/slash//test.txt")

of = fsspec.open_files("tar://**/*::test_w_extraslash.tar")
# before: <List of 0 OpenFile instances>
# after:  <List of 1 OpenFile instances>
```

## Root cause

The raw member name (including the `//`) was used both as the `self.index` key and to derive the directory structure in `_get_dirs`. `AbstractFileSystem._parent("a/b//c.txt")` returns `"a/b/"` — **with a trailing slash** — because `rsplit("/", 1)` splits on the second slash of the `//`. So:

- the inferred parent-directory key became `path/with/extra/slash/` (trailing slash), which never matched a listing of `path/with/extra/slash`, and
- the member's own computed root carried the same trailing slash.

The entry therefore fell out of every directory-traversal comparison in `AbstractArchiveFileSystem` and was unreachable through `ls`/`find`/`glob`/`walk` — while still openable by its exact name (which is why direct access appeared to work).

## Fix

Normalise the filesystem-facing name by collapsing runs of slashes (new `_collapse_slashes` helper) when building both `self.index` and `dir_cache`, **while retaining the original member name** so `tar.extractfile()` still receives the exact archive key. `_open` normalises its lookup path too, so a member is openable by either:

- its normalised name (`path/with/extra/slash/test.txt`, as now returned by `find`/`glob`), or
- its original name (`path/with/extra/slash//test.txt`) — backwards compatible.

This matches the approach the maintainer agreed with in the issue thread ("normalizing the look-up name, while keeping the original tar key for the actual extraction").

## Before / after

| call | before | after |
|------|--------|-------|
| `fs.find("/")` | `[]` | `['path/with/extra/slash/test.txt']` |
| `fs.glob("**/*")` | `['path', 'path/with', 'path/with/extra']` | `[..., 'path/with/extra/slash', 'path/with/extra/slash/test.txt']` |
| `fs.ls("path/with/extra/slash")` | `[]` | `['path/with/extra/slash/test.txt']` |
| `open_files("tar://**/*::…")` | 0 files | 1 file |
| `fs.open(".../slash//test.txt")` | works | works (unchanged) |

Normal single-slash archives are unaffected.

## Tests

Adds `test_ls_with_duplicate_slashes`, parametrized over all four tar compressions (`tar`, `tar.gz`, `tar.bz2`, `tar.xz`), asserting discoverability via `find`/`glob`/`ls`, directory inference via `isdir`, and openability by both name forms.

Proven to guard the bug (source stashed, test kept):

```
# without the fix
FAILED fsspec/implementations/tests/test_tar.py::test_ls_with_duplicate_slashes[tar]
FAILED ...[tar-gz]  FAILED ...[tar-bz2]  FAILED ...[tar-xz]
4 failed
# with the fix
4 passed
```

Full local verification (py3.13):

- `test_tar.py`, `test_archive.py`, `test_zip.py` + memory/local/api: **328 passed, 32 skipped, 1 xfailed**, no regressions.
- `ruff check` and `ruff format --check` clean on both changed files.

Diff is +76/−6 across `fsspec/implementations/tar.py` and its test module.
