### PR TITLE
Honor caller-owned outfile in get_file

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -922,21 +922,25 @@ class AbstractFileSystem(metaclass=_Cached):
         else:
             return self.cat_file(paths[0], **kwargs)
 
-    def get_file(self, rpath, lpath, callback=DEFAULT_CALLBACK, outfile=None, **kwargs):
+    def get_file(
+        self, rpath, lpath=None, callback=DEFAULT_CALLBACK, outfile=None, **kwargs
+    ):
         """Copy single remote file to local"""
         from .implementations.local import LocalFileSystem
 
-        if isfilelike(lpath):
+        if outfile is None and isfilelike(lpath):
             outfile = lpath
-        elif self.isdir(rpath):
+        elif outfile is None and self.isdir(rpath):
             os.makedirs(lpath, exist_ok=True)
             return None
 
-        fs = LocalFileSystem(auto_mkdir=True)
-        fs.makedirs(fs._parent(lpath), exist_ok=True)
+        if outfile is None:
+            fs = LocalFileSystem(auto_mkdir=True)
+            fs.makedirs(fs._parent(lpath), exist_ok=True)
 
         with self.open(rpath, "rb", **kwargs) as f1:
-            if outfile is None:
+            close_outfile = outfile is None
+            if close_outfile:
                 outfile = open(lpath, "wb")
 
             try:
@@ -949,7 +953,7 @@ class AbstractFileSystem(metaclass=_Cached):
                         segment_len = len(data)
                     callback.relative_update(segment_len)
             finally:
-                if not isfilelike(lpath):
+                if close_outfile:
                     outfile.close()
 
     def get(

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -1,4 +1,5 @@
 import glob
+import io
 import json
 import os
 import pickle
@@ -1211,6 +1212,31 @@ def test_dummy_callbacks_file(tmpdir):
     callback.events.clear()
 
     assert destination.read_text("utf-8") == "x" * 100
+
+
+def test_get_file_to_supplied_outfile(tmpdir):
+    fs = DummyOpenFS()
+    source = tmpdir / "source.txt"
+    source.write_text("data", "utf-8")
+    outfile = io.BytesIO()
+
+    fs.get_file(source, outfile=outfile)
+
+    assert not outfile.closed
+    assert outfile.getvalue() == b"data"
+
+
+def test_get_file_explicit_outfile_takes_precedence(tmpdir):
+    fs = DummyOpenFS()
+    source = tmpdir / "source.txt"
+    source.write_text("data", "utf-8")
+    lpath = io.BytesIO()
+    outfile = io.BytesIO()
+
+    fs.get_file(source, lpath, outfile=outfile)
+
+    assert lpath.getvalue() == b""
+    assert outfile.getvalue() == b"data"
 
 
 def test_dummy_callbacks_files(tmpdir):


### PR DESCRIPTION
`get_file(..., outfile=stream)` currently still requires and prepares `lpath`, then closes the caller-owned stream; when both are file-like, `lpath` also silently replaces the explicit `outfile`. This lets `outfile` stand in for `lpath`, gives the explicit argument precedence, and only closes streams opened by fsspec. 

Fixes #1841.
