### PR TITLE
Shut down background cache workers on file close

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -799,6 +799,7 @@ class BackgroundBlockCache(BaseCache):
         self._fetch_future_block_number: int | None = None
         self._fetch_future: Future[bytes] | None = None
         self._fetch_future_lock = threading.Lock()
+        self._closed = False
 
     def cache_info(self) -> UpdatableLRU.CacheInfo:
         """
@@ -810,6 +811,23 @@ class BackgroundBlockCache(BaseCache):
             Returned directly from the LRU Cache used internally.
         """
         return self._fetch_block_cached.cache_info()
+
+    def close(self) -> None:
+        """Cancel pending work and shut down the background worker."""
+        with self._fetch_future_lock:
+            if self._closed:
+                return
+            self._closed = True
+            future = self._fetch_future
+            self._fetch_future = None
+            self._fetch_future_block_number = None
+
+        if future is not None:
+            future.cancel()
+        self._thread_executor.shutdown(wait=True, cancel_futures=True)
+
+        # UpdatableLRU stores a bound method and otherwise forms a reference cycle.
+        del self._fetch_block_cached
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__
@@ -827,6 +845,7 @@ class BackgroundBlockCache(BaseCache):
         self._fetch_future_block_number = None
         self._fetch_future = None
         self._fetch_future_lock = threading.Lock()
+        self._closed = False
 
     def _fetch(self, start: int | None, end: int | None) -> bytes:
         if start is None:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -2220,6 +2220,11 @@ class AbstractBufferedFile(io.IOBase):
             return
         try:
             if self.mode == "rb":
+                cache = self.cache
+                if cache is not None:
+                    close = getattr(cache, "close", None)
+                    if callable(close):
+                        close()
                 self.cache = None
             else:
                 if not getattr(self, "forced", True):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -2220,7 +2220,7 @@ class AbstractBufferedFile(io.IOBase):
             return
         try:
             if self.mode == "rb":
-                cache = self.cache
+                cache = getattr(self, "cache", None)
                 if cache is not None:
                     close = getattr(cache, "close", None)
                     if callable(close):

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -4,6 +4,7 @@ import string
 import pytest
 
 from fsspec.caching import (
+    BackgroundBlockCache,
     BlockCache,
     FirstChunkCache,
     MMapCache,
@@ -290,6 +291,40 @@ def test_background(server, monkeypatch):
     f.read(1)
     time.sleep(0.1)  # second block is loading
     assert len(thread_ids) == 2
+
+
+def test_background_shutdown_on_close():
+    import weakref
+
+    from fsspec.spec import AbstractBufferedFile
+
+    data = b"abcdefgh"
+
+    class TestFile(AbstractBufferedFile):
+        DEFAULT_BLOCK_SIZE = 4
+
+        def _fetch_range(self, start, end):
+            return data[start:end]
+
+    f = TestFile(
+        None,
+        "test",
+        mode="rb",
+        cache_type="background",
+        size=len(data),
+    )
+    f.read(1)
+    cache = f.cache
+    assert isinstance(cache, BackgroundBlockCache)
+    cache_ref = weakref.ref(cache)
+    executor = cache._thread_executor
+    del cache
+
+    f.close()
+
+    with pytest.raises(RuntimeError, match="cannot schedule new futures"):
+        executor.submit(lambda: None)
+    assert cache_ref() is None
 
 
 def test_register_cache():


### PR DESCRIPTION
Closing an `AbstractBufferedFile` currently discards its `BackgroundBlockCache` without stopping the executor. Its `UpdatableLRU` also retains a bound cache method, so repeated background-cached reads can retain workers, files, and cached blocks until cyclic GC runs.

This adds idempotent shutdown that cancels pending prefetch work, joins the executor, and breaks the reference cycle before the buffered file drops the cache. The regression test fails on `master` because the executor still accepts work after `close()` and passes once the cache is released.

Fixes #2008.
