### PR TITLE
[bug]  Fix range reads on whole-file caches and crossed ranges in cat_file

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -748,9 +748,12 @@ class WholeFileCacheFileSystem(CachingFileSystem):
             # infer the compression from the original filename, like
             # the `TarFileSystem`, let's extend the `io.BufferedReader`
             # fileobject protocol by adding a dedicated attribute
-            # `original`.
+            # `original`. `size` is added for the same reason: callers such
+            # as `AbstractFileSystem.cat_file` need it to resolve negative
+            # offsets, and `LocalFileOpener` exposes it the same way.
             f = open(fn, mode)
             f.original = detail.get("original")
+            f.size = os.fstat(f.fileno()).st_size
             return f
 
         hash = self._mapper(path)
@@ -768,12 +771,26 @@ class WholeFileCacheFileSystem(CachingFileSystem):
         path = self._strip_protocol(path)
         sha = self._mapper(path)
         fn = self._check_file(path)
+        if isinstance(fn, tuple):
+            # `WholeFileCacheFileSystem._check_file` returns `(detail, fn)`;
+            # the `SimpleCacheFileSystem` override returns just the path.
+            _, fn = fn
 
         if not fn:
             fn = os.path.join(self.storage[-1], sha)
             await self.fs._get_file(path, fn, **kwargs)
 
         with open(fn, "rb") as f:  # noqa ASYNC230
+            if (start is not None and start < 0) or (end is not None and end < 0):
+                # Negative offsets count backwards from the end of the file, as
+                # documented on ``AbstractFileSystem.cat_file``. They must be
+                # resolved against the file size first: seeking to a negative
+                # absolute position raises ``OSError(EINVAL)``.
+                file_size = os.fstat(f.fileno()).st_size
+                if start is not None and start < 0:
+                    start = max(0, file_size + start)
+                if end is not None and end < 0:
+                    end = max(0, file_size + end)
             if start:
                 f.seek(start)
             size = -1 if end is None else end - f.tell()
@@ -789,7 +806,11 @@ class WholeFileCacheFileSystem(CachingFileSystem):
         rpaths = []
         for p in paths:
             fn = self._check_file(p)
-            if fn is None and p not in rset:
+            if isinstance(fn, tuple):
+                # see `_cat_file`: the two subclasses differ in what
+                # `_check_file` returns for a cached path
+                _, fn = fn
+            if not fn and p not in rset:
                 sha = self._mapper(p)
                 fn = os.path.join(self.storage[-1], sha)
                 download.append(fn)
@@ -963,7 +984,11 @@ class SimpleCacheFileSystem(WholeFileCacheFileSystem):
         fn = self._check_file(path)
         # Just reading does not need special file handling
         if "r" in mode and "+" not in mode:
-            return open(fn, mode)
+            f = open(fn, mode)
+            # `AbstractFileSystem.cat_file` needs `size` to resolve negative
+            # offsets; `LocalFileOpener` exposes it on the raw file the same way.
+            f.size = os.fstat(f.fileno()).st_size
+            return f
 
         fn = os.path.join(self.storage[-1], sha)
         user_specified_kwargs = {

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -793,7 +793,9 @@ class WholeFileCacheFileSystem(CachingFileSystem):
                     end = max(0, file_size + end)
             if start:
                 f.seek(start)
-            size = -1 if end is None else end - f.tell()
+            # a crossed range reads nothing; clamp so that a range crossed by
+            # exactly one byte cannot produce ``-1``, the read-everything sentinel
+            size = -1 if end is None else max(0, end - f.tell())
             return f.read(size)
 
     async def _cat_ranges(
@@ -801,21 +803,28 @@ class WholeFileCacheFileSystem(CachingFileSystem):
     ):
         logger.debug("async cat ranges %s", paths)
         lpaths = []
-        rset = set()
+        # local path per unique remote path: the same path may appear in
+        # ``paths`` more than once (readers of sharded formats ask for several
+        # ranges of one object), and every occurrence needs the local path,
+        # not just the one that scheduled the download
+        resolved = {}
         download = []
         rpaths = []
         for p in paths:
+            if p in resolved:
+                lpaths.append(resolved[p])
+                continue
             fn = self._check_file(p)
             if isinstance(fn, tuple):
                 # see `_cat_file`: the two subclasses differ in what
                 # `_check_file` returns for a cached path
                 _, fn = fn
-            if not fn and p not in rset:
+            if not fn:
                 sha = self._mapper(p)
                 fn = os.path.join(self.storage[-1], sha)
                 download.append(fn)
-                rset.add(p)
                 rpaths.append(p)
+            resolved[p] = fn
             lpaths.append(fn)
         if download:
             await self.fs._get(rpaths, download, on_error=on_error)

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import shutil
@@ -1413,3 +1414,60 @@ def test_class_has_cat_file_and_cat_ranges(tmp_path, protocol):
     for attr in ("_cat_file", "_cat_ranges"):
         assert hasattr(fs, attr), f"instance missing {attr}"
         assert hasattr(type(fs), attr), f"class missing {attr}"
+
+
+@pytest.mark.parametrize("protocol", ["filecache", "simplecache"])
+def test_cat_file_negative_offsets(tmp_path, protocol):
+    """Negative start/end count backwards from the end of the file.
+
+    ``AbstractFileSystem.cat_file`` documents this, and remote backends such as
+    S3 implement it as an HTTP suffix range. Whole-file caches serve ranges from
+    the local copy instead, so they must resolve negative offsets against the
+    file size rather than seeking to a negative absolute position, which raises
+    ``OSError(EINVAL)``.
+    """
+    data = b"0123456789"
+    fsspec.filesystem("memory").pipe_file("/afile", data)
+
+    fs = fsspec.filesystem(
+        protocol, target_protocol="memory", cache_storage=str(tmp_path)
+    )
+
+    assert fs.cat_file("/afile", start=-3) == data[-3:]
+    assert fs.cat_file("/afile", start=-3, end=-1) == data[-3:-1]
+    assert fs.cat_file("/afile", start=2, end=-2) == data[2:-2]
+    # out-of-range suffixes clamp to the whole file, as in the base class
+    assert fs.cat_file("/afile", start=-100) == data
+
+    # non-negative offsets are unaffected
+    assert fs.cat_file("/afile") == data
+    assert fs.cat_file("/afile", start=2) == data[2:]
+    assert fs.cat_file("/afile", start=2, end=5) == data[2:5]
+
+    # async consumers (e.g. zarr's FsspecStore) await ``_cat_file`` directly.
+    # The file is cached by now, so no download is awaited on this path.
+    assert asyncio.run(fs._cat_file("/afile", start=-3)) == data[-3:]
+    assert asyncio.run(fs._cat_file("/afile", start=-3, end=-1)) == data[-3:-1]
+    assert asyncio.run(fs._cat_file("/afile", start=2, end=-2)) == data[2:-2]
+    assert asyncio.run(fs._cat_file("/afile", start=-100)) == data
+    assert asyncio.run(fs._cat_file("/afile", start=2, end=5)) == data[2:5]
+
+
+@pytest.mark.parametrize("protocol", ["filecache", "simplecache"])
+def test_cat_ranges_of_cached_file(tmp_path, protocol):
+    """``_cat_ranges`` must accept what ``_check_file`` returns.
+
+    ``WholeFileCacheFileSystem._check_file`` returns a ``(detail, path)`` tuple
+    for a cached file, while the ``SimpleCacheFileSystem`` override returns the
+    path alone; the shared implementation has to handle both.
+    """
+    data = b"0123456789"
+    fsspec.filesystem("memory").pipe_file("/afile", data)
+
+    fs = fsspec.filesystem(
+        protocol, target_protocol="memory", cache_storage=str(tmp_path)
+    )
+    fs.cat_file("/afile")  # populate the cache
+
+    assert fs.cat_ranges(["/afile"], [2], [5]) == [data[2:5]]
+    assert asyncio.run(fs._cat_ranges(["/afile"], [2], [5])) == [data[2:5]]

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -9,6 +9,7 @@ import pytest
 import fsspec
 from fsspec.compression import compr
 from fsspec.exceptions import BlocksizeMismatchError
+from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
 from fsspec.implementations.cache_mapper import (
     BasenameCacheMapper,
     HashCacheMapper,
@@ -1452,6 +1453,12 @@ def test_cat_file_negative_offsets(tmp_path, protocol):
     assert asyncio.run(fs._cat_file("/afile", start=-100)) == data
     assert asyncio.run(fs._cat_file("/afile", start=2, end=5)) == data[2:5]
 
+    # a range crossed by exactly one byte must not compute a read size of -1,
+    # which would read the rest of the file instead of returning nothing
+    assert asyncio.run(fs._cat_file("/afile", start=6, end=-5)) == b""
+    assert asyncio.run(fs._cat_file("/afile", start=8, end=-5)) == b""
+    assert asyncio.run(fs._cat_file("/afile", start=6, end=5)) == b""
+
 
 @pytest.mark.parametrize("protocol", ["filecache", "simplecache"])
 def test_cat_ranges_of_cached_file(tmp_path, protocol):
@@ -1471,3 +1478,26 @@ def test_cat_ranges_of_cached_file(tmp_path, protocol):
 
     assert fs.cat_ranges(["/afile"], [2], [5]) == [data[2:5]]
     assert asyncio.run(fs._cat_ranges(["/afile"], [2], [5])) == [data[2:5]]
+
+
+@pytest.mark.parametrize("protocol", ["filecache", "simplecache"])
+def test_cat_ranges_repeated_uncached_path(tmp_path, protocol):
+    """Several ranges of one uncached object all resolve to the local copy.
+
+    Readers of sharded formats routinely ask for many ranges of the same
+    object, so only the first occurrence schedules a download and the rest
+    must still be given the local path rather than the cache-miss sentinel.
+    """
+    data = b"0123456789"
+    memfs = fsspec.filesystem("memory")
+    memfs.pipe_file("/afile", data)
+
+    fs = fsspec.filesystem(
+        protocol, fs=AsyncFileSystemWrapper(memfs), cache_storage=str(tmp_path)
+    )
+
+    paths = ["/afile", "/afile", "/afile"]
+    expected = [data[2:5], data[0:3], data[7:9]]
+    assert asyncio.run(fs._cat_ranges(paths, [2, 0, 7], [5, 3, 9])) == expected
+    # and again now that the file is cached
+    assert asyncio.run(fs._cat_ranges(paths, [2, 0, 7], [5, 3, 9])) == expected

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -383,6 +383,33 @@ def test_open_auto_mkdir_create_modes(tmpdir, mode):
     assert fs.cat_file(fn) == b"data"
 
 
+@pytest.mark.parametrize(
+    "start,end",
+    [
+        (6, -5),  # crossed by one byte: end - tell() == -1, read()'s "to EOF"
+        (8, -5),
+        (6, 5),
+        (9, 1),
+        (None, -100),  # suffix longer than the file
+        (2, -2),
+        (-3, -1),
+        (2, 5),
+        (-4, None),
+        (None, None),
+    ],
+)
+def test_cat_file_offsets_match_slices(tmpdir, start, end):
+    # ``cat_file`` documents start/end as behaving "like usual python slices",
+    # so a crossed range must read nothing rather than falling through to a
+    # negative read length.
+    data = b"0123456789"
+    fn = str(tmpdir) + "/afile"
+    fs = fsspec.filesystem("file")
+    fs.pipe_file(fn, data)
+
+    assert fs.cat_file(fn, start=start, end=end) == data[start:end]
+
+
 def test_touch_truncate(tmpdir):
     fn = str(tmpdir + "/tfile")
     fs = fsspec.filesystem("file")

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -853,19 +853,24 @@ class AbstractFileSystem(metaclass=_Cached):
         """
         # explicitly set buffering off?
         with self.open(path, "rb", **kwargs) as f:
-            if start is not None:
-                if start >= 0:
-                    f.seek(start)
-                else:
-                    f.seek(max(0, f.size + start))
-            if end is not None:
-                if end < 0:
-                    end = f.size + end
-                # a crossed range reads nothing, like a python slice. Without
-                # the clamp, a range crossed by exactly one byte computes -1,
-                # which ``read`` takes as "to the end of the file"
-                return f.read(max(0, end - f.tell()))
-            return f.read()
+            if (start is not None and start < 0) or (end is not None and end < 0):
+                # A negative offset counts backwards from the end of the file,
+                # so resolve both to absolute positions -- which is precisely
+                # what a python slice does, clamping included. Only this case
+                # needs the file size, and not every file object carries one
+                # (``tarfile.ExFileObject``, for instance), so nothing else
+                # may touch it.
+                start, end, _ = slice(start, end).indices(f.size)
+
+            if start:
+                f.seek(start)
+            if end is None:
+                # no upper bound: read to the end of the file
+                return f.read()
+            # a crossed range reads nothing. Without the clamp, a range
+            # crossed by exactly one byte gives a length of -1, which ``read``
+            # takes as "to the end of the file"
+            return f.read(max(0, end - f.tell()))
 
     def pipe_file(self, path, value, mode="overwrite", **kwargs):
         """Set the bytes of given file"""

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -861,7 +861,10 @@ class AbstractFileSystem(metaclass=_Cached):
             if end is not None:
                 if end < 0:
                     end = f.size + end
-                return f.read(end - f.tell())
+                # a crossed range reads nothing, like a python slice. Without
+                # the clamp, a range crossed by exactly one byte computes -1,
+                # which ``read`` takes as "to the end of the file"
+                return f.read(max(0, end - f.tell()))
             return f.read()
 
     def pipe_file(self, path, value, mode="overwrite", **kwargs):


### PR DESCRIPTION
`filecache` and `simplecache` serve range reads out of the local copy of a file rather than from the remote. Several defects in that path make range reads on a cached file fail, and chasing them down surfaced one more in the shared base-class implementation.

## `WholeFileCacheFileSystem` / `SimpleCacheFileSystem`

**1. Negative `start`/`end` raise `OSError(EINVAL)`**

`AbstractFileSystem.cat_file` documents negative offsets as counting backwards from the end of the file ("like usual python slices"), and remote backends such as `s3fs` implement them as an HTTP suffix range. `WholeFileCacheFileSystem._cat_file` passed the value straight to `f.seek(start)`, which asks for a negative *absolute* position:

```python
fs = fsspec.filesystem("simplecache", target_protocol="s3")
fs.cat_file(path, start=-260)   # OSError: [Errno 22] Invalid argument
```

The failure happens *after* the whole object has been downloaded into the cache, so the local copy that could trivially serve the read is fetched and then discarded.

**2. `AttributeError: '_io.BufferedReader' object has no attribute 'size'`**

The sync path goes through `AbstractFileSystem.cat_file`, which needs `f.size` to resolve a negative offset. Both `_open` implementations here return a bare `io.BufferedReader`, so it raises. `LocalFileOpener` already attaches `size` to the raw file object (`local.py`), so this follows the existing idiom.

**3. `_check_file` return type is not handled consistently**

`WholeFileCacheFileSystem._check_file` returns a `(detail, path)` tuple, while the `SimpleCacheFileSystem` override returns the path alone. `_cat_file` and `_cat_ranges` assume the latter, so on `filecache`:

```python
fs.cat_file(path)          # populate cache
asyncio.run(fs._cat_file(path))    # TypeError: expected str, bytes or os.PathLike object, not tuple
asyncio.run(fs._cat_ranges([path], [2], [5]))  # AttributeError: 'tuple' object has no attribute 'startswith'
```

`_cat_ranges` additionally never downloaded an uncached path, because it tests `fn is None` while the cache-miss sentinel here is `False`.

**4. A range crossed by one byte reads the rest of the file**

`_cat_file` computed the read length as `end - f.tell()`. `read()` treats a negative length as "to the end of the file", so a range crossed by exactly one byte hit that sentinel by accident. Resolving negative offsets to absolute ones (defect 1) makes this reachable from ordinary input:

```python
# 10-byte cached file
asyncio.run(fs._cat_file(path, start=6, end=-5))   # b"6789", expected b""
asyncio.run(fs._cat_file(path, start=8, end=-5))   # ValueError: read length must be non-negative or -1
```

Note the two different failures: a one-byte crossing computes `-1` and silently returns data, anything wider computes `-2` or less and raises.

**5. Repeated paths in `_cat_ranges` resolve to the cache-miss sentinel**

`_cat_ranges` used `rset` purely as a membership set, so only the *first* occurrence of an uncached path was assigned a local path. Every later occurrence appended the falsy sentinel to `lpaths`, and `LocalFileSystem.cat_ranges` returned an exception object in that slot — silently, since `on_error` defaults to `"return"`:

```python
asyncio.run(fs._cat_ranges(["/d1", "/d1", "/d1"], [2, 0, 7], [5, 3, 9]))
# [b'234', AttributeError("'bool' object has no attribute 'startswith'"), AttributeError(...)]
```

Asking for several ranges of one object is the normal access pattern for sharded formats, which is exactly what this PR is about.

## `AbstractFileSystem.cat_file`

Defect 4 is not specific to the caches — the base implementation computes the length the same way, so it is reachable on *every* backend that does not override `cat_file`:

```python
fsspec.filesystem("file").cat_file(fn, start=6, end=-5)   # b"6789", expected b""
```

The offsets were also normalized inconsistently: a negative `start` clamped at 0, a negative `end` did not, so a suffix longer than the file raised instead of yielding empty (`data[:-100]` is `b""`, but `cat_file(end=-100)` raised `ValueError`). And `None` was handled by control flow rather than as a value, giving three different mechanisms for one idea.

`slice.indices` already performs exactly this normalization — clamping included — so both offsets now resolve through it, which is literally what the docstring promises. It needs the size up front and not every file object has one (`TarFileSystem` yields a `tarfile.ExFileObject`, which would then break even a plain full-file read), so the size is consulted only when an offset is actually negative — the same condition under which the old code read `f.size`. No backend loses a case that previously worked.

### How this came up

zarr v3 sharded arrays store the inner-chunk index at the *end* of each shard object, so every read begins with a suffix-range request. Reading such an array over `simplecache::s3://` downloads the full shard and use negative index to read files.

### Changes

`fsspec/implementations/cached.py`

- `_cat_file`: resolve negative `start`/`end` against the file size before seeking, mirroring `AbstractFileSystem.cat_file`, and clamp the read length so a crossed range cannot collide with `read()`'s to-EOF sentinel.
- `_open` (both classes): expose `size` on the returned file object.
- `_cat_file` / `_cat_ranges`: accept either `_check_file` return shape, and treat any falsy value as a cache miss.
- `_cat_ranges`: track the resolved local path per unique path, so repeated paths all resolve.

`fsspec/spec.py`

- `cat_file`: resolve `start`/`end` through `slice.indices` against the file size, consulted only when an offset is negative.

Tests

- Negative offsets, crossed ranges, and cached `cat_ranges` on both `filecache` and `simplecache`, over sync `cat_file` and the awaited `_cat_file` that async consumers (e.g. zarr's `FsspecStore`) use.
- Repeated uncached paths through `_cat_ranges`, against an async target so the download branch is actually exercised.
- `cat_file` start/end combinations checked against `data[start:end]` directly, since python slice semantics are what the docstring promises.
