### PR TITLE
Add age-based cleanup for simplecache

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,8 @@ Dev
 
 Fixes
 
+- Allow ``simplecache`` files to be removed by age using their modification times
+
 - Avoid mutating live ``BlockCache`` and ``BackgroundBlockCache`` instances
   when pickling (#2102)
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -289,6 +289,9 @@ should not mix block- and file-caches in the same directory. "simplecache" is th
 except without the options for cache expiry and to check the original source - it can be used where the
 target can be considered static, and particularly where a large number of target files are expected
 (because no metadata is written to disc). Only "simplecache" is guaranteed thread/process-safe.
+Cached files can still be removed by age using their local modification times, for example
+``fs.clear_expired_cache(expiry_time=7 * 24 * 60 * 60)``. This only changes the writable cache
+location when multiple cache directories are configured.
 
 Remote Write Caching
 --------------------

--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -847,6 +847,38 @@ class SimpleCacheFileSystem(WholeFileCacheFileSystem):
     def load_cache(self):
         pass
 
+    def clear_expired_cache(self, expiry_time=None):
+        """Remove cached files older than ``expiry_time`` seconds.
+
+        SimpleCache does not store metadata, so cached file modification times
+        are used instead. Only the last (writable) cache location is changed.
+
+        Parameters
+        ----------
+        expiry_time: int or float
+            Maximum age of a cached file in seconds. This must be supplied
+            explicitly because SimpleCache has no configured expiry time.
+        """
+        if expiry_time is None:
+            raise ValueError("expiry_time must be provided for simplecache")
+        if expiry_time < 0:
+            raise ValueError("expiry_time must be non-negative")
+
+        self._mkcache()
+        cutoff = time.time() - expiry_time
+        with os.scandir(self.storage[-1]) as entries:
+            for entry in entries:
+                try:
+                    if (
+                        entry.is_file(follow_symlinks=False)
+                        and entry.stat(follow_symlinks=False).st_mtime < cutoff
+                    ):
+                        os.remove(entry.path)
+                except FileNotFoundError:
+                    # Another process may be using the same simple cache.
+                    pass
+        self._cache_size = None
+
     def pipe_file(self, path, value=None, **kwargs):
         if self._intrans:
             with self.open(path, "wb") as f:

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -455,6 +455,49 @@ def test_clear_expired(tmp_path):
         fs.clear_expired_cache()
 
 
+def test_simplecache_clear_expired_uses_file_times(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    old_source = source / "old"
+    recent_source = source / "recent"
+    cache = tmp_path / "cache"
+    fs = fsspec.filesystem(
+        "simplecache",
+        target_protocol="file",
+        cache_storage=str(cache),
+        skip_instance_cache=True,
+    )
+
+    with fs.open(str(old_source), "wb") as f:
+        f.write(b"old")
+    with fs.open(str(recent_source), "wb") as f:
+        f.write(b"recent")
+    old_cached = fs._check_file(str(old_source))
+    recent_cached = fs._check_file(str(recent_source))
+    os.utime(old_cached, (1, 1))
+
+    fs.clear_expired_cache(expiry_time=60)
+
+    assert not os.path.exists(old_cached)
+    assert os.path.exists(recent_cached)
+    assert cache.is_dir()
+
+
+def test_simplecache_clear_expired_requires_age(tmp_path):
+    fs = fsspec.filesystem(
+        "simplecache",
+        target_protocol="file",
+        cache_storage=str(tmp_path / "cache"),
+        skip_instance_cache=True,
+    )
+
+    with pytest.raises(ValueError, match="expiry_time must be provided"):
+        fs.clear_expired_cache()
+
+    with pytest.raises(ValueError, match="expiry_time must be non-negative"):
+        fs.clear_expired_cache(expiry_time=-1)
+
+
 def test_pop():
     import tempfile
 

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -472,8 +472,10 @@ def test_simplecache_clear_expired_uses_file_times(tmp_path):
         f.write(b"old")
     with fs.open(str(recent_source), "wb") as f:
         f.write(b"recent")
-    old_cached = fs._check_file(str(old_source))
-    recent_cached = fs._check_file(str(recent_source))
+    old_cached = fs._check_file(fs._strip_protocol(str(old_source)))
+    recent_cached = fs._check_file(fs._strip_protocol(str(recent_source)))
+    assert old_cached is not None
+    assert recent_cached is not None
     os.utime(old_cached, (1, 1))
 
     fs.clear_expired_cache(expiry_time=60)


### PR DESCRIPTION
Fixes #2105.

`SimpleCacheFileSystem` does not persist cache metadata, so its inherited `clear_expired_cache()` had no records to inspect and silently retained every cached file. This override uses each cached file's local modification time, requires an explicit non-negative maximum age, and only modifies the writable cache location.

The regression tests cover files retained after writes, selective age-based removal, and invalid expiry arguments. Cache lookups in the regression test are normalized through the wrapped filesystem before `os.utime`, matching the cache-key contract on Windows. The feature documentation and changelog now describe manual age-based cleanup.

Validation at `b6f8f8054c97139249fa932098ad7a6241835c96`:

- focused expiry tests: 2 passed, 118 deselected
- complete cached-filesystem module: 89 passed, 31 skipped
- all pre-commit hooks on changed files passed, including Ruff and codespell
- `git diff --check` passed
- full suite: 1788 passed, 170 skipped, 2 xfailed, 52 failed

All 52 full-suite failures are the same macOS baseline failures in the unchanged `test_posix_tests_bash_stat` parameterizations. Those tests invoke GNU `stat -c %N`; macOS BSD `stat` does not support `-c`, so the command produces no matching output. No Windows manual test was performed.

Hosted CI:

- Windows passed, including the regression that previously failed before cache-path normalization
- Python 3.10, 3.11, 3.12, and 3.14 passed
- Python 3.13 ran 2192 passing tests and failed only six unchanged `GitHubFileSystem` tests because unauthenticated GitHub API requests returned HTTP 403 rate-limit responses; these failures are unrelated to this branch
- Python 3.14 free-threaded passed

AI assistance was used for implementation and testing.
