### PR TITLE
Permit composite URL protocol schemes in `infer_storage_options`

### DIFF
--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -223,6 +223,13 @@ def test_infer_simple():
     assert out.get("host", None) is None
 
 
+def test_infer_composite_protocol():
+    out = infer_storage_options("foo+bar-baz://db.example.org")
+    assert out["protocol"] == "foo+bar-baz"
+    assert out["host"] == "db.example.org"
+    assert out["path"] == ""
+
+
 @pytest.mark.parametrize(
     "urlpath, expected_path",
     (

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -56,11 +56,18 @@ def infer_storage_options(
     "host": "node", "port": 123, "path": "/mnt/datasets/test.csv",
     "url_query": "q=1", "extra": "value"}
     """
-    # Handle Windows paths including disk name in this special case
-    if (
-        re.match(r"^[a-zA-Z]:[\\/]", urlpath)
-        or re.match(r"^[a-zA-Z0-9]+://", urlpath) is None
-    ):
+
+    # Discover Windows paths including disk name in this special case.
+    is_filesystem = re.match(r"^[a-zA-Z]:[\\/]", urlpath)
+
+    # Discover URI according to RFC 3986: Scheme names consist of a
+    # sequence of characters beginning with a letter and followed by
+    # any combination of letters, digits, plus ("+"), period ("."),
+    # or hyphen ("-").
+    # https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
+    is_uri = re.match(r"^[a-zA-Z0-9+.-]+://", urlpath)
+
+    if is_filesystem or is_uri is None:
         return {"protocol": "file", "path": urlpath}
 
     parsed_path = urlsplit(urlpath)


### PR DESCRIPTION
Hi there. In [omniload](https://omniload.readthedocs.io/), we are [using](https://github.com/panodata/omniload/blob/v0.7.0/omniload/core/registry.py) composite URL protocol schemes like `https+webdav://`, `mongodb+srv://`, or `mysql+pymysql://`. While the code used custom auxiliary/helper functions before, we are now aiming to modernize and refactor a bit, for example towards using `fsspec.utils.infer_storage_options` across the board. On this occasion, we found that a specific regex pattern needed a minor adjustment to permit such URL protocol schemes that include a `+` character.

- Reference: https://github.com/panodata/omniload/pull/236