### PR TITLE
Fix seeks on async HTTP streams

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,8 @@ Dev
 
 Fixes
 
+- Make seeks on asynchronous HTTP stream files affect subsequent reads
+
 - Avoid mutating live ``BlockCache`` and ``BackgroundBlockCache`` instances
   when pickling (#2102)
 

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -806,13 +806,56 @@ class AsyncStreamFile(AbstractAsyncStreamedFile):
         super().__init__(fs=fs, path=url, mode=mode, cache_type="none")
         self.size = size
 
+    async def _open_response(self):
+        kwargs = self.kwargs.copy()
+        headers = kwargs.pop("headers", {}).copy()
+        if self.loc:
+            headers["Range"] = f"bytes={self.loc}-"
+        if headers:
+            kwargs["headers"] = headers
+
+        r = await self.session.get(self.fs.encode_url(self.url), **kwargs).__aenter__()
+        try:
+            self.fs._raise_not_found_for_status(r, self.url)
+            if self.loc:
+                content_range = r.headers.get("Content-Range", "")
+                content_start = content_range.partition(" ")[2].partition("-")[0]
+                if r.status != 206 and content_start != str(self.loc):
+                    # The server did not prove that it honored the Range header.
+                    # Reopen from the beginning and discard bytes so that the
+                    # response position still matches the logical file position.
+                    r.close()
+                    headers.pop("Range")
+                    if headers:
+                        kwargs["headers"] = headers
+                    else:
+                        kwargs.pop("headers", None)
+                    r = await self.session.get(
+                        self.fs.encode_url(self.url), **kwargs
+                    ).__aenter__()
+                    self.fs._raise_not_found_for_status(r, self.url)
+                    remaining = self.loc
+                    while remaining:
+                        chunk = await r.content.read(min(remaining, 1024**2))
+                        if not chunk:
+                            break
+                        remaining -= len(chunk)
+        except Exception:
+            r.close()
+            raise
+        self.r = r
+
+    def seek(self, loc, whence=0):
+        previous = self.loc
+        location = super().seek(loc, whence)
+        if location != previous and self.r is not None:
+            self.r.close()
+            self.r = None
+        return location
+
     async def read(self, num=-1):
         if self.r is None:
-            r = await self.session.get(
-                self.fs.encode_url(self.url), **self.kwargs
-            ).__aenter__()
-            self.fs._raise_not_found_for_status(r, self.url)
-            self.r = r
+            await self._open_response()
         out = await self.r.content.read(num)
         self.loc += len(out)
         return out

--- a/fsspec/implementations/tests/test_http.py
+++ b/fsspec/implementations/tests/test_http.py
@@ -540,6 +540,25 @@ async def test_async_file(server):
     await fs._session.close()
 
 
+@pytest.mark.asyncio
+async def test_async_file_seek(server):
+    fs = fsspec.filesystem(
+        "http",
+        asynchronous=True,
+        skip_instance_cache=True,
+    )
+    try:
+        of = await fs.open_async(server.realfile)
+        async with of as f:
+            assert await f.read(5) == data[:5]
+            assert f.seek(31) == 31
+            assert await f.read(5) == data[31:36]
+            assert f.seek(3) == 3
+            assert await f.read(5) == data[3:8]
+    finally:
+        await fs._session.close()
+
+
 def test_encoded(server):
     fs = fsspec.filesystem("http", encoded=True)
     out = fs.cat(


### PR DESCRIPTION
Fixes async HTTP stream seeking by reopening the response at the logical file position. It uses byte ranges when supported and falls back to streaming past the offset otherwise.

Tests: HTTP suite (61 passed), async suite (27 passed), Ruff.

Closes #1772

AI assistance was used for implementation and testing.
