### PR TITLE
Preserve the source trailing slash in `DirFileSystem._join`

### DIFF
--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -68,6 +68,10 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
                 return path
             if not path:
                 return self.path
+            # a trailing slash requests "copy the contents" in bulk
+            # operations (docs/source/copying.rst), so preserve it across the
+            # join even though _strip_protocol removes it
+            suffix = "/" if path.endswith("/") else ""
             path = self._strip_protocol(path)
             # ".." only navigates above the root on filesystems that resolve it
             # against a real directory tree; on object stores it is a literal
@@ -76,7 +80,10 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
                 raise ValueError(
                     f"path {path!r} escapes the {self.path!r} root of the filesystem"
                 )
-            return self.fs.sep.join((self.path, path))
+            joined = self.fs.sep.join((self.path, path))
+            if suffix and not joined.endswith("/"):
+                joined += "/"
+            return joined
         if isinstance(path, dict):
             return {self._join(_path): value for _path, value in path.items()}
         return [self._join(_path) for _path in path]

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -129,6 +129,31 @@ def test_join_keeps_dotdot_for_non_local(fs, path):
     assert dirfs._join(path) == f"root/{path}"
 
 
+def test_join_preserves_trailing_slash(tmp_path):
+    # a trailing slash requests "copy the contents" in bulk operations
+    # (docs/source/copying.rst), so it must survive the join
+    dirfs = DirFileSystem(str(tmp_path), LocalFileSystem())
+    assert dirfs._join("foo/") == f"{dirfs.path}/foo/"
+
+
+def test_get_directory_contents_to_existing_directory(tmp_path):
+    # https://github.com/fsspec/filesystem_spec/issues/1851: without the
+    # trailing slash preserved, the second get() nests a fresh copy inside
+    # the existing target instead of copying the contents (copying.rst 1e)
+    source = tmp_path / "source"
+    (source / "dir").mkdir(parents=True)
+    (source / "dir" / "file.txt").write_text("data")
+    target = tmp_path / "target"
+    target.mkdir()
+
+    dirfs = DirFileSystem(str(source), LocalFileSystem())
+    for _ in range(2):
+        dirfs.get("dir/", str(target / "dir"), recursive=True)
+
+    assert (target / "dir" / "file.txt").is_file()
+    assert not (target / "dir" / "dir").exists()
+
+
 def test_sep(mocker, dirfs):
     sep = mocker.Mock()
     dirfs.fs.sep = sep


### PR DESCRIPTION
Addresses #1851.

The nesting reported in that issue is not specific to `DirFileSystem` — local and memory filesystems do the same, matching the documented semantics for a source without a trailing slash (copying.rst, 1e). But it did surface a dirfs-specific bug: `_join` runs paths through `_strip_protocol`, which strips a trailing slash, so the documented way to ask for "copy the contents" is silently lost. On a second `get` of the same directory, dirfs nests a fresh copy inside the target where every other filesystem copies the contents:

```python
>>> dirfs.get("dir/", "local/dir", recursive=True)  # local/dir/f.txt
>>> dirfs.get("dir/", "local/dir", recursive=True)  # local/dir/dir/f.txt without the fix
```

The fix keeps the caller's trailing slash across the join. Single-path operations are unaffected since the wrapped filesystem's own `_strip_protocol` normalizes them anyway.

Added tests `test_join_preserves_trailing_slash` and `test_get_directory_contents_to_existing_directory` in `test_dirfs.py`; both fail without the fix.
