### PR TITLE
Fix incorrect glob docstring for '[!]' (empty negated class)

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -587,11 +587,7 @@ class AbstractFileSystem(metaclass=_Cached):
         Special behaviors:
         - If the path ends with '/', only folders are returned
         - Consecutive '*' characters are compressed into a single '*'
-        - Empty brackets '[]' never match anything
-        - A bare '[!]' is treated as the literal string '[!]', matching the
-          behaviour of Python's ``glob``/``fnmatch``; to negate a character
-          class the brackets must contain at least one character (e.g. '[!a]'
-          matches any single character other than 'a')
+        - Empty set '[]' or negated empty negated set '[!]' never match anything
         - Special characters in character classes are escaped properly
 
         Limitations:

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -588,7 +588,10 @@ class AbstractFileSystem(metaclass=_Cached):
         - If the path ends with '/', only folders are returned
         - Consecutive '*' characters are compressed into a single '*'
         - Empty brackets '[]' never match anything
-        - Negated empty brackets '[!]' match any single character
+        - A bare '[!]' is treated as the literal string '[!]', matching the
+          behaviour of Python's ``glob``/``fnmatch``; to negate a character
+          class the brackets must contain at least one character (e.g. '[!a]'
+          matches any single character other than 'a')
         - Special characters in character classes are escaped properly
 
         Limitations:

--- a/fsspec/tests/test_spec.py
+++ b/fsspec/tests/test_spec.py
@@ -63,6 +63,12 @@ GLOB_POSIX_TESTS = {
     "argnames": ("path", "expected"),
     "argvalues": [
         ("nonexistent", []),
+        # bare "[!]" is the literal string "[!]" (an empty negated class),
+        # and "[]" is an empty class; neither matches anything -- matching
+        # Python's glob/fnmatch and bash. See glob() docstring.
+        ("test0/[!]", []),
+        ("[]", []),
+        ("test[]0.json", []),
         ("test0.json", ["test0.json"]),
         ("test0", ["test0"]),
         ("test0/", ["test0"]),


### PR DESCRIPTION
### Problem

`AbstractFileSystem.glob`'s docstring documents a rule that is incorrect:

> - Negated empty brackets `'[!]'` match any single character

A bare `[!]` is an *empty* negated character class, and — like Python's `glob`/`fnmatch` and like bash — fsspec treats it as the **literal string** `[!]`, which matches nothing:

```python
import fsspec
fs = fsspec.filesystem("memory")
for p in ("/h/z.txt", "/h/q.txt"):
    fs.pipe(p, b"x")

fs.glob("/h/?.txt")     # ['/h/q.txt', '/h/z.txt']   -- ? matches one char
fs.glob("/h/[!].txt")   # []                          -- docstring implies this matches z/q
```

```python
import fnmatch
fnmatch.translate("[!]")   # '(?s:\\[!\\])\\Z'  -- literal '[!]', not a wildcard
```

So a user trusting the docstring would write `[!]` expecting single-character matches and silently get nothing.

### Change

The runtime behaviour is already correct and matches Python/bash — only the documentation is wrong. This corrects the docstring, and adds three cases (`test0/[!]`, `[]`, `test[]0.json`) to `GLOB_POSIX_TESTS`. Those cases run through the existing `test_posix_tests_python_glob`, `test_posix_tests_bash_stat` and `test_glob_posix_rules` parity tests, so they lock the behaviour to Python's `glob`, bash, and fsspec simultaneously — I verified all three agree.

---
*Disclosure: I used an LLM to help with this change; I've reviewed every line, reproduced the behaviour, and run the tests myself.*
