### PR TITLE
Allow per-instance filesystem protocols

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,8 @@ Dev
 
 Fixes
 
+- Allow filesystem implementations to assign ``protocol`` per instance
+
 - Avoid mutating live ``BlockCache`` and ``BackgroundBlockCache`` instances
   when pickling (#2102)
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -10,7 +10,7 @@ import weakref
 from errno import ESPIPE
 from glob import has_magic
 from hashlib import sha256
-from typing import Any, ClassVar
+from typing import Any
 
 from .callbacks import DEFAULT_CALLBACK
 from .config import apply_config, conf
@@ -159,7 +159,9 @@ class AbstractFileSystem(metaclass=_Cached):
     _cached = False
     blocksize = 2**22
     sep = "/"
-    protocol: ClassVar[str | tuple[str, ...]] = "abstract"
+    # Implementations may select their protocol per instance (for example, a
+    # single adapter class backed by different storage implementations).
+    protocol: str | tuple[str, ...] = "abstract"
     _latest = None
     async_impl = False
     mirror_sync_methods = False


### PR DESCRIPTION
Closes #1800

`AbstractFileSystem.protocol` is currently declared as a `ClassVar`, so type checkers reject filesystem adapters that choose their protocol from constructor state. This removes the `ClassVar` restriction while preserving the existing string-or-tuple type and class default.

Concrete implementations with a fixed protocol can continue declaring their own `ClassVar`. The changelog now documents support for per-instance protocol selection.

Validation:

- The issue-shaped Pyright fixture fails before the change with `Attribute "protocol" cannot be assigned through a class instance because it is a ClassVar` and passes afterward with 0 errors.
- `fsspec/tests/test_spec.py` portable tests: 186 passed, 10 skipped, 1 xfailed. The 52 excluded Bash-reference cases require GNU `stat -c` and fail unchanged on macOS.
- Ruff check, Ruff format check, and `git diff --check` pass.
