### PR TITLE
Fix for `merge_offset_ranges` becoming quadratic

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,7 @@ Enhancements
 
 Fixes
 
-- Make ``merge_offset_ranges`` `O(n log n)` and never emit overlapping ranges, replacing the quadratic nested-range filter added in #1982 (#2091)
+- Make ``merge_offset_ranges`` `O(n log n)` and never emit overlapping ranges (raise on unsorted starts when ``sort=False``), replacing the quadratic nested-range filter added in #1982 (#2091)
 - Fix incorrect glob docstring for '[!]' (#2084)
 - Propagate storage_options to all backends resolved by GenericFileSystem (#2083)
 - Handle end=None in FirstChunkCache._fetch like the other caches (#2082)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Enhancements
 
 Fixes
 
+- Make ``merge_offset_ranges`` linear-time and never emit overlapping ranges, replacing the quadratic nested-range filter added in #1982
 - Fix incorrect glob docstring for '[!]' (#2084)
 - Propagate storage_options to all backends resolved by GenericFileSystem (#2083)
 - Handle end=None in FirstChunkCache._fetch like the other caches (#2082)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,7 @@ Enhancements
 
 Fixes
 
-- Make ``merge_offset_ranges`` linear-time and never emit overlapping ranges, replacing the quadratic nested-range filter added in #1982 (#2091)
+- Make ``merge_offset_ranges`` `O(n log n)` and never emit overlapping ranges, replacing the quadratic nested-range filter added in #1982 (#2091)
 - Fix incorrect glob docstring for '[!]' (#2084)
 - Propagate storage_options to all backends resolved by GenericFileSystem (#2083)
 - Handle end=None in FirstChunkCache._fetch like the other caches (#2082)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,7 @@ Enhancements
 
 Fixes
 
-- Make ``merge_offset_ranges`` linear-time and never emit overlapping ranges, replacing the quadratic nested-range filter added in #1982
+- Make ``merge_offset_ranges`` linear-time and never emit overlapping ranges, replacing the quadratic nested-range filter added in #1982 (#2091)
 - Fix incorrect glob docstring for '[!]' (#2084)
 - Propagate storage_options to all backends resolved by GenericFileSystem (#2083)
 - Handle end=None in FirstChunkCache._fetch like the other caches (#2082)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,7 @@ Enhancements
 
 Fixes
 
-- Make ``merge_offset_ranges`` `O(n log n)` and never emit overlapping ranges (raise on unsorted starts when ``sort=False``), replacing the quadratic nested-range filter added in #1982 (#2091)
+- Make ``merge_offset_ranges`` `O(n log n)` and keep merged blocks within ``max_block``, replacing the quadratic nested-range filter added in #1982 (#2091)
 - Fix incorrect glob docstring for '[!]' (#2084)
 - Propagate storage_options to all backends resolved by GenericFileSystem (#2083)
 - Handle end=None in FirstChunkCache._fetch like the other caches (#2082)

--- a/fsspec/tests/test_parquet.py
+++ b/fsspec/tests/test_parquet.py
@@ -12,7 +12,9 @@ try:
 except ImportError:
     pq = None
 
+from fsspec.core import url_to_fs
 from fsspec.parquet import (
+    _get_parquet_byte_ranges,
     open_parquet_file,
     open_parquet_files,
 )
@@ -146,6 +148,36 @@ def test_with_filter(tmpdir):
 
     result = pd.read_parquet(f, engine="fastparquet", filters=[["b", "==", "b"]])
     pd.testing.assert_frame_equal(expect, result)
+
+
+@pytest.mark.filterwarnings("ignore:.*Not enough data.*")
+@FASTPARQUET_MARK
+def test_metadata_row_group_order(tmpdir):
+    # A list of row-group metadata objects is iterated in the caller's
+    # order, so the collected byte ranges can descend. Every range must
+    # still be fetched, whatever the order
+    df = pd.DataFrame({"a": range(20), "b": ["x"] * 20})
+    fn = os.path.join(str(tmpdir), "test.parquet")
+    df.to_parquet(fn, engine="fastparquet", row_group_offsets=[0, 10])
+
+    pf = fastparquet.ParquetFile(fn)
+    fs, path = url_to_fs(fn)
+    row_groups = list(pf.row_groups)[::-1]
+
+    ranges = _get_parquet_byte_ranges(
+        [path], fs, metadata=pf, row_groups=row_groups, engine="fastparquet"
+    )
+
+    covered = set()
+    for blocks in ranges.values():
+        for start, end in blocks:
+            covered.update(range(start, end))
+
+    for row_group in row_groups:
+        for column in row_group.columns:
+            meta = column.meta_data
+            start = meta.dictionary_page_offset or meta.data_page_offset
+            assert set(range(start, start + meta.total_compressed_size)) <= covered
 
 
 @pytest.mark.filterwarnings("ignore:.*Not enough data.*")

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -472,9 +472,8 @@ def test_merge_offset_ranges_drops_nested():
     [
         # Exact duplicates: keep one
         ([0, 0], [50, 50], [(0, 50)]),
-        # Nested in either order
+        # Nested range
         ([0, 10], [80, 20], [(0, 80)]),
-        ([10, 0], [20, 80], [(0, 80)]),
         # None end covers to EOF
         ([0, 0], [None, 50], [(0, None)]),
         ([0, 0], [50, None], [(0, None)]),
@@ -493,6 +492,19 @@ def test_merge_offset_ranges_edges(starts, ends, expected, sort):
     )
 
     assert list(zip(*result)) == [("f", *rng) for rng in expected]
+
+
+def test_merge_offset_ranges_sorts_unsorted_nested_ranges():
+    result = merge_offset_ranges(
+        ["f", "f"],
+        [10, 0],
+        [20, 80],
+        max_gap=100,
+        max_block=1000,
+        sort=True,
+    )
+
+    assert list(zip(*result)) == [("f", 0, 80)]
 
 
 @pytest.mark.parametrize("max_block", [None, 4, 128])
@@ -537,21 +549,24 @@ def test_merge_offset_ranges_covers_every_input_range():
 
 def test_merge_offset_ranges_many_sequential_is_fast():
     # Regression: O(n²) nested-range filter added in #1982
-    n = 20_000
-    paths = ["file"] * n
-    starts = list(range(0, n * 240, 240))
-    ends = [s + 240 for s in starts]
+    def run(n):
+        paths = ["file"] * n
+        starts = list(range(0, n * 240, 240))
+        ends = [s + 240 for s in starts]
+        t0 = time.perf_counter()
+        result = merge_offset_ranges(
+            paths, starts, ends, max_block=8_388_608, sort=True
+        )
+        return time.perf_counter() - t0, result, ends[-1]
 
-    t0 = time.perf_counter()
-    result_paths, result_starts, result_ends = merge_offset_ranges(
-        paths, starts, ends, max_block=8_388_608, sort=True
-    )
-    elapsed = time.perf_counter() - t0
+    small_elapsed, _, _ = run(5_000)
+    large_elapsed, result, expected_end = run(20_000)
+    result_paths, result_starts, result_ends = result
 
-    assert elapsed < 1.0
+    assert large_elapsed < small_elapsed * 8
     assert result_paths == ["file"]
     assert result_starts == [0]
-    assert result_ends == [ends[-1]]
+    assert result_ends == [expected_end]
 
 
 def test_size():

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -507,6 +507,19 @@ def test_merge_offset_ranges_sorts_unsorted_nested_ranges():
     assert list(zip(*result)) == [("f", 0, 80)]
 
 
+def test_merge_offset_ranges_unsorted_sort_false_raises():
+    # Walking start backwards after emitting a later block would produce
+    # overlapping output; fail loud instead of silent min().
+    with pytest.raises(ValueError, match="sorted ascending"):
+        merge_offset_ranges(
+            ["f"] * 3,
+            [0, 100, 5],
+            [10, 110, 7],
+            max_gap=0,
+            sort=False,
+        )
+
+
 @pytest.mark.parametrize("max_block", [None, 4, 128])
 def test_merge_offset_ranges_never_overlap(max_block):
     # Overlaps must merge even past max_block

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -507,17 +507,30 @@ def test_merge_offset_ranges_sorts_unsorted_nested_ranges():
     assert list(zip(*result)) == [("f", 0, 80)]
 
 
-def test_merge_offset_ranges_unsorted_sort_false_raises():
-    # Walking start backwards after emitting a later block would produce
-    # overlapping output; fail loud instead of silent min().
-    with pytest.raises(ValueError, match="sorted ascending"):
-        merge_offset_ranges(
-            ["f"] * 3,
-            [0, 100, 5],
-            [10, 110, 7],
-            max_gap=0,
-            sort=False,
+@pytest.mark.parametrize(
+    "starts,ends",
+    [
+        # Range starting behind an already emitted block
+        ([0, 100, 5], [10, 110, 7]),
+        # Range nested inside an earlier block, not the current one
+        ([102, 267, 108], [174, 286, 152]),
+        # Fully reversed
+        ([200, 100, 0], [210, 110, 10]),
+    ],
+)
+def test_merge_offset_ranges_unsorted_keeps_coverage(starts, ends):
+    # `sort=False` with out-of-order input must still cover every range
+    result = merge_offset_ranges(
+        ["f"] * len(starts), list(starts), list(ends), max_gap=0, sort=False
+    )
+
+    blocks = list(zip(*result))
+    for start, end in zip(starts, ends):
+        assert any(
+            block_start <= start and end <= block_end
+            for _, block_start, block_end in blocks
         )
+        assert all(block_end >= block_start for _, block_start, block_end in blocks)
 
 
 @pytest.mark.parametrize("max_block", [None, 4, 128])

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -559,11 +559,12 @@ def test_merge_offset_ranges_many_sequential_is_fast():
         )
         return time.perf_counter() - t0, result, ends[-1]
 
-    small_elapsed, _, _ = run(5_000)
     large_elapsed, result, expected_end = run(20_000)
     result_paths, result_starts, result_ends = result
 
-    assert large_elapsed < small_elapsed * 8
+    # Generous ceiling: the linear implementation needs ~10ms here, while the
+    # quadratic one needs tens of seconds.
+    assert large_elapsed < 1.0
     assert result_paths == ["file"]
     assert result_starts == [0]
     assert result_ends == [expected_end]

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -1,5 +1,7 @@
 import io
+import random
 import sys
+import time
 from pathlib import Path, PurePath
 from unittest.mock import Mock
 
@@ -448,6 +450,108 @@ def test_merge_offset_ranges(max_gap, max_block):
     assert expect_paths == result_paths
     assert expect_starts == result_starts
     assert expect_ends == result_ends
+
+
+def test_merge_offset_ranges_drops_nested():
+    paths = ["f", "f", "f", "f", "g"]
+    starts = [0, 10, 0, 100, 0]
+    ends = [50, 20, 80, 150, 10]
+
+    result_paths, result_starts, result_ends = merge_offset_ranges(
+        paths, starts, ends, max_gap=0, max_block=None
+    )
+
+    assert result_paths == ["f", "f", "g"]
+    assert result_starts == [0, 100, 0]
+    assert result_ends == [80, 150, 10]
+
+
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize(
+    "starts,ends,expected",
+    [
+        # Exact duplicates: keep one
+        ([0, 0], [50, 50], [(0, 50)]),
+        # Nested in either order
+        ([0, 10], [80, 20], [(0, 80)]),
+        ([10, 0], [20, 80], [(0, 80)]),
+        # None end covers to EOF
+        ([0, 0], [None, 50], [(0, None)]),
+        ([0, 0], [50, None], [(0, None)]),
+        # None end past max_block: keep separate
+        ([0, 50], [10, None], [(0, 10), (50, None)]),
+    ],
+)
+def test_merge_offset_ranges_edges(starts, ends, expected, sort):
+    result = merge_offset_ranges(
+        ["f"] * len(starts),
+        list(starts),
+        list(ends),
+        max_gap=100,
+        max_block=1000,
+        sort=sort,
+    )
+
+    assert list(zip(*result)) == [("f", *rng) for rng in expected]
+
+
+@pytest.mark.parametrize("max_block", [None, 4, 128])
+def test_merge_offset_ranges_never_overlap(max_block):
+    # Overlaps must merge even past max_block
+    paths = ["f"] * 3
+    starts = [0, 8, 12]
+    ends = [10, 40, 20]
+
+    result_paths, result_starts, result_ends = merge_offset_ranges(
+        paths, starts, ends, max_gap=0, max_block=max_block
+    )
+
+    assert result_paths == ["f"]
+    assert result_starts == [0]
+    assert result_ends == [40]
+
+
+def test_merge_offset_ranges_covers_every_input_range():
+    # Output ranges must not overlap; every input must be covered
+    rand = random.Random(42)
+    paths, starts, ends = [], [], []
+    for _ in range(200):
+        path = f"f{rand.randint(0, 2)}"
+        start = rand.randrange(0, 4000)
+        paths.append(path)
+        starts.append(start)
+        ends.append(start + rand.randrange(1, 500))
+
+    result = merge_offset_ranges(paths, starts, ends, max_gap=8, max_block=512)
+
+    blocks = sorted(zip(*result))
+    for (path1, _, end1), (path2, start2, _) in zip(blocks, blocks[1:]):
+        assert path1 != path2 or start2 >= end1
+
+    for path, start, end in zip(paths, starts, ends):
+        assert any(
+            path == block_path and block_start <= start and end <= block_end
+            for block_path, block_start, block_end in blocks
+        )
+
+
+def test_merge_offset_ranges_many_sequential_is_fast():
+    # Regression: O(n²) nested-range filter added in #1982
+    n = 20_000
+    paths = ["file"] * n
+    starts = list(range(0, n * 240, 240))
+    ends = [s + 240 for s in starts]
+
+    t0 = time.perf_counter()
+    result_paths, result_starts, result_ends = merge_offset_ranges(
+        paths, starts, ends, max_block=8_388_608, sort=True
+    )
+    elapsed = time.perf_counter() - t0
+
+    assert elapsed < 1.0
+    assert result_paths == ["file"]
+    assert result_starts == [0]
+    assert result_ends == [ends[-1]]
 
 
 def test_size():

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -533,24 +533,28 @@ def test_merge_offset_ranges_unsorted_keeps_coverage(starts, ends):
         assert all(block_end >= block_start for _, block_start, block_end in blocks)
 
 
-@pytest.mark.parametrize("max_block", [None, 4, 128])
-def test_merge_offset_ranges_never_overlap(max_block):
-    # Overlaps must merge even past max_block
-    paths = ["f"] * 3
-    starts = [0, 8, 12]
-    ends = [10, 40, 20]
-
-    result_paths, result_starts, result_ends = merge_offset_ranges(
-        paths, starts, ends, max_gap=0, max_block=max_block
+@pytest.mark.parametrize(
+    "max_block,expected",
+    [
+        # Overlaps merge when the block stays within `max_block`
+        (None, [(0, 40)]),
+        (128, [(0, 40)]),
+        # Merging (8, 40) would exceed `max_block`, so it becomes its own
+        # block, overlapping the first. (12, 20) is already covered by it
+        (4, [(0, 10), (8, 40)]),
+    ],
+)
+def test_merge_offset_ranges_overlap_respects_max_block(max_block, expected):
+    result = merge_offset_ranges(
+        ["f"] * 3, [0, 8, 12], [10, 40, 20], max_gap=0, max_block=max_block
     )
 
-    assert result_paths == ["f"]
-    assert result_starts == [0]
-    assert result_ends == [40]
+    assert list(zip(*result)) == [("f", *rng) for rng in expected]
 
 
 def test_merge_offset_ranges_covers_every_input_range():
-    # Output ranges must not overlap; every input must be covered
+    # Every input must be covered, and no block may exceed max_block
+    # when every input range is itself smaller than max_block
     rand = random.Random(42)
     paths, starts, ends = [], [], []
     for _ in range(200):
@@ -563,13 +567,37 @@ def test_merge_offset_ranges_covers_every_input_range():
     result = merge_offset_ranges(paths, starts, ends, max_gap=8, max_block=512)
 
     blocks = sorted(zip(*result))
-    for (path1, _, end1), (path2, start2, _) in zip(blocks, blocks[1:]):
-        assert path1 != path2 or start2 >= end1
+    for _, block_start, block_end in blocks:
+        assert block_end - block_start <= 512
 
     for path, start, end in zip(paths, starts, ends):
         assert any(
             path == block_path and block_start <= start and end <= block_end
             for block_path, block_start, block_end in blocks
+        )
+
+
+def test_merge_offset_ranges_overlap_chain_is_bounded():
+    # Regression: chained overlaps each extended the open block, so the
+    # merged block grew past max_block without bound
+    n = 20_000
+    max_block = 8_192
+    starts = list(range(0, n * 100, 100))
+    ends = [s + 150 for s in starts]
+
+    result = merge_offset_ranges(
+        ["f"] * n, starts, ends, max_gap=0, max_block=max_block
+    )
+
+    blocks = list(zip(*result))
+    assert len(blocks) > 1
+    for _, block_start, block_end in blocks:
+        assert block_end - block_start <= max_block
+
+    for start, end in zip(starts, ends):
+        assert any(
+            block_start <= start and end <= block_end
+            for _, block_start, block_end in blocks
         )
 
 

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -546,11 +546,12 @@ def merge_offset_ranges(
     """Merge adjacent byte-offset ranges when the inter-range
     gap is <= `max_gap`, and when the merged byte range does not
     exceed `max_block` (if specified). Overlapping ranges are always
-    merged, even past `max_block`, so returned ranges never overlap.
-    An `end` of `None` means to the end of the file. By default, this
-    function will re-order the input paths and byte ranges to ensure
-    sorted order. If the user can guarantee that the inputs are already
-    sorted, passing `sort=False` will skip the re-ordering.
+    merged, even past `max_block`, so returned ranges never overlap
+    when the input is sorted. An `end` of `None` means to the end of
+    the file. By default, this function will re-order the input paths
+    and byte ranges to ensure sorted order. If the user can guarantee
+    that the inputs are already sorted, passing `sort=False` will skip
+    the re-ordering.
     """
     # Check input
     if not isinstance(paths, list):

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -545,11 +545,15 @@ def merge_offset_ranges(
 ) -> tuple[list[str], list[int], list[int | None]]:
     """Merge adjacent byte-offset ranges when the inter-range
     gap is <= `max_gap`, and when the merged byte range does not
-    exceed `max_block` (if specified). Overlapping ranges are always
-    merged, even past `max_block`, so with `sort=True` the returned
-    ranges never overlap. An `end` of `None` means to the end of the
-    file. By default, this function will re-order the input paths and
-    byte ranges to ensure sorted order.
+    exceed `max_block` (if specified). Every input range is covered by
+    at least one returned range. Overlapping input ranges are merged
+    where `max_block` allows it, so returned ranges may overlap once a
+    chain of overlapping inputs reaches `max_block`; a single input
+    range larger than `max_block` is still returned whole.
+
+    An `end` of `None` means to the end of the file. By default, this
+    function will re-order the input paths and byte ranges to ensure
+    sorted order.
 
     Passing `sort=False` skips the re-ordering, which is only worthwhile
     when the inputs are already grouped by path and ascending by start
@@ -608,8 +612,24 @@ def merge_offset_ranges(
             # Previous block already covers the rest of the file
             continue
         elif start < prev_end:
-            # Overlap / nested: merge into the union even past max_block
-            if end is None or end > prev_end:
+            # Overlap / nested
+            if end is not None and end <= prev_end:
+                # Already covered by the current block
+                continue
+            elif (
+                end is not None
+                and max_block is not None
+                and (end - new_starts[-1]) > max_block
+            ):
+                # Extending would exceed `max_block`. Start a new block,
+                # which overlaps the previous one, rather than letting a
+                # chain of overlaps grow the block without bound
+                new_paths.append(path)
+                new_starts.append(start)
+                new_ends.append(end)
+            else:
+                # An `end` of None extends the block to EOF; a separate
+                # block would subsume the current one anyway
                 new_ends[-1] = end
         elif (start - prev_end) > max_gap or (
             max_block is not None

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -546,12 +546,17 @@ def merge_offset_ranges(
     """Merge adjacent byte-offset ranges when the inter-range
     gap is <= `max_gap`, and when the merged byte range does not
     exceed `max_block` (if specified). Overlapping ranges are always
-    merged, even past `max_block`, so returned ranges never overlap
-    when the input is sorted. An `end` of `None` means to the end of
-    the file. By default, this function will re-order the input paths
-    and byte ranges to ensure sorted order. If the user can guarantee
-    that the inputs are already sorted, passing `sort=False` will skip
-    the re-ordering.
+    merged, even past `max_block`, so with `sort=True` the returned
+    ranges never overlap. An `end` of `None` means to the end of the
+    file. By default, this function will re-order the input paths and
+    byte ranges to ensure sorted order.
+
+    Passing `sort=False` skips the re-ordering, and requires the caller
+    to guarantee that the inputs are grouped by path and ascending by
+    start within each path. Descending starts within a path raise
+    ``ValueError`` rather than silently emitting overlapping ranges;
+    a path that re-appears after a different path is treated as a new
+    group, so ranges for it may overlap an earlier group.
     """
     # Check input
     if not isinstance(paths, list):
@@ -593,12 +598,19 @@ def merge_offset_ranges(
             new_paths.append(path)
             new_starts.append(start)
             new_ends.append(end)
+        elif start < new_starts[-1]:
+            # Starts must be non-decreasing within a path; walking the
+            # current block start backwards can overlap a prior emitted
+            # block when sort=False.
+            raise ValueError(
+                "starts must be sorted ascending within each path; "
+                f"got start={start} before current block start={new_starts[-1]}"
+            )
         elif prev_end is None:
             # Previous block already covers the rest of the file
             continue
         elif start < prev_end:
             # Overlap / nested: merge into the union even past max_block
-            new_starts[-1] = min(new_starts[-1], start)
             if end is None or end > prev_end:
                 new_ends[-1] = end
         elif (start - prev_end) > max_gap or (

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -551,12 +551,11 @@ def merge_offset_ranges(
     file. By default, this function will re-order the input paths and
     byte ranges to ensure sorted order.
 
-    Passing `sort=False` skips the re-ordering, and requires the caller
-    to guarantee that the inputs are grouped by path and ascending by
-    start within each path. Descending starts within a path raise
-    ``ValueError`` rather than silently emitting overlapping ranges;
-    a path that re-appears after a different path is treated as a new
-    group, so ranges for it may overlap an earlier group.
+    Passing `sort=False` skips the re-ordering, which is only worthwhile
+    when the inputs are already grouped by path and ascending by start
+    within each path. Ranges that break that order still appear in the
+    output, as their own range rather than merged, so coverage holds for
+    any input order.
     """
     # Check input
     if not isinstance(paths, list):
@@ -599,13 +598,12 @@ def merge_offset_ranges(
             new_starts.append(start)
             new_ends.append(end)
         elif start < new_starts[-1]:
-            # Starts must be non-decreasing within a path; walking the
-            # current block start backwards can overlap a prior emitted
-            # block when sort=False.
-            raise ValueError(
-                "starts must be sorted ascending within each path; "
-                f"got start={start} before current block start={new_starts[-1]}"
-            )
+            # Out of order (only possible when `sort=False`). Walking the
+            # current block start backwards would uncover bytes already
+            # attributed to it, so give this range its own block
+            new_paths.append(path)
+            new_starts.append(start)
+            new_ends.append(end)
         elif prev_end is None:
             # Previous block already covers the rest of the file
             continue

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -537,17 +537,19 @@ def nullcontext(obj: T) -> Iterator[T]:
 
 def merge_offset_ranges(
     paths: list[str],
-    starts: list[int] | int,
-    ends: list[int] | int,
+    starts: list[int | None] | int | None,
+    ends: list[int | None] | int | None,
     max_gap: int = 0,
     max_block: int | None = None,
     sort: bool = True,
-) -> tuple[list[str], list[int], list[int]]:
+) -> tuple[list[str], list[int], list[int | None]]:
     """Merge adjacent byte-offset ranges when the inter-range
     gap is <= `max_gap`, and when the merged byte range does not
-    exceed `max_block` (if specified). By default, this function
-    will re-order the input paths and byte ranges to ensure sorted
-    order. If the user can guarantee that the inputs are already
+    exceed `max_block` (if specified). Overlapping ranges are always
+    merged, even past `max_block`, so returned ranges never overlap.
+    An `end` of `None` means to the end of the file. By default, this
+    function will re-order the input paths and byte ranges to ensure
+    sorted order. If the user can guarantee that the inputs are already
     sorted, passing `sort=False` will skip the re-ordering.
     """
     # Check input
@@ -560,59 +562,57 @@ def merge_offset_ranges(
     if len(starts) != len(paths) or len(ends) != len(paths):
         raise ValueError
 
-    # Early Return
-    if len(starts) <= 1:
-        return paths, starts, ends
+    starts_i: list[int] = [s or 0 for s in starts]
+    ends_i: list[int | None] = ends
 
-    starts = [s or 0 for s in starts]
+    # Early Return
+    if len(starts_i) <= 1:
+        return paths, starts_i, ends_i
+
     # Sort by paths and then ranges if `sort=True`
     if sort:
-        paths, starts, ends = (
-            list(v)
-            for v in zip(
-                *sorted(
-                    zip(paths, starts, ends),
-                )
-            )
+        ranges = sorted(
+            zip(paths, starts_i, ends_i),
+            # None end sorts last (covers furthest into the file)
+            key=lambda pse: (pse[0], pse[1], math.inf if pse[2] is None else pse[2]),
         )
-    remove = []
-    for i, (path, start, end) in enumerate(zip(paths, starts, ends)):
-        if any(
-            e is not None and p == path and start >= s and end <= e and i != i2
-            for i2, (p, s, e) in enumerate(zip(paths, starts, ends))
+        paths = [r[0] for r in ranges]
+        starts_i = [r[1] for r in ranges]
+        ends_i = [r[2] for r in ranges]
+
+    # Loop through the coupled `paths`, `starts`, and
+    # `ends`, and merge adjacent blocks when appropriate
+    new_paths = paths[:1]
+    new_starts = starts_i[:1]
+    new_ends = ends_i[:1]
+    for path, start, end in zip(paths[1:], starts_i[1:], ends_i[1:]):
+        prev_end = new_ends[-1]
+        if path != new_paths[-1]:
+            # Cannot merge with previous block
+            new_paths.append(path)
+            new_starts.append(start)
+            new_ends.append(end)
+        elif prev_end is None:
+            # Previous block already covers the rest of the file
+            continue
+        elif start < prev_end:
+            # Overlap / nested: merge into the union even past max_block
+            new_starts[-1] = min(new_starts[-1], start)
+            if end is None or end > prev_end:
+                new_ends[-1] = end
+        elif (start - prev_end) > max_gap or (
+            max_block is not None
+            and (end is None or (end - new_starts[-1]) > max_block)
         ):
-            remove.append(i)
-    paths = [p for i, p in enumerate(paths) if i not in remove]
-    starts = [s for i, s in enumerate(starts) if i not in remove]
-    ends = [e for i, e in enumerate(ends) if i not in remove]
+            # Gap too large, or merging would exceed `max_block`
+            new_paths.append(path)
+            new_starts.append(start)
+            new_ends.append(end)
+        else:
+            # Merge with the previous block
+            new_ends[-1] = end
 
-    if paths:
-        # Loop through the coupled `paths`, `starts`, and
-        # `ends`, and merge adjacent blocks when appropriate
-        new_paths = paths[:1]
-        new_starts = starts[:1]
-        new_ends = ends[:1]
-        for i in range(1, len(paths)):
-            if paths[i] == paths[i - 1] and new_ends[-1] is None:
-                continue
-            elif (
-                paths[i] != paths[i - 1]
-                or ((starts[i] - new_ends[-1]) > max_gap)
-                or (max_block is not None and (ends[i] - new_starts[-1]) > max_block)
-            ):
-                # Cannot merge with previous block.
-                # Add new `paths`, `starts`, and `ends` elements
-                new_paths.append(paths[i])
-                new_starts.append(starts[i])
-                new_ends.append(ends[i])
-            else:
-                # Merge with the previous block by updating the
-                # last element of `ends`
-                new_ends[-1] = ends[i]
-        return new_paths, new_starts, new_ends
-
-    # `paths` is empty. Just return input lists
-    return paths, starts, ends
+    return new_paths, new_starts, new_ends
 
 
 def file_size(filelike: IO[bytes]) -> int:


### PR DESCRIPTION
#1982 introduced a performance regression that was raised as an issue here: https://github.com/TGSAI/segy/issues/343

This PR seeks to restore the original `O(n log n)` algorithm while retaining the fixes for Parquet.