### PR TITLE
ci: add zarr to test_downstream extra (test_xarray_zarr skipped since #1553)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ test_downstream = [
     "moto[server]>4,<5",
     "pytest-timeout",
     "xarray",
+    "zarr",
     "aiobotocore>=2.5.4,<3.0.0",
 ]
 


### PR DESCRIPTION
#1553 moved the downstream job's dependencies from `ci/environment-downstream.yml` (which listed `zarr`) into the new `test_downstream` extra, but zarr didn't make the new list, so `test_downstream.py::test_xarray_zarr` has import-skipped on every run since April 2024 while the job stays green — e.g. the latest master run: [`test_xarray_zarr SKIPPED`](https://github.com/fsspec/filesystem_spec/actions/runs/32860054221/job/97841514105). The README still describes this job as running "very minimal tests against pandas and zarr" ([README L77–L82](https://github.com/fsspec/filesystem_spec/blob/9b7cd481e5d1c4395752e69653443e6b05ac9a3e/README.md#L77-L82)).

Verified on my fork: unchanged master reproduces the skip ([1](https://github.com/glaziermag/filesystem_spec/actions/runs/33203575828/job/98958842268), [2](https://github.com/glaziermag/filesystem_spec/actions/runs/33203576377/job/98958844652)); with this one-line change the test runs and passes on current zarr 3.1.6 ([3](https://github.com/glaziermag/filesystem_spec/actions/runs/33203591615/job/98958897166)).

Disclosure: found while auditing CI logs with an AI assistant (Claude); I re-verified the commit history and reran the reproduction myself before opening this.
