### PR TITLE
Forward ls kwargs from cached filesystems

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -436,8 +436,8 @@ class CachingFileSystem(ChainedFileSystem):
         close()
         f.closed = True
 
-    def ls(self, path, detail=True):
-        return self.fs.ls(path, detail)
+    def ls(self, path, detail=True, **kwargs):
+        return self.fs.ls(path, detail, **kwargs)
 
     def __getattribute__(self, item):
         if item in {

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -172,6 +172,14 @@ def test_constructor_kwargs(tmpdir):
         )
 
 
+def test_whole_file_cache_ls_forwards_kwargs(tmp_path, m, mocker):
+    fs = WholeFileCacheFileSystem(fs=m, cache_storage=str(tmp_path))
+    backend_ls = mocker.spy(m, "ls")
+
+    assert fs.ls("/", detail=False, refresh=True) == []
+    backend_ls.assert_called_once_with("/", False, refresh=True)
+
+
 @pytest.mark.skipif(win, reason="POSIX file permissions")
 @pytest.mark.parametrize("protocol", ["filecache", "simplecache", "blockcache"])
 def test_cache_storage_mode(tmp_path, protocol):


### PR DESCRIPTION
`CachingFileSystem.ls()` rejects backend-specific options such as `refresh`, even though the wrapped filesystem and `SimpleCacheFileSystem` accept them. Forward `**kwargs` to the wrapped `ls()` and cover the behavior with a regression test. Fixes #1737.
