### PR TITLE
Fix LocalFileSystem directory symlink removal

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 Fixes
 
+- LocalFS: remove directory symlinks without requiring recursive mode (#1299)
 - FTP: preserve filenames containing whitespace in _mlsd2 (#2043)
 - Prevent attribute error for 'forced' before flushing cache (#2042)
 - Reflect async _walk correctly (#2040)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -194,7 +194,7 @@ class LocalFileSystem(AbstractFileSystem):
 
         for p in path:
             p = self._strip_protocol(p)
-            if self.isdir(p):
+            if self.isdir(p) and not self.islink(p):
                 if not recursive:
                     raise ValueError("Cannot delete directory, set recursive=True")
                 if osp.abspath(p) == os.getcwd():

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -834,6 +834,13 @@ def test_linked_directories(tmpdir):
     assert fs.info(subdir1)["islink"]
     assert fs.info(subdir2)["islink"]
 
+    fs.rm(subdir1)
+    fs.rm(subdir2, recursive=True)
+
+    assert not fs.lexists(subdir1)
+    assert not fs.lexists(subdir2)
+    assert fs.isdir(subdir0)
+
 
 def test_isfilestore():
     fs = LocalFileSystem(auto_mkdir=False)


### PR DESCRIPTION
`LocalFileSystem.rm()` treated directory symlinks as directories because `isdir()` follows links, so removing a link required `recursive=True` and then routed it through `rmtree()`. Excluding symlinks from the directory branch unlinks them with `os.remove()` while leaving the target untouched; the linked-directory test now covers both recursive modes.

Fixes #1299

Test: `python -m pytest -q fsspec/implementations/tests/test_local.py` (140 passed, 16 skipped)
