### PR TITLE
Pass maxdepth through in AsyncFileSystem._rm

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -364,10 +364,12 @@ class AsyncFileSystem(AbstractFileSystem):
             return await self._rm(path, recursive=False, batch_size=1, **kwargs)
         raise NotImplementedError
 
-    async def _rm(self, path, recursive=False, batch_size=None, **kwargs):
+    async def _rm(
+        self, path, recursive=False, batch_size=None, maxdepth=None, **kwargs
+    ):
         # TODO: implement on_error
         batch_size = batch_size or self.batch_size
-        path = await self._expand_path(path, recursive=recursive)
+        path = await self._expand_path(path, recursive=recursive, maxdepth=maxdepth)
         return await _run_coros_in_chunks(
             [self._rm_file(p, **kwargs) for p in reversed(path)],
             batch_size=batch_size,

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -254,6 +254,46 @@ def test_rm_file_without_implementation():
         fs.rm_file("test/file.txt")
 
 
+class _MaxDepthFS(fsspec.asyn.AsyncFileSystem):
+    # Mirrors the gcsfs/s3fs pattern: implements the primitives, inherits _rm.
+    def __init__(self, files, **kwargs):
+        super().__init__(**kwargs)
+        self.files = set(files)
+        self.removed_paths = []
+
+    async def _ls(self, path, detail=True, **kwargs):
+        path = path.rstrip("/")
+        kids = {}
+        for f in self.files:
+            if not f.startswith(path + "/"):
+                continue
+            head = f[len(path) + 1 :].split("/")[0]
+            full = f"{path}/{head}"
+            kids[full] = {
+                "name": full,
+                "size": 0,
+                "type": "file" if full in self.files else "directory",
+            }
+        return list(kids.values()) if detail else sorted(kids)
+
+    async def _info(self, path, **kwargs):
+        path = path.rstrip("/")
+        typ = "file" if path in self.files else "directory"
+        return {"name": path, "size": 0, "type": typ}
+
+    async def _rm_file(self, path, **kwargs):
+        self.removed_paths.append(path)
+        self.files.discard(path)
+
+
+def test_rm_honours_maxdepth():
+    tree = ["/root/a.txt", "/root/d1/b.txt", "/root/d1/d2/c.txt"]
+    fs = _MaxDepthFS(tree)
+    fs.rm("/root", recursive=True, maxdepth=1)
+    assert "/root/d1/b.txt" not in fs.removed_paths
+    assert "/root/d1/d2/c.txt" not in fs.removed_paths
+
+
 class _CatRangesFS(fsspec.asyn.AsyncFileSystem):
     # Mirrors the gcsfs/s3fs pattern: overrides _cat_file, inherits _cat_ranges.
     cachable = False


### PR DESCRIPTION
`AsyncFileSystem._rm` accepts `maxdepth` into `**kwargs` and never uses it, so async filesystems delete deeper than the caller asked for.

```python
async def _rm(self, path, recursive=False, batch_size=None, **kwargs):
    batch_size = batch_size or self.batch_size
    path = await self._expand_path(path, recursive=recursive)
```

The sync twin passes it on:

```python
def rm(self, path, recursive=False, maxdepth=None):
    path = self.expand_path(path, recursive=recursive, maxdepth=maxdepth)
```

`maxdepth` bounds which paths get collected for deletion, and its own docstring says that without it "there will be no limit and infinite recursion may be possible". On the async side it lands in `**kwargs` and is forwarded to `_rm_file`, which has no use for it, while `_expand_path` runs unbounded.

With a tree of `/root/a.txt`, `/root/d1/b.txt` and `/root/d1/d2/c.txt`, calling `rm("/root", recursive=True, maxdepth=1)` on the same primitives:

```
sync   deleted /root, /root/a.txt, /root/d1
async  deleted /root, /root/a.txt, /root/d1, /root/d1/b.txt, /root/d1/d2, /root/d1/d2/c.txt
```

Three files the bound was meant to protect. That's data loss. This reaches any backend implementing `_rm_file` and inheriting `_rm`, which is the usual pattern, and `delete()` is an alias of `rm` carrying `maxdepth` too.

Test is `test_rm_honours_maxdepth`, using the same shape as the existing `_CatRangesFS` case. Suite goes 1556 to 1557 on `fsspec/tests` and `fsspec/implementations/tests`. Reverting only `asyn.py` fails that one test, so it's the fix being measured. `ruff check` and `ruff format` are clean under the 0.14.3 you pin in pre-commit.

This only touches the base class. A backend overriding `_rm` with its own signature needs the same change, and I have not run this against a real cloud backend.
