### PR TITLE
get: reject copy destinations that resolve above the target

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -15,7 +15,7 @@ from .callbacks import DEFAULT_CALLBACK
 from .exceptions import FSTimeoutError
 from .implementations.local import LocalFileSystem, make_path_posix, trailing_sep
 from .spec import AbstractBufferedFile, AbstractFileSystem
-from .utils import glob_translate, is_exception, other_paths
+from .utils import check_contained, glob_translate, is_exception, other_paths
 
 private = re.compile("_[^_]")
 iothread = [None]  # dedicated fsspec IO thread
@@ -698,6 +698,11 @@ class AsyncFileSystem(AbstractFileSystem):
                 exists=exists,
                 flatten=not source_is_str,
             )
+            if isinstance(lpath, str):
+                # The names came from the source listing; ".." in one of them
+                # would otherwise place the copy above the destination. When
+                # lpath is a list the caller named every destination itself.
+                check_contained(lpath, lpaths)
 
         [os.makedirs(os.path.dirname(lp), exist_ok=True) for lp in lpaths]
         batch_size = kwargs.pop("batch_size", self.batch_size)

--- a/fsspec/implementations/tests/test_archive.py
+++ b/fsspec/implementations/tests/test_archive.py
@@ -393,24 +393,10 @@ class TestAnyArchive:
 
         with scenario.provider(data) as archive:
             fs = fsspec.filesystem(scenario.protocol, fo=archive)
-            try:
-                fs.get("*", str(dest), recursive=True)
-            except ValueError:
-                pass
-
-        assert not outside.exists(), f"copy wrote {outside}, above {dest}"
-
-    def test_get_rejects_member_pointing_above_destination(
-        self, scenario: ArchiveTestScenario, tmp_path
-    ):
-        data = {"readme.txt": b"ok", "../escaped.txt": b"escaped"}
-        dest = tmp_path / "dest"
-        dest.mkdir()
-
-        with scenario.provider(data) as archive:
-            fs = fsspec.filesystem(scenario.protocol, fo=archive)
             with pytest.raises(ValueError, match="outside the destination"):
                 fs.get("*", str(dest), recursive=True)
+
+        assert not outside.exists(), f"copy wrote {outside}, above {dest}"
 
     def test_get_keeps_dotdot_inside_destination(
         self, scenario: ArchiveTestScenario, tmp_path

--- a/fsspec/implementations/tests/test_archive.py
+++ b/fsspec/implementations/tests/test_archive.py
@@ -380,3 +380,49 @@ class TestAnyArchive:
         with scenario.provider(archive_data) as archive:
             fs = fsspec.filesystem(scenario.protocol, fo=archive)
             assert fs.open("a").read() == b""
+
+    def test_get_does_not_write_above_destination(
+        self, scenario: ArchiveTestScenario, tmp_path
+    ):
+        # Member names come from the archive, so a name holding ".." must not
+        # place the copy above the destination the caller asked for.
+        data = {"readme.txt": b"ok", "../escaped.txt": b"escaped"}
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        outside = tmp_path / "escaped.txt"
+
+        with scenario.provider(data) as archive:
+            fs = fsspec.filesystem(scenario.protocol, fo=archive)
+            try:
+                fs.get("*", str(dest), recursive=True)
+            except ValueError:
+                pass
+
+        assert not outside.exists(), f"copy wrote {outside}, above {dest}"
+
+    def test_get_rejects_member_pointing_above_destination(
+        self, scenario: ArchiveTestScenario, tmp_path
+    ):
+        data = {"readme.txt": b"ok", "../escaped.txt": b"escaped"}
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        with scenario.provider(data) as archive:
+            fs = fsspec.filesystem(scenario.protocol, fo=archive)
+            with pytest.raises(ValueError, match="outside the destination"):
+                fs.get("*", str(dest), recursive=True)
+
+    def test_get_keeps_dotdot_inside_destination(
+        self, scenario: ArchiveTestScenario, tmp_path
+    ):
+        # ".." that resolves within the destination stays a legitimate name.
+        data = {"plain.txt": b"ok", "a/b/../inner.txt": b"inner"}
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        with scenario.provider(data) as archive:
+            fs = fsspec.filesystem(scenario.protocol, fo=archive)
+            fs.get("*", str(dest), recursive=True)
+
+        assert (dest / "plain.txt").read_bytes() == b"ok"
+        assert (dest / "a" / "inner.txt").read_bytes() == b"inner"

--- a/fsspec/implementations/tests/test_asyn_wrapper.py
+++ b/fsspec/implementations/tests/test_asyn_wrapper.py
@@ -1,5 +1,7 @@
 import asyncio
+import io
 import os
+import tarfile
 from itertools import cycle
 
 import pytest
@@ -218,3 +220,28 @@ async def test_deadlock_when_asynchronous():
 
     with pytest.raises(RuntimeError, match="Concurrent requests!"):
         await asyncio.gather(*(fs._cat_file(path) for path in paths))
+
+
+def test_get_does_not_write_above_destination(tmp_path):
+    # The async copy builds its destinations the same way the sync one does,
+    # so a source name holding ".." must not escape the destination there
+    # either. tar is synchronous, so it is wrapped to exercise
+    # AsyncFileSystem._get.
+    archive = tmp_path / "traversal.tar"
+    with tarfile.open(archive, "w") as t:
+        for name, data in [("readme.txt", b"ok"), ("../escaped.txt", b"escaped")]:
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            t.addfile(info, io.BytesIO(data))
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    outside = tmp_path / "escaped.txt"
+
+    fs = AsyncFileSystemWrapper(fsspec.filesystem("tar", fo=str(archive)))
+    try:
+        fs.get("*", str(dest), recursive=True)
+    except ValueError:
+        pass
+
+    assert not outside.exists(), f"async copy wrote {outside}, above {dest}"

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -18,6 +18,7 @@ from .dircache import DirCache
 from .transaction import Transaction
 from .utils import (
     _unstrip_protocol,
+    check_contained,
     glob_translate,
     isfilelike,
     other_paths,
@@ -1057,6 +1058,11 @@ class AbstractFileSystem(metaclass=_Cached):
                 exists=exists,
                 flatten=not source_is_str,
             )
+            if isinstance(lpath, str):
+                # The names came from the source listing; ".." in one of them
+                # would otherwise place the copy above the destination. When
+                # lpath is a list the caller named every destination itself.
+                check_contained(lpath, lpaths)
 
         callback.set_size(len(lpaths))
         for lpath, rpath in callback.wrap(zip(lpaths, rpaths)):

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -1,4 +1,5 @@
 import io
+import os
 import sys
 from pathlib import Path, PurePath
 from unittest.mock import Mock
@@ -8,6 +9,7 @@ import pytest
 import fsspec.utils
 from fsspec.utils import (
     can_be_local,
+    check_contained,
     common_prefix,
     get_file_extension,
     get_protocol,
@@ -490,3 +492,26 @@ def test_stringify_path(path, expected):
     path = fsspec.utils.stringify_path(path)
 
     assert path == expected
+
+
+@pytest.mark.parametrize(
+    "root, path, contained",
+    (
+        ("/dest", "/dest/inside.txt", True),
+        ("/dest", "/dest/a/b/inside.txt", True),
+        ("/dest", "/dest", True),
+        ("/dest", "/dest/a/../inside.txt", True),
+        ("/dest", "/escaped.txt", False),
+        ("/dest", "/dest/../escaped.txt", False),
+        # A sibling whose name starts with the root must not count as inside.
+        ("/dest", "/destination/escaped.txt", False),
+    ),
+)
+def test_check_contained(root, path, contained):
+    root = os.path.abspath(root)
+    path = os.path.abspath(path)
+    if contained:
+        check_contained(root, [path])
+    else:
+        with pytest.raises(ValueError, match="outside the destination"):
+            check_contained(root, [path])

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -422,6 +422,36 @@ def other_paths(
     return path2
 
 
+def check_contained(root: str, paths: list[str]) -> None:
+    """Raise if any of ``paths`` lies outside the destination ``root``.
+
+    Bulk copies build their destination names by joining source names onto a
+    destination root. Those names come from the source listing, so a name
+    holding ".." segments resolves above the root and writes outside the
+    destination the caller asked for.
+
+    Parameters
+    ----------
+    root: str
+        The destination the caller passed.
+    paths: list of str
+        The destination names built for that root.
+    """
+    root_abs = os.path.abspath(root)
+    # normcase so that a case-insensitive platform does not report a false
+    # escape, while the message keeps the paths as the caller would see them.
+    root_key = os.path.normcase(root_abs)
+    prefix = root_key.rstrip(os.sep) + os.sep
+    for path in paths:
+        path_abs = os.path.abspath(path)
+        path_key = os.path.normcase(path_abs)
+        if path_key != root_key and not path_key.startswith(prefix):
+            raise ValueError(
+                f"path {path!r} would be copied to {path_abs!r}, which is "
+                f"outside the destination {root!r}"
+            )
+
+
 def is_exception(obj: Any) -> bool:
     return isinstance(obj, BaseException)
 


### PR DESCRIPTION
## Summary

`get(rpath, lpath, recursive=True)` builds each local destination by joining a name from the
source listing onto `lpath`, then writes it. A name carrying `..` segments resolves above that
root, so the copy lands outside the directory the caller asked for. Nothing between
`other_paths` and `get_file` compares the result against the root.

A tar or zip whose member list is `["readme.txt", "../escaped.txt"]` puts `readme.txt` in the
destination and `escaped.txt` one level above it. With more segments the location moves further
out: a member named `../../../../escaped.txt` copied into a destination four levels down lands at
the filesystem root. There is no exception, no warning, and the call returns normally, so a caller
has nothing to check.

The async path in `AsyncFileSystem._get` has the same shape and behaves the same way, which is
the path `s3fs`, `gcsfs`, `adlfs` and `HTTPFileSystem` take.

This is the same class as #2047, one surface further along. That one hardened `DirFileSystem._join`
on the source side; the copy path still builds destinations by string arithmetic.

## The change

A helper in `fsspec/utils.py` compares each built destination against the destination root and
raises `ValueError` if it resolves outside, called from `AbstractFileSystem.get` and
`AsyncFileSystem._get` right after `other_paths`, and only when `lpath` is a single string. When
the caller passes a list, they named every destination themselves and the guard stays out of the
way.

## On the ".." objection from #2047

The concern raised there was that `..` is a legitimate path part on many filesystems and only
means something on `LocalFileSystem`, so `_join` ended up narrowing its guard to that case. This
check does not need the same narrowing, because it sits on the destination side, and the
destination of `get` is a real local directory tree by definition. `copying.rst` states the
intent directly: the copy functions are meant to behave as POSIX `cp` does.

A `..` that stays inside the root is still a plain name. `a/b/../inner.txt` lands at
`dest/a/inner.txt` both before and after the change, and there is a test for it.

## Testing

Three cases were added to `TestAnyArchive`, so they run across zip, tar, tar.gz, tar.bz2, tar.xz
and libarchive, plus one in `test_asyn_wrapper.py` for the async path. Two of them state the
property (nothing above the destination) and the contract (`ValueError`); the third is the
control that `..` inside the destination keeps working.

Measured in a conda environment built from `ci/environment-linux.yml` with the 3.14 matrix entry
and `pip install -e .[test_full]`, `CIRUN=true`, so the s3fs, gcsfs, adlfs, pyarrow, pandas, dask,
zarr, fastparquet, kerchunk, panel, paramiko, smbprotocol and libarchive suites all ran:

| | without the change | with the change |
|---|---|---|
| full suite | 5 failed, 1892 passed, 66 skipped, 3 xfailed | 5 failed, 1911 passed, 66 skipped, 3 xfailed |

The set of failing tests is identical in both runs, so there is no regression. Those five are
`test_reference.py` parquet cases that already fail on an untouched tree in this environment.

One aside, in case it turns up in a CI run: `test_cached.py::test_clear_expired` is timing
dependent here. Run on its own it failed once in six attempts with the change and once in six
without it, so it does not look related to this patch, but I would rather mention it than have it
appear unexplained.

Before the change the new cases give 13 failed, 6 passed, the six being the control across the
archive scenarios. The first of them reports the substance rather than a missing exception:

```
AssertionError: copy wrote /tmp/pytest-of-root/pytest-1/test_get_does_not_write_above_0/escaped.txt,
above /tmp/pytest-of-root/pytest-1/test_get_does_not_write_above_0/dest
```

`ruff check fsspec/` reports the same findings with and without the change.

## Neighbours I did not touch

`put` and `copy` build their destinations the same way, but their target is a remote filesystem
where `..` is an ordinary name part, which is the situation #2047 discussed. They seem to want a
different answer and are left alone here.

`ReferenceFileSystem.get` overrides `get` and calls `other_paths` itself, so this change does not
reach it. Its listing does carry `..` keys through `expand_path`, but in my setup that copy wrote
nothing at all, including the benign file, so I have no working control there and make no claim
about it. Happy to look again if it is worth a separate issue.

I did not add a changelog entry, since recent merged pull requests do not seem to carry one. Say
the word and I will add a line.
