### PR TITLE
Clamp read end to file size in BlockCache and BackgroundBlockCache

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -386,7 +386,7 @@ class BlockCache(BaseCache):
     def _fetch(self, start: int | None, end: int | None) -> bytes:
         if start is None:
             start = 0
-        if end is None:
+        if end is None or end > self.size:
             end = self.size
         if start >= self.size or start >= end:
             return b""
@@ -831,7 +831,7 @@ class BackgroundBlockCache(BaseCache):
     def _fetch(self, start: int | None, end: int | None) -> bytes:
         if start is None:
             start = 0
-        if end is None:
+        if end is None or end > self.size:
             end = self.size
         if start >= self.size or start >= end:
             return b""

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -177,6 +177,16 @@ def test_cache_empty_file(Cache_imp):
     assert cache._fetch(0, 0) == b""
 
 
+def test_cache_fetch_past_end_of_file(Cache_imp):
+    # Reading past the end of the file returns the available bytes rather than
+    # raising: `read(n)` yields at most n bytes. BlockCache/BackgroundBlockCache
+    # used to overflow their block count and raise ValueError here.
+    blocksize = 5
+    size = len(string.ascii_letters)
+    cache = Cache_imp(blocksize, letters_fetcher, size)
+    assert cache._fetch(0, size + 3 * blocksize) == string.ascii_letters.encode()
+
+
 def test_cache_pickleable(Cache_imp):
     blocksize = 5
     size = 100


### PR DESCRIPTION
### Problem

Reading past the end of a file raises from `BlockCache` and `BackgroundBlockCache`:

```python
ValueError: 'block_number=N' is greater than the number of blocks (M)
```

`_fetch(start, end)` sets `end = self.size` only when `end is None`; an over-large `end` (a read that runs past EOF) is passed straight through, so `(end - 1) // blocksize` addresses a block beyond the file and `_fetch_block` rejects it. `ReadAheadCache`, `BytesCache`, and `MMapCache` return the available bytes for the same read — only the two block cachers raise.

This is reachable with the default cacher and block size: e.g. a 1 MB remote file opened with the default 5 MB block size, then `f.read(20_000_000)`, raises instead of returning the 1 MB.

### Change

Clamp `end` to `self.size` in both `_fetch` methods, mirroring `ReadAheadCache._fetch`:

```python
if end is None or end > self.size:
    end = self.size
```

`read(n)` should return at most n bytes; clamping makes the block cachers agree with the others. The block-number guard in `_fetch_block` is left in place.

### Tests

`test_cache_fetch_past_end_of_file` is parametrized over every cacher and reads past EOF, asserting the available bytes come back. Before the change it fails for `blockcache` and `background` (ValueError) and passes for the rest; after, all pass. `fsspec/tests/test_caches.py` stays green (156 passed); `ruff check` / `ruff format --check` pass on both files.

---

*Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the issue, wrote and ran the repro and the test, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*

