### PR TITLE
Create the parent dir for "x" and "a" modes under auto_mkdir

### DIFF
--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -210,7 +210,7 @@ class LocalFileSystem(AbstractFileSystem):
 
     def _open(self, path, mode="rb", block_size=None, **kwargs):
         path = self._strip_protocol(path)
-        if self.auto_mkdir and "w" in mode:
+        if self.auto_mkdir and ("w" in mode or "x" in mode or "a" in mode):
             self.makedirs(self._parent(path), exist_ok=True)
         return LocalFileOpener(path, mode, fs=self, **kwargs)
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -372,6 +372,17 @@ def test_touch(tmpdir):
         assert info2["mtime"] > info["mtime"]
 
 
+@pytest.mark.parametrize("mode", ["wb", "xb", "ab"])
+def test_open_auto_mkdir_create_modes(tmpdir, mode):
+    # auto_mkdir must create the parent dir for every file-creating mode, not
+    # just "w": "x" (exclusive create) and "a" (append) create a file too.
+    fn = str(tmpdir) + f"/{mode}_dir/file"
+    fs = fsspec.filesystem("file", auto_mkdir=True)
+    with fs.open(fn, mode) as f:
+        f.write(b"data")
+    assert fs.cat_file(fn) == b"data"
+
+
 def test_touch_truncate(tmpdir):
     fn = str(tmpdir + "/tfile")
     fs = fsspec.filesystem("file")


### PR DESCRIPTION
`LocalFileSystem._open` runs `auto_mkdir` only for `"w"`, but `"x"` (exclusive create) and `"a"` (append) also create a file and need the parent dir. So with `auto_mkdir=True` and a missing parent they raise `FileNotFoundError` while `"wb"` succeeds. This widens the check to match the write-mode test `core.py` already uses (#2078).

```python
fs = fsspec.filesystem("file", auto_mkdir=True)
fs.open("/tmp/new/dir/f", "wb")   # ok — parent created
fs.open("/tmp/new/dir2/f", "xb")  # was FileNotFoundError, now ok
```

Test added covering `wb`/`xb`/`ab`. (`smb.py:306` has the same `"w" in mode` pattern, but reproducing it needs a live server — noting it as a matching sibling rather than touching it here.)

*Found, fixed, and tested by an AI coding agent (Claude Code) running autonomously on this account; the human account holder reviews every change and is accountable for it. The repro and test are real and re-runnable from it.*

