### PR TITLE
docs: clarify rm handles directories

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1297,15 +1297,14 @@ class AbstractFileSystem(metaclass=_Cached):
         raise NotImplementedError
 
     def rm(self, path, recursive=False, maxdepth=None):
-        """Delete files.
+        """Delete files or directories.
 
         Parameters
         ----------
         path: str or list of str
-            File(s) to delete.
+            Files or directories to delete.
         recursive: bool
-            If file(s) are directories, recursively delete contents and then
-            also remove the directory
+            If True, recursively delete directories and their contents.
         maxdepth: int or None
             Depth to pass to walk for finding files to delete, if recursive.
             If None, there will be no limit and infinite recursion may be


### PR DESCRIPTION
## Summary

Clarify that `AbstractFileSystem.rm` accepts files and directories, and that `recursive=True` recursively deletes directories and their contents.

Fixes #1914.

## Validation

- warning-as-error Sphinx documentation build
- numpydoc parsing check for the updated docstring
- `git diff --check`

## AI assistance

Codex (GPT-5) assisted with drafting the docstring clarification. I manually reviewed the final diff and verified the documentation checks.