### PR TITLE
Fix get_file_extension when a parent directory name contains a dot

### DIFF
--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -348,6 +348,10 @@ def test_get_protocol(par):
         ("file:///home/user/no_extension", ""),
         ("/local/path/to/file.json", "json"),
         ("relative/path/file.yaml", "yaml"),
+        # A "." in a parent directory name is not the file's extension
+        ("/path/to.dir/file", ""),
+        ("s3://bucket.name/data/file", ""),
+        ("/path/to.dir/file.parquet", "parquet"),
     ),
 )
 def test_get_file_extension(url, expected):

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -433,7 +433,9 @@ def get_protocol(url: str) -> str:
 
 def get_file_extension(url: str) -> str:
     url = stringify_path(url)
-    ext_parts = url.rsplit(".", 1)
+    # Only consider the final path component: a "." in a parent directory name
+    # (e.g. "/path/to.dir/file") is not the file's extension.
+    ext_parts = url.rsplit("/", 1)[-1].rsplit(".", 1)
     if len(ext_parts) > 1:
         return ext_parts[-1]
     return ""


### PR DESCRIPTION
`get_file_extension` splits on the last `.` in the entire path, so a `.` in a parent directory name is mistaken for the file's extension:

```python
>>> from fsspec.utils import get_file_extension
>>> get_file_extension("/path/to.dir/file")
'dir/file'   # expected ''  (the file has no extension)
>>> get_file_extension("s3://bucket.name/data/file")
'name/data/file'   # expected ''
```

This splits within the final path component instead, so a file with no extension inside a dotted directory correctly returns `""`. Files that do have an extension are not affected. For example, `"/path/to.dir/file.parquet"` still returns `"parquet"`. Added regression tests.