### PR TITLE
docs: remove stale AsyncFileSystemWrapper experimental warning

### DIFF
--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -156,7 +156,7 @@ available as the attribute ``.loop``.
 AsyncFileSystemWrapper
 ----------------------
 
-The `AsyncFileSystemWrapper` class is an experimental feature that allows you to convert
+The `AsyncFileSystemWrapper` class allows you to convert
 a synchronous filesystem into an asynchronous one. This is useful for quickly integrating
 synchronous filesystems into workflows that may expect `AsyncFileSystem` instances.
 
@@ -183,6 +183,6 @@ backed by the normal, synchronous methods of `LocalFileSystem`:
 Limitations
 -----------
 
-This is experimental. Users should not expect this wrapper to magically make things faster.
+Users should not expect this wrapper to magically make things faster.
 It is primarily provided to allow usage of synchronous filesystems with interfaces that expect
 `AsyncFileSystem` instances.


### PR DESCRIPTION
Fixes #2087

## Summary

- Remove the stale "experimental" warning from the AsyncFileSystemWrapper documentation.
- Retain the existing note that wrapping synchronous filesystems does not make operations faster.

## Validation

- `git diff --check`
- `uv run --no-project --with sphinx --with numpydoc --with sphinx-design --with sphinx-rtd-theme --with yarl sphinx-build -b dummy docs/source /tmp/fsspec-docs-2087` (build succeeds; two pre-existing autodoc/numpydoc warnings)

Prepared with AI assistance; I reviewed the implementation and validation output.