### PR TITLE
Fix ArrowFSWrapper parent paths for S3

### DIFF
--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -52,6 +52,8 @@ class ArrowFSWrapper(AbstractFileSystem):
         global PYARROW_VERSION
         PYARROW_VERSION = get_package_version_without_import("pyarrow")
         self.fs = fs
+        if fs.type_name == "s3":
+            self.root_marker = ""
         super().__init__(**kwargs)
 
     @property
@@ -61,6 +63,13 @@ class ArrowFSWrapper(AbstractFileSystem):
     @cached_property
     def fsid(self):
         return "hdfs_" + tokenize(self.fs.host, self.fs.port)
+
+    def _parent(self, path):
+        if self.root_marker:
+            return super()._parent(path)
+
+        path = self._strip_protocol(path).lstrip("/")
+        return path.rsplit("/", 1)[0] if "/" in path else self.root_marker
 
     @classmethod
     def _strip_protocol(cls, path):

--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -35,6 +35,7 @@ def wrap_exceptions(func):
 
 
 PYARROW_VERSION = None
+_EMPTY_ROOT_MARKER_FILESYSTEMS = {"gcs", "s3"}
 
 
 class ArrowFSWrapper(AbstractFileSystem):
@@ -52,7 +53,7 @@ class ArrowFSWrapper(AbstractFileSystem):
         global PYARROW_VERSION
         PYARROW_VERSION = get_package_version_without_import("pyarrow")
         self.fs = fs
-        if fs.type_name == "s3":
+        if fs.type_name in _EMPTY_ROOT_MARKER_FILESYSTEMS:
             self.root_marker = ""
         super().__init__(**kwargs)
 
@@ -69,7 +70,7 @@ class ArrowFSWrapper(AbstractFileSystem):
             return super()._parent(path)
 
         path = self._strip_protocol(path).lstrip("/")
-        return path.rsplit("/", 1)[0] if "/" in path else self.root_marker
+        return path.rsplit("/", 1)[0] if "/" in path else ""
 
     @classmethod
     def _strip_protocol(cls, path):

--- a/fsspec/implementations/tests/test_arrow.py
+++ b/fsspec/implementations/tests/test_arrow.py
@@ -28,6 +28,21 @@ def test_protocol():
     assert fss.protocol == "mock"
 
 
+def test_s3_parent_has_no_leading_slash():
+    class S3FileSystem:
+        type_name = "s3"
+
+        def create_dir(self, path, recursive):
+            self.created_path = path
+
+    backend = S3FileSystem()
+    fs = ArrowFSWrapper(backend, skip_instance_cache=True)
+    fs.makedirs(fs._parent("bucket/path/file"))
+
+    assert backend.created_path == "bucket/path"
+    assert fs.root_marker == ""
+
+
 def strip_keys(original_entry):
     entry = original_entry.copy()
     entry.pop("mtime")

--- a/fsspec/implementations/tests/test_arrow.py
+++ b/fsspec/implementations/tests/test_arrow.py
@@ -28,14 +28,16 @@ def test_protocol():
     assert fss.protocol == "mock"
 
 
-def test_s3_parent_has_no_leading_slash():
-    class S3FileSystem:
-        type_name = "s3"
+@pytest.mark.parametrize("type_name", ["gcs", "s3"])
+def test_object_store_parent_has_no_leading_slash(type_name):
+    class ObjectStoreFileSystem:
+        def __init__(self, type_name):
+            self.type_name = type_name
 
         def create_dir(self, path, recursive):
             self.created_path = path
 
-    backend = S3FileSystem()
+    backend = ObjectStoreFileSystem(type_name)
     fs = ArrowFSWrapper(backend, skip_instance_cache=True)
     fs.makedirs(fs._parent("bucket/path/file"))
 


### PR DESCRIPTION
ArrowFSWrapper always inherited `/` as its root marker, so `put()` derived `/bucket/...` parents that pyarrow's S3 backend rejects. S3 wrappers now use an empty instance root marker and resolve parents from that marker; other Arrow backends keep their existing behavior.

Fixes #2015

Tested with the Arrow, spec, core, and mapping test modules (284 passed, 69 skipped, 1 xfailed) and Ruff.
