### PR TITLE
fixes for pytest deprecation

### DIFF
--- a/fsspec/implementations/tests/local/local_fixtures.py
+++ b/fsspec/implementations/tests/local/local_fixtures.py
@@ -6,7 +6,8 @@ from fsspec.tests.abstract import AbstractFixtures
 
 class LocalFixtures(AbstractFixtures):
     @pytest.fixture(scope="class")
-    def fs(self):
+    @classmethod
+    def fs(cls):
         return LocalFileSystem(auto_mkdir=True)
 
     @pytest.fixture

--- a/fsspec/implementations/tests/memory/memory_fixtures.py
+++ b/fsspec/implementations/tests/memory/memory_fixtures.py
@@ -6,7 +6,8 @@ from fsspec.tests.abstract import AbstractFixtures
 
 class MemoryFixtures(AbstractFixtures):
     @pytest.fixture(scope="class")
-    def fs(self):
+    @classmethod
+    def fs(cls):
         m = filesystem("memory")
         m.store.clear()
         m.pseudo_dirs.clear()

--- a/fsspec/tests/abstract/__init__.py
+++ b/fsspec/tests/abstract/__init__.py
@@ -260,7 +260,8 @@ class AbstractFixtures(BaseAbstractFixtures):
         raise NotImplementedError("This function must be overridden in derived classes")
 
     @pytest.fixture(scope="class")
-    def local_fs(self):
+    @classmethod
+    def local_fs(cls):
         # Maybe need an option for auto_mkdir=False?  This is only relevant
         # for certain implementations.
         return LocalFileSystem(auto_mkdir=True)


### PR DESCRIPTION
https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method

addresses issue https://github.com/fsspec/filesystem_spec/issues/2059