### PR TITLE
Mirror `readinto` from the pyarrow stream onto `ArrowFile`

### DIFF
--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -227,6 +227,7 @@ class ArrowFSWrapper(AbstractFileSystem):
     "stream",
     [
         "read",
+        "readinto",
         "seek",
         "tell",
         "write",

--- a/fsspec/implementations/tests/test_arrow.py
+++ b/fsspec/implementations/tests/test_arrow.py
@@ -1,3 +1,4 @@
+import io
 import secrets
 
 import pytest
@@ -269,6 +270,41 @@ def test_seekable(fs, remote_dir):
     with fs.open(remote_dir + "/a.txt", "rb", seekable=False) as file:
         with pytest.raises(OSError):
             file.seek(5)
+
+
+def test_readinto(fs, remote_dir):
+    data = b"dvc.org"
+
+    with fs.open(remote_dir + "/a.txt", "wb") as stream:
+        stream.write(data)
+
+    for seekable in [True, False]:
+        with fs.open(remote_dir + "/a.txt", "rb", seekable=seekable) as file:
+            buffer = bytearray(3)
+            assert file.readinto(buffer) == 3
+            assert bytes(buffer) == data[:3]
+
+
+@pytest.mark.parametrize(
+    "read",
+    [
+        lambda buffered: buffered.read(3),
+        lambda buffered: buffered.peek(3)[:3],
+        lambda buffered: buffered.read1(3),
+    ],
+    ids=["read", "peek", "read1"],
+)
+def test_readinto_supports_a_buffered_reader(fs, remote_dir, read):
+    # Each of these fills a buffer io.BufferedReader owns, so they go through
+    # readinto rather than read(); an unsized read() does not. A gzip reader takes
+    # the peek()/read1() path.
+    data = b"dvc.org"
+
+    with fs.open(remote_dir + "/a.txt", "wb") as stream:
+        stream.write(data)
+
+    with fs.open(remote_dir + "/a.txt", "rb") as file:
+        assert read(io.BufferedReader(file)) == data[:3]
 
 
 def test_get_kwargs_from_urls_hadoop_fs():


### PR DESCRIPTION
`ArrowFile` mirrors a fixed method list from the pyarrow stream it wraps, and `readinto` is not on
it, though `pyarrow.NativeFile` implements it. That makes it the one file class here without one:
`AbstractBufferedFile` implements `readinto` (`fsspec/spec.py`), so anything written
against the usual fsspec handle contract breaks on an Arrow-backed filesystem and nowhere else.

**`LibArchiveFileSystem` is the in-repo case, and it fails silently.** `custom_reader` documents that
"the `file` object must support the standard `readinto` and 'seek' methods" and calls it from a
ctypes callback. An `AttributeError` there is swallowed by ctypes, libarchive sees a zero-length
read, and `ls()` returns an empty archive rather than raising:

```python
>>> fs = ArrowFSWrapper(LocalFileSystem())
>>> LibArchiveFileSystem(fo=fs.open("a.tar", "rb")).ls("", detail=False)
Exception ignored on calling ctypes callback function ...
AttributeError: 'ArrowFile' object has no attribute 'readinto'
[]                      # on master; ['hello.txt'] with this patch
```

(The swallow itself is pre-existing and independent of this patch: any `readinto` failure in that
callback yields an empty archive rather than an error. This just removes the trigger.)

Buffered reads raise properly at least:

```python
>>> io.BufferedReader(fs.open("a.txt", "rb")).read(3)
AttributeError: 'ArrowFile' object has no attribute 'readinto'
```

A whole-file `read()` is fine, since that path goes to `read()` on the raw object. A *sized* read,
`peek()` and `read1()` each fill the buffer through `readinto`.

Gzip is how it turned up. `fsspec/compression.py` registers isal's `IGzipFile` as the `gzip` codec
when `isal` imports and the stdlib `GzipFile` only when it does not, and isal decompresses through
`readinto`. So a `.gz` file read through any Arrow-backed filesystem fails in an environment that
merely carries the package, and reads fine everywhere else. A transitive `xopen` dependency brought
isal in on x86-64 and AArch64, and every `.gz` read started raising.

One entry on the mirror list, following #1154 (`seekable`) and #1944 (`size`).

### Tests

`test_readinto` covers the handle directly on both the seekable and non-seekable paths;
`test_readinto_supports_a_buffered_reader` is parametrized over `read(3)`, `peek(3)` and `read1(3)`.
All eight cases fail on `master` with the `AttributeError` above and pass with the one-line change.

Neither the gzip nor the libarchive case is asserted: isal is not guaranteed on CI and libarchive is
optional, and a combined libarchive + pyarrow fixture does not exist here. Both were reproduced by
hand against `master` and this branch. One note for anyone reproducing the buffered cases: the
pure-Python `_pyio.BufferedReader` uses `raw.read` for sized reads and so does *not* show the bug,
only the C `io.BufferedReader` does.

A downstream workaround, for anyone hitting this before a release: panodata/omniload#314 mixes a
`_open` override into its Arrow-backed filesystem classes to expose the stream's own `readinto`.
