### PR TITLE
Handle end=None in FirstChunkCache._fetch like the other caches

### DIFF
--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -304,6 +304,8 @@ class FirstChunkCache(BaseCache):
             logger.debug("FirstChunkCache: requested start > file size")
             return b""
 
+        if end is None:
+            end = self.size
         end = min(end, self.size)
 
         if start < self.blocksize:

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -19,6 +19,7 @@ def test_cache_getitem(Cache_imp):
     assert cacher._fetch(0, 4) == b"abcd"
     assert cacher._fetch(None, 4) == b"abcd"
     assert cacher._fetch(2, 4) == b"cd"
+    assert cacher._fetch(0, None) == string.ascii_letters.encode()
 
 
 def test_block_cache_lru():


### PR DESCRIPTION
## The issue

`BaseCache._fetch` is typed `(start: int | None, end: int | None)`, and most cache implementations treat `end=None` as "read to the end of the file":

- `ReadAheadCache`: `if end is None or end > self.size: end = self.size`
- `BytesCache`: `if end is None: end = self.size`
- `BlockCache` / `MMapCache`: handle it too

`FirstChunkCache` is the odd one out — it does `end = min(end, self.size)`, which raises `TypeError` on `None`:

```python
>>> from fsspec.caching import FirstChunkCache
>>> c = FirstChunkCache(4, lambda s, e: b"x" * (e - s), 100)
>>> c._fetch(0, None)
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

## Fix

Fall back to `self.size` when `end is None`, mirroring the sibling caches. One-line behavioural change; the existing `int` path is untouched.

## Scope / reachability

I want to be upfront: the buffered-read path (`AbstractBufferedFile.read`) resolves the length to an `int` before calling `self.cache._fetch`, so a normal file read doesn't hit this. But `_fetch` is a public contract that the other caches honor — the shared `test_cache_getitem` already exercises `_fetch(None, 4)` (start=None) across every cache — and `FirstChunkCache` is the only subclass that diverges. This makes it consistent.

## Verification

- Extended the existing parametrized `test_cache_getitem` with a `_fetch(0, None)` assertion. It fails only for `FirstChunkCache[first]` on `main` (TypeError) and passes for all caches with this change.
- `fsspec/tests/test_caches.py`: **147 passed**.
- `ruff check` clean.

---

*Disclosure:* this PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the divergence, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
