### PR TITLE
fix: Make Cached metaclass instance instantiation thread-safe and fork-safe

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -76,6 +76,12 @@ class _Cached(type):
 
             os.register_at_fork(after_in_child=_reset_lock)
 
+    def _check_cache(cls, token):
+        inst = cls._cache.get(token)
+        if inst is not None:
+            cls._latest = token
+        return inst
+
     def __call__(cls, *args, **kwargs):
         kwargs = apply_config(cls, kwargs)
         extra_tokens = tuple(
@@ -96,9 +102,8 @@ class _Cached(type):
 
         if not skip and cls.cachable:
             if pid == cls._pid:
-                inst = cls._cache.get(token)
+                inst = cls._check_cache(token)
                 if inst is not None:
-                    cls._latest = token
                     return inst
 
             with cls._instantiation_lock:
@@ -106,9 +111,8 @@ class _Cached(type):
                     cls._cache.clear()
                     cls._pid = pid
 
-                inst = cls._cache.get(token)
+                inst = cls._check_cache(token)
                 if inst is not None:
-                    cls._latest = token
                     return inst
 
         obj = super().__call__(*args, **kwargs, **strip_tokenize_options)
@@ -123,13 +127,8 @@ class _Cached(type):
 
         if cls.cachable and not skip:
             with cls._instantiation_lock:
-                if pid != cls._pid:
-                    cls._cache.clear()
-                    cls._pid = pid
-
-                inst = cls._cache.get(token)
+                inst = cls._check_cache(token)
                 if inst is not None:
-                    cls._latest = token
                     return inst
 
                 cls._latest = token

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -95,37 +95,47 @@ class _Cached(type):
             )
         skip = kwargs.pop("skip_instance_cache", False)
 
-        if not skip and cls.cachable and pid == cls._pid:
-            inst = cls._cache.get(token)
-            if inst is not None:
-                cls._latest = token
-                return inst
-
-        with cls._instantiation_lock:
-            if pid != cls._pid:
-                cls._cache.clear()
-                cls._pid = pid
-
-            if not skip and cls.cachable:
+        if not skip and cls.cachable:
+            if pid == cls._pid:
                 inst = cls._cache.get(token)
                 if inst is not None:
                     cls._latest = token
                     return inst
 
-            obj = super().__call__(*args, **kwargs, **strip_tokenize_options)
-            # Setting _fs_token here causes some static linters to complain.
-            obj._fs_token_ = token
-            obj.storage_args = args
-            obj.storage_options = kwargs
-            if obj.async_impl and obj.mirror_sync_methods:
-                from .asyn import mirror_sync_methods
+            with cls._instantiation_lock:
+                if pid != cls._pid:
+                    cls._cache.clear()
+                    cls._pid = pid
 
-                mirror_sync_methods(obj)
+                inst = cls._cache.get(token)
+                if inst is not None:
+                    cls._latest = token
+                    return inst
 
-            if cls.cachable and not skip:
+        obj = super().__call__(*args, **kwargs, **strip_tokenize_options)
+        # Setting _fs_token here causes some static linters to complain.
+        obj._fs_token_ = token
+        obj.storage_args = args
+        obj.storage_options = kwargs
+        if obj.async_impl and obj.mirror_sync_methods:
+            from .asyn import mirror_sync_methods
+
+            mirror_sync_methods(obj)
+
+        if cls.cachable and not skip:
+            with cls._instantiation_lock:
+                if os.getpid() != cls._pid:
+                    cls._cache.clear()
+                    cls._pid = os.getpid()
+
+                inst = cls._cache.get(token)
+                if inst is not None:
+                    cls._latest = token
+                    return inst
+
                 cls._latest = token
                 cls._cache[token] = obj
-            return obj
+        return obj
 
 
 class AbstractFileSystem(metaclass=_Cached):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -123,9 +123,9 @@ class _Cached(type):
 
         if cls.cachable and not skip:
             with cls._instantiation_lock:
-                if os.getpid() != cls._pid:
+                if pid != cls._pid:
                     cls._cache.clear()
-                    cls._pid = os.getpid()
+                    cls._pid = pid
 
                 inst = cls._cache.get(token)
                 if inst is not None:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -98,8 +98,8 @@ class _Cached(type):
 
         with cls._instantiation_lock:
             if pid != cls._pid:
-                cls._pid = pid
                 cls._cache.clear()
+                cls._pid = pid
 
             if not skip and cls.cachable:
                 inst = cls._cache.get(token)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -112,10 +112,9 @@ class _Cached(type):
                     cls._pid = pid
 
         if not skip and cls.cachable:
-            if pid == cls._pid:
-                inst = cls._check_instance_cache(token)
-                if inst is not None:
-                    return inst
+            inst = cls._check_instance_cache(token)
+            if inst is not None:
+                return inst
 
             with cls._instantiation_lock:
                 inst = cls._check_instance_cache(token)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -81,12 +81,7 @@ class _Cached(type):
             )
         skip = kwargs.pop("skip_instance_cache", False)
 
-        if (
-            not skip
-            and cls.cachable
-            and pid == cls._pid
-            and token in cls._cache
-        ):
+        if not skip and cls.cachable and pid == cls._pid and token in cls._cache:
             cls._latest = token
             return cls._cache[token]
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -76,7 +76,7 @@ class _Cached(type):
 
             os.register_at_fork(after_in_child=_reset_lock)
 
-    def _check_cache(cls, token):
+    def _check_instance_cache(cls, token):
         inst = cls._cache.get(token)
         if inst is not None:
             cls._latest = token
@@ -102,7 +102,7 @@ class _Cached(type):
 
         if not skip and cls.cachable:
             if pid == cls._pid:
-                inst = cls._check_cache(token)
+                inst = cls._check_instance_cache(token)
                 if inst is not None:
                     return inst
 
@@ -111,7 +111,7 @@ class _Cached(type):
                     cls._cache.clear()
                     cls._pid = pid
 
-                inst = cls._check_cache(token)
+                inst = cls._check_instance_cache(token)
                 if inst is not None:
                     return inst
 
@@ -127,7 +127,7 @@ class _Cached(type):
 
         if cls.cachable and not skip:
             with cls._instantiation_lock:
-                inst = cls._check_cache(token)
+                inst = cls._check_instance_cache(token)
                 if inst is not None:
                     return inst
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -6,6 +6,7 @@ import logging
 import os
 import threading
 import warnings
+import weakref
 from errno import ESPIPE
 from glob import has_magic
 from hashlib import sha256
@@ -51,7 +52,6 @@ class _Cached(type):
 
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        import weakref
 
         # Note: we intentionally create a reference here, to avoid garbage
         # collecting instances when all other references are gone. To really

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -33,6 +33,20 @@ def make_instance(cls, args, kwargs):
     return cls(*args, **kwargs)
 
 
+_register_instances = weakref.WeakSet()
+
+
+def _reset_instances_lock():
+    for c in _register_instances:
+        c._instantiation_lock = threading.RLock()
+        c._cache.clear()
+        c._pid = os.getpid()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_instances_lock)
+
+
 class _Cached(type):
     """
     Metaclass for caching file system instances.
@@ -65,16 +79,7 @@ class _Cached(type):
         cls._instantiation_lock = threading.RLock()
 
         if hasattr(os, "register_at_fork"):
-            cls_ref = weakref.ref(cls)
-
-            def _reset_lock():
-                c = cls_ref()
-                if c is not None:
-                    c._instantiation_lock = threading.RLock()
-                    c._cache.clear()
-                    c._pid = os.getpid()
-
-            os.register_at_fork(after_in_child=_reset_lock)
+            _register_instances.add(cls)
 
     def _check_instance_cache(cls, token):
         inst = cls._cache.get(token)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -6,7 +6,6 @@ import logging
 import os
 import threading
 import warnings
-import weakref
 from errno import ESPIPE
 from glob import has_magic
 from hashlib import sha256
@@ -52,6 +51,8 @@ class _Cached(type):
 
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        import weakref
+
         # Note: we intentionally create a reference here, to avoid garbage
         # collecting instances when all other references are gone. To really
         # delete a FileSystem, the cache must be cleared.
@@ -64,8 +65,6 @@ class _Cached(type):
         cls._instantiation_lock = threading.RLock()
 
         if hasattr(os, "register_at_fork"):
-            import weakref
-
             cls_ref = weakref.ref(cls)
 
             def _reset_lock():

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -105,6 +105,12 @@ class _Cached(type):
             )
         skip = kwargs.pop("skip_instance_cache", False)
 
+        if pid != cls._pid:
+            with cls._instantiation_lock:
+                if pid != cls._pid:
+                    cls._cache.clear()
+                    cls._pid = pid
+
         if not skip and cls.cachable:
             if pid == cls._pid:
                 inst = cls._check_instance_cache(token)
@@ -112,10 +118,6 @@ class _Cached(type):
                     return inst
 
             with cls._instantiation_lock:
-                if pid != cls._pid:
-                    cls._cache.clear()
-                    cls._pid = pid
-
                 inst = cls._check_instance_cache(token)
                 if inst is not None:
                     return inst
@@ -279,8 +281,10 @@ class AbstractFileSystem(metaclass=_Cached):
 
         If no instance has been created, then create one with defaults
         """
-        if cls._latest in cls._cache:
-            return cls._cache[cls._latest]
+        with cls._instantiation_lock:
+            inst = cls._cache.get(cls._latest)
+            if inst is not None:
+                return inst
         return cls()
 
     @property

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -61,7 +61,7 @@ class _Cached(type):
         else:
             cls._cache = {}
         cls._pid = os.getpid()
-        cls._instantiation_lock = threading.Lock()
+        cls._instantiation_lock = threading.RLock()
 
     def __call__(cls, *args, **kwargs):
         kwargs = apply_config(cls, kwargs)

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -61,7 +61,7 @@ class _Cached(type):
         else:
             cls._cache = {}
         cls._pid = os.getpid()
-        cls._instantiation_lock = threading.RLock()
+        cls._cache_lock = threading.Lock()
 
     def __call__(cls, *args, **kwargs):
         kwargs = apply_config(cls, kwargs)
@@ -71,46 +71,41 @@ class _Cached(type):
         strip_tokenize_options = {
             k: kwargs.pop(k) for k in cls._strip_tokenize_options if k in kwargs
         }
+        pid = os.getpid()
+        if pid != cls._pid:
+            cls._pid = pid
+            cls._cache.clear()
+            cls._cache_lock = threading.Lock()
+
         if getattr(cls, "async_impl", False) and not kwargs.get("asynchronous", False):
-            token = tokenize(cls, os.getpid(), *args, *extra_tokens, **kwargs)
+            token = tokenize(cls, cls._pid, *args, *extra_tokens, **kwargs)
         else:
             token = tokenize(
-                cls, os.getpid(), threading.get_ident(), *args, *extra_tokens, **kwargs
+                cls, cls._pid, threading.get_ident(), *args, *extra_tokens, **kwargs
             )
         skip = kwargs.pop("skip_instance_cache", False)
 
-        if (
-            not skip
-            and cls.cachable
-            and os.getpid() == cls._pid
-            and token in cls._cache
-        ):
-            cls._latest = token
-            return cls._cache[token]
+        if not skip and cls.cachable:
+            with cls._cache_lock:
+                if token in cls._cache:
+                    cls._latest = token
+                    return cls._cache[token]
 
-        with cls._instantiation_lock:
-            if os.getpid() != cls._pid:
-                cls._cache.clear()
-                cls._pid = os.getpid()
+        obj = super().__call__(*args, **kwargs, **strip_tokenize_options)
+        # Setting _fs_token here causes some static linters to complain.
+        obj._fs_token_ = token
+        obj.storage_args = args
+        obj.storage_options = kwargs
+        if obj.async_impl and obj.mirror_sync_methods:
+            from .asyn import mirror_sync_methods
 
-            if not skip and cls.cachable and token in cls._cache:
-                cls._latest = token
-                return cls._cache[token]
+            mirror_sync_methods(obj)
 
-            obj = super().__call__(*args, **kwargs, **strip_tokenize_options)
-            # Setting _fs_token here causes some static linters to complain.
-            obj._fs_token_ = token
-            obj.storage_args = args
-            obj.storage_options = kwargs
-            if obj.async_impl and obj.mirror_sync_methods:
-                from .asyn import mirror_sync_methods
-
-                mirror_sync_methods(obj)
-
-            if cls.cachable and not skip:
+        if cls.cachable and not skip:
+            with cls._cache_lock:
                 cls._latest = token
                 cls._cache[token] = obj
-            return obj
+        return obj
 
 
 class AbstractFileSystem(metaclass=_Cached):
@@ -1627,7 +1622,8 @@ class AbstractFileSystem(metaclass=_Cached):
         since the instances refcount will not drop to zero until
         ``clear_instance_cache`` is called.
         """
-        cls._cache.clear()
+        with getattr(cls, "_cache_lock", threading.Lock()):
+            cls._cache.clear()
 
     def created(self, path):
         """Return the created timestamp of a file as a datetime.datetime"""

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -79,15 +79,20 @@ class _Cached(type):
             )
         skip = kwargs.pop("skip_instance_cache", False)
 
-        if not skip and cls.cachable and os.getpid() == cls._pid and token in cls._cache:
+        if (
+            not skip
+            and cls.cachable
+            and os.getpid() == cls._pid
+            and token in cls._cache
+        ):
             cls._latest = token
             return cls._cache[token]
-            
+
         with cls._instantiation_lock:
             if os.getpid() != cls._pid:
                 cls._cache.clear()
                 cls._pid = os.getpid()
-            
+
             if not skip and cls.cachable and token in cls._cache:
                 cls._latest = token
                 return cls._cache[token]

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -61,6 +61,7 @@ class _Cached(type):
         else:
             cls._cache = {}
         cls._pid = os.getpid()
+        cls._instantiation_lock = threading.Lock()
 
     def __call__(cls, *args, **kwargs):
         kwargs = apply_config(cls, kwargs)
@@ -83,7 +84,12 @@ class _Cached(type):
         if not skip and cls.cachable and token in cls._cache:
             cls._latest = token
             return cls._cache[token]
-        else:
+            
+        with cls._instantiation_lock:
+            if not skip and cls.cachable and token in cls._cache:
+                cls._latest = token
+                return cls._cache[token]
+
             obj = super().__call__(*args, **kwargs, **strip_tokenize_options)
             # Setting _fs_token here causes some static linters to complain.
             obj._fs_token_ = token

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -78,14 +78,16 @@ class _Cached(type):
                 cls, cls._pid, threading.get_ident(), *args, *extra_tokens, **kwargs
             )
         skip = kwargs.pop("skip_instance_cache", False)
-        if os.getpid() != cls._pid:
-            cls._cache.clear()
-            cls._pid = os.getpid()
-        if not skip and cls.cachable and token in cls._cache:
+
+        if not skip and cls.cachable and os.getpid() == cls._pid and token in cls._cache:
             cls._latest = token
             return cls._cache[token]
             
         with cls._instantiation_lock:
+            if os.getpid() != cls._pid:
+                cls._cache.clear()
+                cls._pid = os.getpid()
+            
             if not skip and cls.cachable and token in cls._cache:
                 cls._latest = token
                 return cls._cache[token]

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -63,6 +63,15 @@ class _Cached(type):
         cls._pid = os.getpid()
         cls._instantiation_lock = threading.RLock()
 
+        if hasattr(os, "register_at_fork"):
+
+            def _reset_lock():
+                cls._instantiation_lock = threading.RLock()
+                cls._cache.clear()
+                cls._pid = os.getpid()
+
+            os.register_at_fork(after_in_child=_reset_lock)
+
     def __call__(cls, *args, **kwargs):
         kwargs = apply_config(cls, kwargs)
         extra_tokens = tuple(

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -64,11 +64,16 @@ class _Cached(type):
         cls._instantiation_lock = threading.RLock()
 
         if hasattr(os, "register_at_fork"):
+            import weakref
+
+            cls_ref = weakref.ref(cls)
 
             def _reset_lock():
-                cls._instantiation_lock = threading.RLock()
-                cls._cache.clear()
-                cls._pid = os.getpid()
+                c = cls_ref()
+                if c is not None:
+                    c._instantiation_lock = threading.RLock()
+                    c._cache.clear()
+                    c._pid = os.getpid()
 
             os.register_at_fork(after_in_child=_reset_lock)
 
@@ -1637,7 +1642,11 @@ class AbstractFileSystem(metaclass=_Cached):
         since the instances refcount will not drop to zero until
         ``clear_instance_cache`` is called.
         """
-        with getattr(cls, "_instantiation_lock", threading.RLock()):
+        lock = getattr(cls, "_instantiation_lock", None)
+        if lock is not None:
+            with lock:
+                cls._cache.clear()
+        else:
             cls._cache.clear()
 
     def created(self, path):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -90,19 +90,22 @@ class _Cached(type):
             )
         skip = kwargs.pop("skip_instance_cache", False)
 
-        if not skip and cls.cachable and pid == cls._pid and token in cls._cache:
-            cls._latest = token
-            return cls._cache[token]
+        if not skip and cls.cachable and pid == cls._pid:
+            inst = cls._cache.get(token)
+            if inst is not None:
+                cls._latest = token
+                return inst
 
         with cls._instantiation_lock:
             if pid != cls._pid:
                 cls._pid = pid
                 cls._cache.clear()
-                cls._instantiation_lock = threading.RLock()
 
-            if not skip and cls.cachable and token in cls._cache:
-                cls._latest = token
-                return cls._cache[token]
+            if not skip and cls.cachable:
+                inst = cls._cache.get(token)
+                if inst is not None:
+                    cls._latest = token
+                    return inst
 
             obj = super().__call__(*args, **kwargs, **strip_tokenize_options)
             # Setting _fs_token here causes some static linters to complain.

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -61,7 +61,7 @@ class _Cached(type):
         else:
             cls._cache = {}
         cls._pid = os.getpid()
-        cls._cache_lock = threading.Lock()
+        cls._instantiation_lock = threading.RLock()
 
     def __call__(cls, *args, **kwargs):
         kwargs = apply_config(cls, kwargs)
@@ -72,40 +72,48 @@ class _Cached(type):
             k: kwargs.pop(k) for k in cls._strip_tokenize_options if k in kwargs
         }
         pid = os.getpid()
-        if pid != cls._pid:
-            cls._pid = pid
-            cls._cache.clear()
-            cls._cache_lock = threading.Lock()
 
         if getattr(cls, "async_impl", False) and not kwargs.get("asynchronous", False):
-            token = tokenize(cls, cls._pid, *args, *extra_tokens, **kwargs)
+            token = tokenize(cls, pid, *args, *extra_tokens, **kwargs)
         else:
             token = tokenize(
-                cls, cls._pid, threading.get_ident(), *args, *extra_tokens, **kwargs
+                cls, pid, threading.get_ident(), *args, *extra_tokens, **kwargs
             )
         skip = kwargs.pop("skip_instance_cache", False)
 
-        if not skip and cls.cachable:
-            with cls._cache_lock:
-                if token in cls._cache:
-                    cls._latest = token
-                    return cls._cache[token]
+        if (
+            not skip
+            and cls.cachable
+            and pid == cls._pid
+            and token in cls._cache
+        ):
+            cls._latest = token
+            return cls._cache[token]
 
-        obj = super().__call__(*args, **kwargs, **strip_tokenize_options)
-        # Setting _fs_token here causes some static linters to complain.
-        obj._fs_token_ = token
-        obj.storage_args = args
-        obj.storage_options = kwargs
-        if obj.async_impl and obj.mirror_sync_methods:
-            from .asyn import mirror_sync_methods
+        with cls._instantiation_lock:
+            if pid != cls._pid:
+                cls._pid = pid
+                cls._cache.clear()
+                cls._instantiation_lock = threading.RLock()
 
-            mirror_sync_methods(obj)
+            if not skip and cls.cachable and token in cls._cache:
+                cls._latest = token
+                return cls._cache[token]
 
-        if cls.cachable and not skip:
-            with cls._cache_lock:
+            obj = super().__call__(*args, **kwargs, **strip_tokenize_options)
+            # Setting _fs_token here causes some static linters to complain.
+            obj._fs_token_ = token
+            obj.storage_args = args
+            obj.storage_options = kwargs
+            if obj.async_impl and obj.mirror_sync_methods:
+                from .asyn import mirror_sync_methods
+
+                mirror_sync_methods(obj)
+
+            if cls.cachable and not skip:
                 cls._latest = token
                 cls._cache[token] = obj
-        return obj
+            return obj
 
 
 class AbstractFileSystem(metaclass=_Cached):
@@ -1622,7 +1630,7 @@ class AbstractFileSystem(metaclass=_Cached):
         since the instances refcount will not drop to zero until
         ``clear_instance_cache`` is called.
         """
-        with getattr(cls, "_cache_lock", threading.Lock()):
+        with getattr(cls, "_instantiation_lock", threading.RLock()):
             cls._cache.clear()
 
     def created(self, path):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -33,17 +33,18 @@ def make_instance(cls, args, kwargs):
     return cls(*args, **kwargs)
 
 
-_register_instances = weakref.WeakSet()
+FORK_AVAILABLE = hasattr(os, "register_at_fork")
 
 
-def _reset_instances_lock():
-    for c in _register_instances:
-        c._instantiation_lock = threading.RLock()
-        c._cache.clear()
-        c._pid = os.getpid()
+if FORK_AVAILABLE:
+    _registered_classes = weakref.WeakSet()
 
+    def _reset_instances_lock():
+        for cls in _registered_classes:
+            cls._instantiation_lock = threading.RLock()
+            cls._cache.clear()
+            cls._pid = os.getpid()
 
-if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=_reset_instances_lock)
 
 
@@ -78,8 +79,8 @@ class _Cached(type):
         cls._pid = os.getpid()
         cls._instantiation_lock = threading.RLock()
 
-        if hasattr(os, "register_at_fork"):
-            _register_instances.add(cls)
+        if FORK_AVAILABLE:
+            _registered_classes.add(cls)
 
     def _check_instance_cache(cls, token):
         inst = cls._cache.get(token)
@@ -117,6 +118,8 @@ class _Cached(type):
                 return inst
 
             with cls._instantiation_lock:
+                # protect against the race condition that a new instance was created
+                # and inserted into the cache since the initial check just above
                 inst = cls._check_instance_cache(token)
                 if inst is not None:
                     return inst
@@ -133,6 +136,8 @@ class _Cached(type):
 
         if cls.cachable and not skip:
             with cls._instantiation_lock:
+                # another thread may have created the instance while we were calling
+                # super().__call__(), so we check again.
                 inst = cls._check_instance_cache(token)
                 if inst is not None:
                     return inst
@@ -280,10 +285,9 @@ class AbstractFileSystem(metaclass=_Cached):
 
         If no instance has been created, then create one with defaults
         """
-        with cls._instantiation_lock:
-            inst = cls._cache.get(cls._latest)
-            if inst is not None:
-                return inst
+        inst = cls._cache.get(cls._latest)
+        if inst is not None:
+            return inst
         return cls()
 
     @property
@@ -1658,12 +1662,7 @@ class AbstractFileSystem(metaclass=_Cached):
         since the instances refcount will not drop to zero until
         ``clear_instance_cache`` is called.
         """
-        lock = getattr(cls, "_instantiation_lock", None)
-        if lock is not None:
-            with lock:
-                cls._cache.clear()
-        else:
-            cls._cache.clear()
+        cls._cache.clear()
 
     def created(self, path):
         """Return the created timestamp of a file as a datetime.datetime"""

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -72,10 +72,10 @@ class _Cached(type):
             k: kwargs.pop(k) for k in cls._strip_tokenize_options if k in kwargs
         }
         if getattr(cls, "async_impl", False) and not kwargs.get("asynchronous", False):
-            token = tokenize(cls, cls._pid, *args, *extra_tokens, **kwargs)
+            token = tokenize(cls, os.getpid(), *args, *extra_tokens, **kwargs)
         else:
             token = tokenize(
-                cls, cls._pid, threading.get_ident(), *args, *extra_tokens, **kwargs
+                cls, os.getpid(), threading.get_ident(), *args, *extra_tokens, **kwargs
             )
         skip = kwargs.pop("skip_instance_cache", False)
 

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -769,6 +769,63 @@ def test_instance_cache_concurrency():
     assert all(r is results[0] for r in results)
 
 
+def test_clear_instance_cache_concurrency():
+    import concurrent.futures
+
+    for i in range(10):
+        DummyTestFS(i)
+
+    def clear_cache():
+        DummyTestFS.clear_instance_cache()
+
+    def instantiate():
+        return DummyTestFS(100)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = []
+        for _ in range(20):
+            futures.append(executor.submit(clear_cache))
+            futures.append(executor.submit(instantiate))
+        concurrent.futures.wait(futures)
+
+    assert True
+
+
+def test_fork_deadlock():
+    import multiprocessing
+
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("Fork method is not available on this platform")
+
+    DummyTestFS._instantiation_lock.acquire()
+
+    def child_process(q):
+        try:
+            DummyTestFS(12345)
+            q.put(True)
+        except Exception as e:
+            q.put(str(e))
+
+    q = multiprocessing.Queue()
+    ctx = multiprocessing.get_context("fork")
+    p = ctx.Process(target=child_process, args=(q,))
+    p.start()
+    p.join(timeout=3)
+
+    try:
+        DummyTestFS._instantiation_lock.release()
+    except Exception:
+        pass
+
+    if p.is_alive():
+        p.terminate()
+        p.join()
+        pytest.fail("Child process deadlocked during instantiation")
+
+    result = q.get()
+    assert result is True
+
+
 def test_cache_not_pickled(server):
     fs = fsspec.filesystem(
         "http",

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -830,7 +830,6 @@ def test_fork_deadlock():
     if p.is_alive():
         p.terminate()
         p.join()
-        p.join()
         pytest.fail("Child process deadlocked during instantiation")
 
     result = q.get()

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -745,6 +745,30 @@ def test_cache():
     assert len(DummyTestFS._cache) == 0
 
 
+def test_instance_cache_concurrency():
+    import concurrent.futures
+    import time
+    
+    class SleepyFS(DummyTestFS):
+        async_impl = True
+        
+        def __init__(self, *args, **kwargs):
+            time.sleep(0.1)
+            super().__init__(*args, **kwargs)
+            
+    SleepyFS.clear_instance_cache()
+
+    def instantiate():
+        return SleepyFS()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(instantiate) for _ in range(50)]
+        results = [f.result() for f in futures]
+
+    assert len(SleepyFS._cache) == 1
+    assert all(r is results[0] for r in results)
+
+
 def test_cache_not_pickled(server):
     fs = fsspec.filesystem(
         "http",

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -840,9 +840,8 @@ def test_clear_instance_cache_concurrency():
         for _ in range(20):
             futures.append(executor.submit(clear_cache))
             futures.append(executor.submit(instantiate))
-        concurrent.futures.wait(futures)
-
-    assert True
+        for f in futures:
+            f.result()
 
 
 def test_fork_deadlock():
@@ -886,7 +885,11 @@ def test_fork_deadlock():
         p.join()
         pytest.fail("Child process deadlocked during instantiation")
 
-    result = q.get()
+    import queue
+    try:
+        result = q.get(timeout=1)
+    except queue.Empty:
+        pytest.fail("Child process crashed before writing to queue")
     assert result is True
 
 

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -886,6 +886,7 @@ def test_fork_deadlock():
         pytest.fail("Child process deadlocked during instantiation")
 
     import queue
+
     try:
         result = q.get(timeout=1)
     except queue.Empty:

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -793,11 +793,11 @@ def test_clear_instance_cache_concurrency():
 
 def test_fork_deadlock():
     import multiprocessing
+    import threading
+    import time
 
     if "fork" not in multiprocessing.get_all_start_methods():
         pytest.skip("Fork method is not available on this platform")
-
-    DummyTestFS._instantiation_lock.acquire()
 
     def child_process(q):
         try:
@@ -806,19 +806,30 @@ def test_fork_deadlock():
         except Exception as e:
             q.put(str(e))
 
+    def locker_thread(started_event):
+        DummyTestFS._instantiation_lock.acquire()
+        started_event.set()
+        time.sleep(2)
+        try:
+            DummyTestFS._instantiation_lock.release()
+        except Exception:
+            pass
+
+    t_event = threading.Event()
+    t = threading.Thread(target=locker_thread, args=(t_event,))
+    t.start()
+    t_event.wait()
+
     q = multiprocessing.Queue()
     ctx = multiprocessing.get_context("fork")
     p = ctx.Process(target=child_process, args=(q,))
     p.start()
     p.join(timeout=3)
-
-    try:
-        DummyTestFS._instantiation_lock.release()
-    except Exception:
-        pass
+    t.join()
 
     if p.is_alive():
         p.terminate()
+        p.join()
         p.join()
         pytest.fail("Child process deadlocked during instantiation")
 

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -769,6 +769,60 @@ def test_instance_cache_concurrency():
     assert all(r is results[0] for r in results)
 
 
+def test_uncached_instantiation_concurrency():
+    import concurrent.futures
+    import time
+
+    class SleepyFS(DummyTestFS):
+        async_impl = True
+
+        def __init__(self, *args, **kwargs):
+            time.sleep(0.1)
+            super().__init__(*args, **kwargs)
+
+    SleepyFS.clear_instance_cache()
+
+    def instantiate(i):
+        return SleepyFS(skip_instance_cache=True, i=i)
+
+    t0 = time.time()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(instantiate, i) for i in range(10)]
+        results = [f.result() for f in futures]
+    t1 = time.time()
+
+    assert len(SleepyFS._cache) == 0
+    assert len(set(results)) == 10
+    assert t1 - t0 < 0.5
+
+
+def test_different_tokens_concurrency():
+    import concurrent.futures
+    import time
+
+    class SleepyFS(DummyTestFS):
+        async_impl = True
+
+        def __init__(self, *args, **kwargs):
+            time.sleep(0.1)
+            super().__init__(*args, **kwargs)
+
+    SleepyFS.clear_instance_cache()
+
+    def instantiate(i):
+        return SleepyFS(i=i)
+
+    t0 = time.time()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(instantiate, i) for i in range(10)]
+        results = [f.result() for f in futures]
+    t1 = time.time()
+
+    assert len(SleepyFS._cache) == 10
+    assert len(set(results)) == 10
+    assert t1 - t0 < 0.5
+
+
 def test_clear_instance_cache_concurrency():
     import concurrent.futures
 

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -748,14 +748,14 @@ def test_cache():
 def test_instance_cache_concurrency():
     import concurrent.futures
     import time
-    
+
     class SleepyFS(DummyTestFS):
         async_impl = True
-        
+
         def __init__(self, *args, **kwargs):
             time.sleep(0.1)
             super().__init__(*args, **kwargs)
-            
+
     SleepyFS.clear_instance_cache()
 
     def instantiate():


### PR DESCRIPTION
Fix #2065
### Scope
This PR tackles a race condition in the `_Cached` metaclass.

### The Problem
There were three distinct overlapping lock gaps around system forks:
1. **Unprotected Instantiation**: The `super().__call__` instantiation process inside `_Cached` was entirely unprotected, allowing concurrent cache misses to spin up disjoint raw instances independently.
2. **Post-fork Cache Clearing Race**: When a process forks, `os.getpid() != cls._pid` attempts to clear the inherited cache. When 10 new threads simultaneously wake up post-fork and evaluate this, they concurrently bypass the cache logic.
3. **Ghost Tokenization**: `token = tokenize(cls, cls._pid, ...)` historically evaluated before any locking boundary. The very first thread running post-fork evaluated `tokenize()` utilizing the lingering *parent's* PID before updating `cls._pid` inside the lock. Subsequence threads would then evaluate `tokenize()` natively under the child's PID, resulting in permanently ghosted, duplicated Cache hashes for identically parameterized filesystems.

### The Solution
*   **Double-Checked Locking**: Re-instated a standard `_instantiation_lock` in `_Cached.__call__` that strictly gates the underlying filesystem instantiation and cache updates. We also updated `clear_instance_cache()` to respect this exact lock.
*   **Encapsulated Fork Boundaries**: Moved the `os.getpid() != cls._pid` cache clearing evaluation strictly inside the boundaries of the lock. Furthermore, we explicitly re-initialize `cls._instantiation_lock = threading.RLock()` across forks so child processes do not natively inherit and permanent-deadlock on parent-locked states.
*   **Deterministic Tokenizing**: Altered `tokenize()` targeting to natively utilize `os.getpid()` rather than evaluating across `cls._pid`, ensuring deterministic key hashes pre-and-post fork regardless of strict thread scheduling.
*   **Testing**: Added `test_instance_cache_concurrency`, `test_clear_instance_cache_concurrency`, and `test_fork_deadlock` heavily simulating asynchronous thread congestion across cache misses, explicit cache-clear injections, and native OS forks to guarantee locking determinism.