### PR TITLE
Always end the transaction, even when a commit or discard raises

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,9 @@ Fixes
 - Avoid mutating live ``BlockCache`` and ``BackgroundBlockCache`` instances
   when pickling (#2102)
 
+- End the transaction even when a commit or discard raises, so the filesystem
+  is not left in transaction mode and deferred temporary files are cleaned up
+
 2026.7.0
 --------
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -1,5 +1,6 @@
 import bz2
 import errno
+import glob
 import gzip
 import os
 import os.path
@@ -16,7 +17,12 @@ import pytest
 import fsspec
 from fsspec import compression
 from fsspec.core import OpenFile, get_fs_token_paths, open_files
-from fsspec.implementations.local import LocalFileSystem, get_umask, make_path_posix
+from fsspec.implementations.local import (
+    LocalFileOpener,
+    LocalFileSystem,
+    get_umask,
+    make_path_posix,
+)
 from fsspec.tests.test_utils import WIN
 
 files = {
@@ -531,6 +537,37 @@ def test_transaction_with_compression(tmpdir):
 
     with gzip.open(path, "rt") as f:
         assert f.read() == "data"
+
+
+def test_transaction_ends_when_a_commit_fails(tmpdir):
+    # A failed commit must not leave the filesystem mid-transaction: instances
+    # are cached, so every later write would be deferred into a temporary file
+    # that nothing commits, and would vanish without an error.
+    fs = LocalFileSystem()
+    real_commit = LocalFileOpener.commit
+    tmp_before = set(glob.glob(os.path.join(tempfile.gettempdir(), "tmp*")))
+
+    def commit(self):
+        if os.path.basename(self.path) == "b":
+            raise PermissionError(self.path)
+        real_commit(self)
+
+    with patch.object(LocalFileOpener, "commit", commit):
+        with pytest.raises(PermissionError):
+            with fs.transaction:
+                for name in ("a", "b", "c"):
+                    with fs.open(str(tmpdir / name), "wb") as f:
+                        f.write(b"data")
+
+    assert fs._intrans is False
+    assert fs._transaction is None
+    assert not set(glob.glob(os.path.join(tempfile.gettempdir(), "tmp*"))) - tmp_before
+
+    # the instance is still usable, and a later write is not swallowed
+    path = str(tmpdir / "later")
+    with fs.open(path, "wb") as f:
+        f.write(b"data")
+    assert fs.cat(path) == b"data"
 
 
 def test_same_permissions_with_and_without_transaction(tmpdir):

--- a/fsspec/transaction.py
+++ b/fsspec/transaction.py
@@ -1,4 +1,7 @@
+import logging
 from collections import deque
+
+logger = logging.getLogger("fsspec")
 
 
 class Transaction:
@@ -38,15 +41,32 @@ class Transaction:
 
     def complete(self, commit=True):
         """Finish transaction: commit or discard all deferred files"""
-        while self.files:
-            f = self.files.popleft()
-            if commit:
-                f.commit()
-            else:
-                f.discard()
-        self.fs._intrans = False
-        self.fs._transaction = None
-        self.fs = None
+        f = None
+        try:
+            while self.files:
+                f = self.files.popleft()
+                if commit:
+                    f.commit()
+                else:
+                    f.discard()
+                f = None
+        finally:
+            # the file being processed when the error was raised is already
+            # off the queue; put it back so its temporary file is cleaned up
+            if f is not None:
+                self.files.appendleft(f)
+            # A failed commit or discard must still end the transaction.
+            # Leaving _intrans set would defer every later write on this
+            # filesystem into a temporary file that nothing ever commits,
+            # and instances are cached, so that would persist process-wide.
+            while self.files:
+                try:
+                    self.files.popleft().discard()
+                except Exception:
+                    logger.debug("Discarding deferred file failed", exc_info=True)
+            self.fs._intrans = False
+            self.fs._transaction = None
+            self.fs = None
 
 
 class FileActor:
@@ -82,9 +102,12 @@ class DaskTransaction(Transaction):
 
     def complete(self, commit=True):
         """Finish transaction: commit or discard all deferred files"""
-        if commit:
-            self.files.commit().result()
-        else:
-            self.files.discard().result()
-        self.fs._intrans = False
-        self.fs = None
+        try:
+            if commit:
+                self.files.commit().result()
+            else:
+                self.files.discard().result()
+        finally:
+            self.fs._intrans = False
+            self.fs._transaction = None
+            self.fs = None


### PR DESCRIPTION
## The problem

`Transaction.complete()` drains the file deque with no `try`/`finally`:

```python
while self.files:
    f = self.files.popleft()
    if commit:
        f.commit()
    else:
        f.discard()
self.fs._intrans = False
self.fs._transaction = None
self.fs = None
```

If any `commit()` or `discard()` raises, the loop aborts. Files still queued are neither committed nor discarded, so their temporary files leak, and the three reset lines never run. `__exit__` cannot compensate — its `if self.fs:` reset block sits *after* the `complete()` call that raised.

Leaving `_intrans` set is the damaging part. Filesystem instances are cached, so the poisoned object is handed back for the rest of the process and **every later write silently disappears**:

```python
fs = fsspec.filesystem("file")
try:
    with fs.transaction:
        ...            # one commit fails, e.g. an unwritable target directory
except PermissionError:
    pass

fs2 = fsspec.filesystem("file")   # same cached object
with fs2.open(somewhere_else, "wb") as f:
    f.write(b"important")         # no error raised
os.path.exists(somewhere_else)    # False
```

Verbatim, before this change:

```
transaction raised: PermissionError
-- leaked temp files: 2
   fs._intrans     = True
   fs._transaction = True
   fsspec.filesystem('file') is the same object: True
   wrote written_much_later.txt with no error raised
   ...but exists = False
```

and after:

```
-- leaked temp files: 0
   fs._intrans     = False
   fs._transaction = False
   wrote written_much_later.txt with no error raised
   ...but exists = True
```

## The contract

> If the context finishes due to an (uncaught) exception, then the files are discarded and the file target locations untouched.
> — `docs/source/features.rst:137`

That sentence is unqualified. The partial commit itself is arguably covered by "semi-atomic" a few lines above, so this change does not attempt to roll back files that already committed — but leaked temporaries and a filesystem stuck in transaction mode are not covered by anything.

## The change

Drain in a `try`, and in the `finally` discard whatever is still queued — including the file that was in flight when the error was raised, since it is already off the deque — then always reset `_intrans` / `_transaction` / `fs`. Cleanup failures are logged rather than raised, so a failing `os.remove` cannot mask the user's original exception (which is what happens today on the discard path: a `FileNotFoundError` from reaping `/tmp` replaces the caller's own error).

`DaskTransaction.complete` had the same hole and additionally never cleared `_transaction`; it gets the same `finally`.

## Tests

`test_transaction_ends_when_a_commit_fails` in `fsspec/implementations/tests/test_local.py` patches `LocalFileOpener.commit` to fail on one of three files, then asserts the transaction state is cleared, no temporaries are left in the temp directory, and a subsequent write on the same instance actually lands.

Nothing existing covered this: `grep -rn "_intrans" fsspec/tests/ fsspec/implementations/tests/` only finds two SMB/SFTP happy-path assertions.

Verified by reverting only `fsspec/transaction.py` and keeping the test — it fails on `assert fs._intrans is False`. Full suite: 867 passed, 117 skipped, 2 xfailed.

---

*Disclosure: this patch was prepared with AI assistance. The reproduction, the red/green check and the suite run above were executed against this branch; happy to adjust anything on request.*
