### PR TITLE
Use "/" as the only glob separator, on every platform

### DIFF
--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -1477,10 +1477,12 @@ def test_local_glob_is_unaffected_by_the_forward_slash_translator(tmp_path):
     (tmp_path / "sub" / "c.txt").write_text("c")
 
     assert sorted(fs.glob(f"{root}/*.txt")) == [f"{root}/a.txt"]
-    assert sorted(fs.glob(f"{root}/*")) == [f"{root}/a.txt", f"{root}/b.log",
-                                            f"{root}/sub"]
-    assert sorted(fs.glob(f"{root}/**/*.txt")) == [f"{root}/a.txt",
-                                                   f"{root}/sub/c.txt"]
+    assert sorted(fs.glob(f"{root}/*")) == [
+        f"{root}/a.txt",
+        f"{root}/b.log",
+        f"{root}/sub",
+    ]
+    assert sorted(fs.glob(f"{root}/**/*.txt")) == [f"{root}/a.txt", f"{root}/sub/c.txt"]
     # every path out is posix, which is what lets the translator assume "/"
     assert all("\\" not in p for p in fs.glob(f"{root}/**"))
 
@@ -1498,12 +1500,14 @@ def test_a_native_windows_pattern_is_normalised_before_the_translator_sees_it(tm
     (tmp_path / "a.txt").write_text("a")
     (tmp_path / "sub" / "b.txt").write_text("b")
 
-    native = f"{tmp_path}\\*.txt"          # C:\...\*.txt
+    native = f"{tmp_path}\\*.txt"  # C:\...\*.txt
     assert "\\" in native
     root = make_path_posix(str(tmp_path))
     assert sorted(fs.glob(native)) == [f"{root}/a.txt"]
-    assert sorted(fs.glob(f"{tmp_path}\\**\\*.txt")) == [f"{root}/a.txt",
-                                                         f"{root}/sub/b.txt"]
+    assert sorted(fs.glob(f"{tmp_path}\\**\\*.txt")) == [
+        f"{root}/a.txt",
+        f"{root}/sub/b.txt",
+    ]
 
     # the mechanism itself, so it cannot rot silently
     assert "\\" not in make_path_posix(native)

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -1459,3 +1459,51 @@ def test_issue_1447():
             assert isinstance(fs, fsspec.implementations.local.LocalFileSystem)
             with fs.open(urlpath, "rb") as f:
                 assert f.read() == contents
+
+
+def test_local_glob_is_unaffected_by_the_forward_slash_translator(tmp_path):
+    """The counterpart to `test_glob_translate_does_not_depend_on_the_host_os`.
+
+    That test pins the translator to "/" whatever the host says. This one pins
+    the other half: local globbing still resolves the same afterwards. On posix
+    nothing could change, because `seps` was already "/" there; the property
+    worth holding is that it did not change on Windows either.
+    """
+    fs = LocalFileSystem()
+    root = make_path_posix(str(tmp_path))
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.log").write_text("b")
+    (tmp_path / "sub" / "c.txt").write_text("c")
+
+    assert sorted(fs.glob(f"{root}/*.txt")) == [f"{root}/a.txt"]
+    assert sorted(fs.glob(f"{root}/*")) == [f"{root}/a.txt", f"{root}/b.log",
+                                            f"{root}/sub"]
+    assert sorted(fs.glob(f"{root}/**/*.txt")) == [f"{root}/a.txt",
+                                                   f"{root}/sub/c.txt"]
+    # every path out is posix, which is what lets the translator assume "/"
+    assert all("\\" not in p for p in fs.glob(f"{root}/**"))
+
+
+@pytest.mark.skipif(not WIN, reason="a native backslash pattern only exists on Windows")
+def test_a_native_windows_pattern_is_normalised_before_the_translator_sees_it(tmp_path):
+    """Why fixing `seps` to "/" cannot affect a local path.
+
+    `glob()` runs `_strip_protocol` first, and `LocalFileSystem._strip_protocol`
+    calls `make_path_posix`, which replaces every backslash. So a native pattern
+    full of them still globs, and the translator never receives one.
+    """
+    fs = LocalFileSystem()
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "sub" / "b.txt").write_text("b")
+
+    native = f"{tmp_path}\\*.txt"          # C:\...\*.txt
+    assert "\\" in native
+    root = make_path_posix(str(tmp_path))
+    assert sorted(fs.glob(native)) == [f"{root}/a.txt"]
+    assert sorted(fs.glob(f"{tmp_path}\\**\\*.txt")) == [f"{root}/a.txt",
+                                                         f"{root}/sub/b.txt"]
+
+    # the mechanism itself, so it cannot rot silently
+    assert "\\" not in make_path_posix(native)

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -1,4 +1,5 @@
 import io
+import os.path
 import random
 import sys
 import time
@@ -13,6 +14,7 @@ from fsspec.utils import (
     common_prefix,
     get_file_extension,
     get_protocol,
+    glob_translate,
     infer_storage_options,
     merge_offset_ranges,
     mirror_from,
@@ -664,3 +666,42 @@ def test_stringify_path(path, expected):
     path = fsspec.utils.stringify_path(path)
 
     assert path == expected
+
+
+@pytest.mark.parametrize(
+    "sep,altsep",
+    [
+        ("/", None),  # posix
+        ("\\", "/"),  # windows
+    ],
+)
+def test_glob_translate_does_not_depend_on_the_host_os(monkeypatch, sep, altsep):
+    # fsspec paths always use "/", so the pattern a given glob compiles to has to be
+    # the same everywhere. Deriving the separators from os.path made a backslash a
+    # separator on Windows only.
+    monkeypatch.setattr(os.path, "sep", sep)
+    monkeypatch.setattr(os.path, "altsep", altsep)
+
+    assert glob_translate("*") == r"(?s:[^/]+)\Z"
+    assert glob_translate("a/b*") == r"(?s:a/b[^/]*)\Z"
+    # a backslash is an ordinary character in a key, not a separator
+    assert glob_translate("we\\ird.txt") == r"(?s:we\\ird\.txt)\Z"
+
+
+def test_glob_matches_a_name_containing_a_backslash():
+    # A backslash is a legal character in an object store key. It must not be treated
+    # as a path separator, on any platform.
+    fs = fsspec.filesystem("memory")
+    for name in ["/data/plain.txt", "/data/we\\ird.txt"]:
+        with fs.open(name, "wb") as f:
+            f.write(b"x")
+
+    try:
+        assert sorted(fs.glob("/data/*")) == ["/data/plain.txt", "/data/we\\ird.txt"]
+        assert fs.glob("/data/we*") == ["/data/we\\ird.txt"]
+        assert sorted(fs.glob("/data/*.txt")) == [
+            "/data/plain.txt",
+            "/data/we\\ird.txt",
+        ]
+    finally:
+        fs.store.clear()

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -753,12 +753,14 @@ def _translate(pat, STAR, QUESTION_MARK):
 def glob_translate(pat):
     # Copied from: https://github.com/python/cpython/pull/106703.
     # The keyword parameters' values are fixed to:
-    # recursive=True, include_hidden=True, seps=None
+    # recursive=True, include_hidden=True, seps="/"
     """Translate a pathname with shell wildcards to a regular expression."""
-    if os.path.altsep:
-        seps = os.path.sep + os.path.altsep
-    else:
-        seps = os.path.sep
+    # fsspec paths always use "/" as their separator (AbstractFileSystem.sep), on every
+    # platform, and glob() has already put the pattern through _strip_protocol by the
+    # time it reaches here. Taking the separators from os.path instead would make a
+    # backslash a separator on Windows only, so a key containing one, which is an
+    # ordinary character on an object store, would stop matching there.
+    seps = "/"
     escaped_seps = "".join(map(re.escape, seps))
     any_sep = f"[{escaped_seps}]" if len(seps) > 1 else escaped_seps
     not_sep = f"[^{escaped_seps}]"


### PR DESCRIPTION
`glob_translate` takes its separators from `os.path.sep` and `os.path.altsep`, so on Windows a backslash becomes a path separator. fsspec paths always use `/`, as `AbstractFileSystem.sep` declares, and a backslash is an ordinary character in an object store key. The result is that `glob` returns different things on different hosts.

With a key named `/data/we\ird.txt` in a `MemoryFileSystem`:

| pattern | posix | windows |
| --- | --- | --- |
| `/data/*` | `['/data/plain.txt', '/data/we\\ird.txt']` | `['/data/plain.txt']` |
| `/data/we*` | `['/data/we\\ird.txt']` | `[]` |
| `/data/*.txt` | `['/data/plain.txt', '/data/we\\ird.txt']` | `['/data/plain.txt']` |

`find()` lists the key on both platforms. Only `glob` drops it, and it does so silently.

The pattern side is affected in the same way. On Windows `glob_translate("we\\ird.txt")` compiles to `we[\\/]ird\.txt`, so a pattern meant to name one key also matches `we/ird.txt`.

### Fix

`seps` is fixed to `/`. The rest of the function is unchanged, so the compiled pattern is now the same on every platform. CPython's `glob.translate` takes `seps` as a parameter for exactly this reason, and `seps=None` (use the host's separators) is the right default for `glob.glob` over a local filesystem but not for fsspec's abstract paths.

### Why local paths are not affected

`glob()` puts the pattern through `_strip_protocol` before calling `glob_translate`, and `LocalFileSystem._strip_protocol` calls `make_path_posix`, which replaces `\` with `/` in every one of its NT branches. So no local pattern can reach `glob_translate` with a backslash in it, and this change cannot alter `LocalFileSystem` behaviour. `test_local.py` passing unchanged on Windows agrees.

`glob()` also derives separators from `os.path` for its own `ends_with_sep` and `append_slash_to_dirname` checks. Those run on the raw argument, before `_strip_protocol`, where a native Windows path is still a legitimate input, so I have deliberately left them alone. Happy to revisit that separately if you would rather they were consistent.

### Tests

- `test_glob_translate_does_not_depend_on_the_host_os` monkeypatches `os.path.sep` and `os.path.altsep` to both the posix and the Windows values and asserts the compiled pattern is identical. This one fails on Linux too without the fix, so the regression is caught wherever CI runs.
- `test_glob_matches_a_name_containing_a_backslash` covers the behaviour through `fs.glob` on a `MemoryFileSystem`.

Commands run, on Windows with Python 3.12:

- new tests against unpatched `fsspec/utils.py`: 2 failed, 1 passed, so they do cover the reported behaviour
- `pytest fsspec/tests/test_utils.py`: 101 passed
- `pytest fsspec/tests/test_spec.py`: 127 passed, 123 skipped, 1 xfailed (the skips are the bash-based posix glob comparisons, which skip on Windows regardless of this change)
- `pytest fsspec/implementations/tests/test_local.py`: 152 passed, 5 skipped, 12 xfailed
- `pytest fsspec/implementations/tests/test_memory.py`: 37 passed
- `ruff check` and `ruff format --check` with the pinned v0.14.3 from `.pre-commit-config.yaml`: clean

Disclosure: I used AI assistance while investigating this and preparing the patch. I have reviewed every changed line and ran all of the commands above myself.
