### PR TITLE
Keep BlockCache and BackgroundBlockCache usable after pickling

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Dev
+---
+
+Fixes
+
+- Avoid mutating live ``BlockCache`` and ``BackgroundBlockCache`` instances
+  when pickling (#2102)
+
 2026.7.0
 --------
 

--- a/fsspec/caching.py
+++ b/fsspec/caching.py
@@ -375,7 +375,7 @@ class BlockCache(BaseCache):
         return self._fetch_block_cached.cache_info()
 
     def __getstate__(self) -> dict[str, Any]:
-        state = self.__dict__
+        state = self.__dict__.copy()
         del state["_fetch_block_cached"]
         return state
 
@@ -832,7 +832,7 @@ class BackgroundBlockCache(BaseCache):
         del self._fetch_block_cached
 
     def __getstate__(self) -> dict[str, Any]:
-        state = self.__dict__
+        state = self.__dict__.copy()
         del state["_fetch_block_cached"]
         del state["_thread_executor"]
         del state["_fetch_future_block_number"]

--- a/fsspec/tests/test_caches.py
+++ b/fsspec/tests/test_caches.py
@@ -194,7 +194,9 @@ def test_cache_pickleable(Cache_imp):
     size = 100
     cache = Cache_imp(blocksize, _fetcher, size)
     cache._fetch(0, 5)  # fill in cache
-    unpickled = pickle.loads(pickle.dumps(cache))
+    payload = pickle.dumps(cache)
+    assert cache._fetch(0, 10) == b"0" * 10
+    unpickled = pickle.loads(payload)
     assert isinstance(unpickled, Cache_imp)
     assert unpickled.blocksize == blocksize
     assert unpickled.size == size


### PR DESCRIPTION
### Problem

`BlockCache.__getstate__` and `BackgroundBlockCache.__getstate__` used
`self.__dict__` directly and then removed runtime-only attributes from that
mapping. Because it is the live instance dictionary, `pickle.dumps(cache)`
left the original cache unusable.

Subsequent reads raised `AttributeError` for `_fetch_block_cached` in
`BlockCache` and `_fetch_future_lock` in `BackgroundBlockCache`.

### Change

Copy the instance dictionary before removing unpicklable runtime state. This
mirrors `MMapCache.__getstate__` and keeps the original cache intact.

The serialized form remains unchanged in intent: runtime executors, locks,
futures, and in-memory block-cache contents are reconstructed rather than
persisted.

The existing parametrized pickle test now verifies both the original cache
after serialization and the restored cache.

### Validation

On `master`, the regression reproduces both `AttributeError` failures above.

- focused pickle regression: 9 passed
- `fsspec/tests/test_caches.py`: 157 passed
- `fsspec/tests`: 576 passed, 91 skipped, 2 xfailed
- targeted pre-commit hooks: passed
- `git diff --check`: passed

The full cross-platform, downstream, s3fs, and gcsfs matrix was not run locally
and is left to GitHub CI.

### AI assistance disclosure

OpenAI Codex assisted with investigation, test design, adversarial validation,
and drafting this change.
