### PR TITLE
Percent-decode username and password parsed from URLs (#1871)

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,10 @@ Fixes
 - End the transaction even when a commit or discard raises, so the filesystem
   is not left in transaction mode and deferred temporary files are cleaned up
 
+- Percent-decode the username and password parsed from URLs in
+  ``infer_storage_options`` so that backends (ftp, sftp, smb, ...) receive
+  the real credentials rather than their URL-encoded form (#1871)
+
 2026.7.0
 --------
 

--- a/fsspec/tests/test_utils.py
+++ b/fsspec/tests/test_utils.py
@@ -232,6 +232,25 @@ def test_infer_composite_protocol():
     assert out["path"] == ""
 
 
+def test_infer_options_percent_encoded_userinfo():
+    # Percent-encoded characters in the userinfo component must be decoded
+    # so that backends (ftp, sftp, smb, ...) receive the real credentials
+    # rather than the encoded form that appeared in the URL.
+    so = infer_storage_options(
+        "sftp://user%40corp:p%23ass%2Fword%20!@example.com:22/path"
+    )
+    assert so["username"] == "user@corp"
+    assert so["password"] == "p#ass/word !"
+    assert so["host"] == "example.com"
+    assert so["port"] == 22
+    assert so["path"] == "/path"
+
+    # Unencoded credentials pass through unchanged.
+    so = infer_storage_options("ftp://plainuser:plainpw@example.com/f")
+    assert so["username"] == "plainuser"
+    assert so["password"] == "plainpw"
+
+
 @pytest.mark.parametrize(
     "urlpath, expected_path",
     (

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -12,7 +12,7 @@ from functools import partial
 from hashlib import md5
 from importlib.metadata import version
 from typing import IO, TYPE_CHECKING, Any, TypeVar
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 if TYPE_CHECKING:
     import pathlib
@@ -103,9 +103,9 @@ def infer_storage_options(
         if parsed_path.port:
             options["port"] = parsed_path.port
         if parsed_path.username:
-            options["username"] = parsed_path.username
+            options["username"] = unquote(parsed_path.username)
         if parsed_path.password:
-            options["password"] = parsed_path.password
+            options["password"] = unquote(parsed_path.password)
 
     if parsed_path.query:
         options["url_query"] = parsed_path.query


### PR DESCRIPTION
Fixes #1871

## Problem

`infer_storage_options` returned `parsed_path.username` and
`parsed_path.password` verbatim from `urllib.parse.urlsplit`, which does not
decode percent-encoded characters in the userinfo component. When a user is
forced to percent-encode a reserved character in the URL — the classic case
being `#` in a password, which would otherwise be parsed as the fragment
delimiter — the backend receives the literal encoded string:

```python
>>> fsspec.open_files("sftp://user:pass%23with%23hash@host/path")
# password reaching paramiko: "pass%23with%23hash"  (auth fails)
```

The two reports on #1871 both hit this from the FTP/SFTP side, and every
`infer_storage_options` consumer that maps `username`/`password` straight into
its backend client — `FTPFileSystem`, `SFTPFileSystem`, `SMBFileSystem`,
`WebHDFS`, arrow — has the same failure mode.

## Change

Percent-decode both fields with `urllib.parse.unquote` before returning them:

```diff
-        if parsed_path.username:
-            options["username"] = parsed_path.username
-        if parsed_path.password:
-            options["password"] = parsed_path.password
+        if parsed_path.username:
+            options["username"] = unquote(parsed_path.username)
+        if parsed_path.password:
+            options["password"] = unquote(parsed_path.password)
```

`unquote` returns its input unchanged when there is nothing to decode, so
URLs with plain-ASCII credentials (which every existing test uses) are
unaffected. The HTTP/HTTPS branch short-circuits at line 87 and never reaches
this code, so `requests` continues to handle its own URL parsing as noted in
the comment.

Regarding @martindurant's caution on the issue ("SSH would not expect to
have encoded strings"): SSH/SFTP/FTP servers do not implement URL decoding
themselves — they compare raw credentials — so decoding on our side is what
lets an encoded URL work at all. The @Jeansidharta reproducer is exactly this
case: paramiko is handed `pass%23with%23hash%23char` and rejects it.

## Test plan

- Added `test_infer_options_percent_encoded_userinfo` covering both the
  encoded case (`user%40corp` / `p%23ass%2Fword%20!`) and the unencoded
  passthrough case.
- `pytest fsspec/tests/test_utils.py` — 99 passed.
- `pytest fsspec/tests/ fsspec/implementations/tests/` with backend suites
  that need network/cloud services excluded — 1553 passed, 176 skipped,
  2 xfailed.
- `ruff check` / `ruff format --check` clean on the touched files.
- Changelog entry added under the `Dev` section.