### PR TITLE
Expand paths for mode="x" when urlpath is a list

### DIFF
--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -601,7 +601,7 @@ def expand_paths_if_needed(paths, mode, num, fs, name_function):
     expanded_paths = []
     paths = list(paths)
 
-    if "w" in mode:  # read mode
+    if "w" in mode or "x" in mode:  # write mode
         if sum(1 for p in paths if "*" in p) > 1:
             raise ValueError(
                 "When writing data, only one filename mask can be specified."

--- a/fsspec/tests/test_core.py
+++ b/fsspec/tests/test_core.py
@@ -72,6 +72,16 @@ def test_expand_paths_if_needed_in_read_mode(create_files, path, out):
     assert [os.path.basename(p) for p in res] == out
 
 
+@pytest.mark.parametrize("mode", ["w", "w+", "x", "x+"])
+def test_expand_paths_if_needed_in_write_mode(mode):
+    d = str(tempfile.mkdtemp())
+    path = os.path.join(d, "part*.csv")
+
+    fs = fsspec.filesystem("file")
+    res = expand_paths_if_needed([path], mode, 2, fs, None)
+    assert [os.path.basename(p) for p in res] == ["part0.csv", "part1.csv"]
+
+
 def test_expand_error():
     with pytest.raises(ValueError):
         _expand_paths("*.*", None, 1)


### PR DESCRIPTION
### Problem

`open_files` with `mode="x"` silently returns an empty list when the urlpath is a list — the same call with `mode="w"` works, and so does `mode="x"` with a string urlpath:

```python
from fsspec.core import open_files

open_files(["/tmp/d/part*.csv"], mode="wb", num=3)   # -> 3 OpenFiles
open_files(["/tmp/d/part*.csv"], mode="xb", num=3)   # -> []          <- silent
open_files("/tmp/d/part*.csv",   mode="xb", num=3)   # -> 3 OpenFiles
```

No exception is raised — the caller just gets nothing to write to.

### Cause

`get_fs_token_paths` has two branches. The string branch tests both modes:

```python
if ("w" in mode or "x" in mode) and expand:
    paths = _expand_paths(paths, name_function, num)
```

The list branch delegates to `expand_paths_if_needed`, which tests only `"w"`:

```python
if "w" in mode:  # read mode
```

So an `"x"` write falls through into the read branch and gets globbed. The glob matches nothing — the files don't exist yet, which is the whole point of `"x"` — hence the empty list.

(The comment on that line also says "read mode", but it guards the write branch.)

### History

#1333 added `mode="x"` support to `get_fs_token_paths` and parametrized `test_expand_fs_token_paths` over `["w", "w+", "x", "x+"]`. That test passes a **string** urlpath, so it only ever exercises the branch that was fixed; the list branch kept the `"w"`-only test and nothing caught it.

### Fix

Test for both modes in `expand_paths_if_needed`, matching its caller.

### Testing

- Added `test_expand_paths_if_needed_in_write_mode`, parametrized over the same `["w", "w+", "x", "x+"]` as `test_expand_fs_token_paths` but going through `expand_paths_if_needed` (the list path). Verified it fails before the fix on `x`/`x+` and passes on `w`/`w+` — i.e. it reproduces exactly the asymmetry — and that all four pass after.
- `fsspec/tests/` + `implementations/tests/{test_local,test_memory}.py`: 772 passed. The 5 failures are pre-existing — they fail identically on an unmodified `master` in my environment (`pytest-asyncio` isn't installed, so `async def` tests error out) and are unrelated to this change.
- `ruff check` and `ruff format --check` clean.

### AI disclosure

Prepared with AI assistance (Claude Code). I reproduced the behavior against the unmodified library, verified the fix and the test locally, and take responsibility for the change.
