### PR TITLE
Add Internet Archive filesystem implementation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -121,6 +121,7 @@ Built-in Implementations
    implementations.git.GitFileSystem
    implementations.github.GithubFileSystem
    implementations.http.HTTPFileSystem
+   implementations.ia.InternetArchiveFileSystem
    implementations.jupyter.JupyterFileSystem
    implementations.libarchive.LibArchiveFileSystem
    implementations.local.LocalFileSystem
@@ -173,6 +174,9 @@ Built-in Implementations
    :members: __init__
 
 .. autoclass:: fsspec.implementations.http.HTTPFileSystem
+   :members: __init__
+
+.. autoclass:: fsspec.implementations.ia.InternetArchiveFileSystem
    :members: __init__
 
 .. autoclass:: fsspec.implementations.jupyter.JupyterFileSystem

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 Dev
 ---
 
+Enhancements
+
+- ``ia://`` filesystem for files in Internet Archive items: an
+  ``HTTPFileSystem`` reading from ``archive.org/download`` with credentials from
+  ``ia configure``'s ``ia.ini``
+
 Fixes
 
 - Avoid mutating live ``BlockCache`` and ``BackgroundBlockCache`` instances

--- a/fsspec/implementations/ia.py
+++ b/fsspec/implementations/ia.py
@@ -1,0 +1,226 @@
+"""Files in Internet Archive items, ``ia://<identifier>/<filename>``."""
+
+import configparser
+import functools
+import os
+from dataclasses import dataclass, field
+from http.cookies import SimpleCookie
+
+import aiohttp
+import yarl
+
+from ..utils import stringify_path
+from .http import HTTPFileSystem, get_client
+
+DOWNLOAD_URL = "https://archive.org/download/"
+COOKIE_DOMAIN = ".archive.org"
+# The environment variable names the ``internetarchive`` package uses.
+ENV_ACCESS_KEY = "IA_ACCESS_KEY_ID"
+ENV_SECRET_KEY = "IA_SECRET_ACCESS_KEY"
+ENV_CONFIG_FILE = "IA_CONFIG_FILE"
+
+
+def ia_config_path():
+    """The ``ia.ini`` written by ``ia configure``, or None.
+
+    Searched the way the ``internetarchive`` package searches: ``$IA_CONFIG_FILE``,
+    ``$XDG_CONFIG_HOME/internetarchive/ia.ini`` (``XDG_CONFIG_HOME`` defaulting to
+    ``~/.config``), ``~/.config/ia.ini``, ``~/.ia``. The first existing file wins.
+    """
+    home = os.path.expanduser("~")
+    xdg = os.environ.get("XDG_CONFIG_HOME") or os.path.join(home, ".config")
+    candidates = [
+        os.environ.get(ENV_CONFIG_FILE),
+        os.path.join(xdg, "internetarchive", "ia.ini"),
+        os.path.join(home, ".config", "ia.ini"),
+        os.path.join(home, ".ia"),
+    ]
+    return next((p for p in candidates if p and os.path.isfile(p)), None)
+
+
+@dataclass(frozen=True)
+class IACredentials:
+    """What logs a request in at archive.org; all-empty means anonymous."""
+
+    access_key: "str | None" = None
+    secret_key: "str | None" = None
+    cookies: dict = field(default_factory=dict)  # logged-in-user / logged-in-sig
+    config_file: "str | None" = None  # where they were read from
+
+    @property
+    def anonymous(self):
+        return not (self.access_key or self.cookies)
+
+
+def load_ia_credentials(config_file=None):
+    """Credentials from ``ia.ini`` and the environment; anonymous when there are none.
+
+    ``[s3] access/secret`` and ``[cookies] logged-in-user/logged-in-sig`` are read
+    from ``config_file`` (default: :func:`ia_config_path`). Cookie values in the file
+    carry their attributes (``x; expires=...; path=/; domain=.archive.org``), which
+    are parsed off. ``IA_ACCESS_KEY_ID`` / ``IA_SECRET_ACCESS_KEY`` override the
+    file's keys and must be set together. A missing file or section is not an
+    error: public items need nothing.
+    """
+    path = config_file or ia_config_path()
+    access_key = secret_key = None
+    cookies = {}
+    if path and os.path.isfile(path):
+        # RawConfigParser: cookie values contain '%' (URL-encoded emails), which
+        # the default interpolation would reject.
+        parser = configparser.RawConfigParser()
+        parser.read(path, encoding="utf-8")
+        access_key = parser.get("s3", "access", fallback="").strip() or None
+        secret_key = parser.get("s3", "secret", fallback="").strip() or None
+        if parser.has_section("cookies"):
+            for name, raw in parser.items("cookies"):
+                morsels = SimpleCookie()
+                morsels.load(f"{name}={raw}")
+                if name in morsels and morsels[name].value:
+                    cookies[name] = morsels[name].value
+
+    env_access = os.environ.get(ENV_ACCESS_KEY)
+    env_secret = os.environ.get(ENV_SECRET_KEY)
+    if bool(env_access) != bool(env_secret):
+        raise ValueError(f"{ENV_ACCESS_KEY} and {ENV_SECRET_KEY} must be set together")
+    if env_access:
+        access_key, secret_key = env_access, env_secret
+    if not (access_key and secret_key):
+        access_key = secret_key = None
+    found = path if path and os.path.isfile(path) else None
+    return IACredentials(access_key, secret_key, cookies, found)
+
+
+class InternetArchiveFileSystem(HTTPFileSystem):
+    """Files in Internet Archive items, addressed as ``ia://<identifier>/<filename>``.
+
+    Every path is read from ``https://archive.org/download/<identifier>/<filename>``,
+    which redirects to a data node that honours HTTP Range requests, so this is
+    ``HTTPFileSystem`` with a path mapping and archive.org credentials. (IA's
+    S3-like API at ``s3.us.archive.org`` is not used: it ignores Range headers and
+    redirects GET to plain-http data nodes, so block reads would fetch whole files.)
+
+    Public items need no credentials. Restricted items need the account's cookies
+    (and, optionally, its S3 keys) as written by ``ia configure`` from the
+    ``internetarchive`` package to ``ia.ini``; that file is found the way the
+    package finds it (``$IA_CONFIG_FILE``, ``$XDG_CONFIG_HOME/internetarchive/ia.ini``,
+    ``~/.config/ia.ini``, ``~/.ia``). Explicit arguments win over the file.
+
+    Parameters
+    ----------
+    access_key, secret_key: str, optional
+        IA S3 keys, sent as ``Authorization: LOW <access>:<secret>`` on the first
+        request. ``IA_ACCESS_KEY_ID`` / ``IA_SECRET_ACCESS_KEY`` in the environment
+        override ``ia.ini``.
+    cookies: dict, optional
+        ``{"logged-in-user": ..., "logged-in-sig": ...}``. They go into the session's
+        cookie jar for ``.archive.org`` rather than into a ``Cookie`` header: every
+        download is a redirect to another origin, and aiohttp drops ``Cookie`` and
+        ``Authorization`` headers when a redirect changes origin, while the jar
+        re-attaches its cookies to any archive.org host.
+    config_file: str, optional
+        Path to an ``ia.ini`` to read credentials from instead of the default lookup.
+    kwargs:
+        Passed to ``HTTPFileSystem``.
+    """
+
+    protocol = "ia"
+    download_url = DOWNLOAD_URL
+    cookie_domain = COOKIE_DOMAIN
+
+    def __init__(
+        self,
+        access_key=None,
+        secret_key=None,
+        cookies=None,
+        config_file=None,
+        **kwargs,
+    ):
+        if access_key is None and secret_key is None and cookies is None:
+            found = load_ia_credentials(config_file)
+            access_key, secret_key, cookies = (
+                found.access_key,
+                found.secret_key,
+                found.cookies,
+            )
+        self.access_key = access_key
+        self.cookies = dict(cookies or {})
+        headers = dict(kwargs.pop("headers", None) or {})
+        if access_key and secret_key:
+            headers["Authorization"] = f"LOW {access_key}:{secret_key}"
+        if headers:
+            kwargs["headers"] = headers
+        make_client = kwargs.pop("get_client", get_client)
+        super().__init__(
+            get_client=functools.partial(
+                self._client_with_cookies, make_client, self.cookies, self.cookie_domain
+            ),
+            **kwargs,
+        )
+
+    @property
+    def fsid(self):
+        return "ia"
+
+    @staticmethod
+    async def _client_with_cookies(make_client, cookies, domain, **kwargs):
+        session = await make_client(**kwargs)
+        if cookies:
+            morsels = SimpleCookie()
+            for name, value in cookies.items():
+                morsels[name] = value
+                morsels[name]["domain"] = domain
+                morsels[name]["path"] = "/"
+            session.cookie_jar.update_cookies(
+                morsels, yarl.URL(f"https://{domain.lstrip('.')}/")
+            )
+        return session
+
+    @classmethod
+    def _strip_protocol(cls, path):
+        """``ia://item/file`` (or bare ``item/file``) becomes the download URL.
+
+        A URL passes through unchanged, so the mapping is idempotent.
+        """
+        if isinstance(path, list):
+            return [cls._strip_protocol(p) for p in path]
+        path = stringify_path(path)
+        if path.startswith("ia://"):
+            path = path[5:]
+        elif "://" in path:
+            return path
+        return cls.download_url + path.lstrip("/")
+
+    def unstrip_protocol(self, name):
+        if name.startswith(self.download_url):
+            return "ia://" + name[len(self.download_url) :]
+        if name.startswith("ia://"):
+            return name
+        return "ia://" + name.lstrip("/")
+
+    # archive.org answers a restricted item with 403 (401 for a bad LOW key).
+    # HTTPFileSystem reports a failed HEAD+GET as FileNotFoundError and any other
+    # status through raise_for_status(); both become PermissionError so callers can
+    # tell "no such file" from "log in". The two methods callers reach with an
+    # ia:// path directly (open() strips before _open) map it here too.
+    async def _info(self, url, **kwargs):
+        url = self._strip_protocol(url)
+        try:
+            return await super()._info(url, **kwargs)
+        except FileNotFoundError as exc:
+            cause = exc.__cause__
+            if isinstance(cause, aiohttp.ClientResponseError) and cause.status in (
+                401,
+                403,
+            ):
+                raise PermissionError(url) from cause
+            raise
+
+    async def _cat_file(self, url, start=None, end=None, **kwargs):
+        url = self._strip_protocol(url)
+        return await super()._cat_file(url, start=start, end=end, **kwargs)
+
+    def _raise_not_found_for_status(self, response, url):
+        if response.status in (401, 403):
+            raise PermissionError(url)
+        super()._raise_not_found_for_status(response, url)

--- a/fsspec/implementations/tests/test_ia.py
+++ b/fsspec/implementations/tests/test_ia.py
@@ -1,0 +1,187 @@
+"""ia://<identifier>/<filename>: the Internet Archive filesystem.
+
+Offline: the URI mapping, credential loading from ``ia.ini`` and the environment, reads
+through the local HTTP test server, and the cookie-jar scoping. One opt-in network test
+(``IA_NETWORK_TESTS=1``; not ``FSSPEC_IA_*``, which fsspec.config would turn into a constructor
+argument) reads the first bytes of a public item.
+"""
+
+import os
+
+import pytest
+
+import fsspec
+from fsspec.asyn import sync
+from fsspec.implementations.ia import (
+    InternetArchiveFileSystem,
+    ia_config_path,
+    load_ia_credentials,
+)
+from fsspec.tests.conftest import data, server  # noqa: F401
+
+pytest.importorskip("aiohttp")
+
+INI = """[s3]
+access = AKIA-TEST
+secret = s3cr3t
+[cookies]
+logged-in-user = someone%40example.org; expires=Sat, 28-Aug-2027 19:39:52 GMT; path=/; domain=.archive.org
+logged-in-sig = 1756000000-abcdef0123456789; expires=Sat, 28-Aug-2027 19:39:52 GMT; path=/; domain=.archive.org
+[general]
+screenname = Some One
+"""
+
+PUBLIC_ITEM = (
+    "ia://EOT24PRE-20240926175758-crawl808/EOT24PRE-20240926175758-00032.warc.gz"
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_credentials(tmp_path, monkeypatch):
+    """Never read the developer's real ia.ini; never reuse a cached instance, which
+    would carry the previous test's credentials."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    for name in (
+        "IA_CONFIG_FILE",
+        "XDG_CONFIG_HOME",
+        "IA_ACCESS_KEY_ID",
+        "IA_SECRET_ACCESS_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    InternetArchiveFileSystem.clear_instance_cache()
+    yield
+    InternetArchiveFileSystem.clear_instance_cache()
+
+
+@pytest.fixture
+def ini(tmp_path):
+    path = tmp_path / "ia.ini"
+    path.write_text(INI, encoding="utf-8")
+    return str(path)
+
+
+def test_uri_maps_to_download_url_and_back():
+    url = "https://archive.org/download/some-item/some-file.warc.gz"
+    assert (
+        InternetArchiveFileSystem._strip_protocol("ia://some-item/some-file.warc.gz")
+        == url
+    )
+    assert (
+        InternetArchiveFileSystem._strip_protocol("some-item/some-file.warc.gz") == url
+    )
+    assert InternetArchiveFileSystem._strip_protocol(url) == url  # idempotent
+    fs = InternetArchiveFileSystem(cookies={})
+    assert fs.unstrip_protocol(url) == "ia://some-item/some-file.warc.gz"
+    assert fs.unstrip_protocol("some-item/x") == "ia://some-item/x"
+
+
+def test_registered():
+    fs, path = fsspec.core.url_to_fs("ia://some-item/some-file", cookies={})
+    assert isinstance(fs, InternetArchiveFileSystem)
+    assert path == "https://archive.org/download/some-item/some-file"
+    assert fs.fsid == "ia"
+
+
+def test_no_config_means_anonymous():
+    assert ia_config_path() is None
+    credentials = load_ia_credentials()
+    assert credentials.anonymous and credentials.config_file is None
+    fs = InternetArchiveFileSystem()
+    assert fs.cookies == {} and fs.access_key is None
+    assert "Authorization" not in fs.kwargs.get("headers", {})
+
+
+def test_ini_is_parsed(ini, monkeypatch):
+    monkeypatch.setenv("IA_CONFIG_FILE", ini)
+    assert ia_config_path() == ini
+    credentials = load_ia_credentials()
+    assert (credentials.access_key, credentials.secret_key) == ("AKIA-TEST", "s3cr3t")
+    assert credentials.cookies == {
+        "logged-in-user": "someone%40example.org",
+        "logged-in-sig": "1756000000-abcdef0123456789",
+    }
+    fs = InternetArchiveFileSystem()
+    assert fs.kwargs["headers"]["Authorization"] == "LOW AKIA-TEST:s3cr3t"
+    assert fs.cookies == credentials.cookies
+
+
+def test_ini_lookup_order(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    xdg_default = home / ".config" / "internetarchive" / "ia.ini"
+    dot_ia = home / ".ia"
+    for path in (xdg_default, dot_ia):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(INI)
+    assert ia_config_path() == str(xdg_default)
+    xdg_default.unlink()
+    assert ia_config_path() == str(dot_ia)
+    xdg = tmp_path / "xdg" / "internetarchive"
+    xdg.mkdir(parents=True)
+    (xdg / "ia.ini").write_text(INI)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    assert ia_config_path() == str(xdg / "ia.ini")
+    monkeypatch.setenv("IA_CONFIG_FILE", str(dot_ia))
+    assert ia_config_path() == str(dot_ia)
+
+
+def test_environment_keys_override_the_file_and_come_in_pairs(ini, monkeypatch):
+    monkeypatch.setenv("IA_ACCESS_KEY_ID", "ENV-KEY")
+    monkeypatch.setenv("IA_SECRET_ACCESS_KEY", "ENV-SECRET")
+    credentials = load_ia_credentials(ini)
+    assert (credentials.access_key, credentials.secret_key) == ("ENV-KEY", "ENV-SECRET")
+    assert credentials.cookies
+    monkeypatch.delenv("IA_SECRET_ACCESS_KEY")
+    with pytest.raises(ValueError, match="must be set together"):
+        load_ia_credentials(ini)
+
+
+def test_explicit_arguments_win_over_the_file(ini, monkeypatch):
+    monkeypatch.setenv("IA_CONFIG_FILE", ini)
+    fs = InternetArchiveFileSystem(cookies={"logged-in-sig": "explicit"})
+    assert fs.cookies == {"logged-in-sig": "explicit"}
+    assert "Authorization" not in fs.kwargs.get("headers", {})
+
+
+def test_cookies_are_scoped_to_archive_org():
+    """The jar, not a header, carries the login: it must follow the redirect to a data
+    node on another archive.org origin, and go nowhere else."""
+    fs = InternetArchiveFileSystem(
+        cookies={"logged-in-sig": "sig", "logged-in-user": "u"}
+    )
+    session = sync(fs.loop, fs.set_session)
+    jar = session.cookie_jar
+    from yarl import URL
+
+    sent = jar.filter_cookies(URL("https://dn721904.ca.archive.org/0/items/x/y"))
+    assert {m.key for m in sent.values()} == {"logged-in-sig", "logged-in-user"}
+    assert not jar.filter_cookies(URL("https://archive.example.com/"))
+
+
+def test_reads_go_through_the_download_url(server, monkeypatch):
+    monkeypatch.setattr(InternetArchiveFileSystem, "download_url", server.address + "/")
+    fs = InternetArchiveFileSystem(
+        cookies={}, headers={"give_length": "true", "use_206": "true"}
+    )
+    assert fs.cat("ia://index/realfile") == data
+    with fs.open("ia://index/realfile", "rb") as f:
+        assert f.read() == data
+    assert fs.cat_file("ia://index/realfile", start=1, end=10) == data[1:10]
+    assert fs.info("ia://index/realfile")["size"] == len(data)
+
+
+def test_refusal_is_a_permission_error(server, monkeypatch):
+    monkeypatch.setattr(InternetArchiveFileSystem, "download_url", server.address + "/")
+    fs = InternetArchiveFileSystem(cookies={})
+    with pytest.raises(PermissionError):
+        fs.cat("ia://unauthorized")
+    with pytest.raises(PermissionError):
+        fs.open("ia://unauthorized", "rb")
+    with pytest.raises(FileNotFoundError):
+        fs.cat("ia://index/missing")
+
+
+@pytest.mark.skipif(not os.environ.get("IA_NETWORK_TESTS"), reason="needs archive.org")
+def test_public_item_over_the_network():
+    fs = InternetArchiveFileSystem(cookies={})
+    assert fs.cat_file(PUBLIC_ITEM, start=0, end=2) == b"\x1f\x8b"  # gzip magic
+    assert fs.size(PUBLIC_ITEM) > 1_000_000_000

--- a/fsspec/implementations/tests/test_ia.py
+++ b/fsspec/implementations/tests/test_ia.py
@@ -1,12 +1,15 @@
 """ia://<identifier>/<filename>: the Internet Archive filesystem.
 
 Offline: the URI mapping, credential loading from ``ia.ini`` and the environment, reads
-through the local HTTP test server, and the cookie-jar scoping. One opt-in network test
+through the local HTTP test server, and the cookie-jar scoping, including a stand-in
+archive.org whose download URL redirects to a data node on another origin. One opt-in network test
 (``IA_NETWORK_TESTS=1``; not ``FSSPEC_IA_*``, which fsspec.config would turn into a constructor
 argument) reads the first bytes of a public item.
 """
 
 import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
@@ -58,6 +61,78 @@ def ini(tmp_path):
     path = tmp_path / "ia.ini"
     path.write_text(INI, encoding="utf-8")
     return str(path)
+
+
+class _CrossOriginHandler(BaseHTTPRequestHandler):
+    """``/download/<path>`` on 127.0.0.1 redirects to ``/items/<path>`` on ``localhost``:
+    the same server, but another origin, which is where aiohttp drops any ``Cookie`` or
+    ``Authorization`` header. The item route serves ``files`` by Range and, when
+    ``required`` is set, only to a request carrying that cookie."""
+
+    files = {}
+    required = None
+    hits = []
+
+    def log_message(self, *args):
+        pass
+
+    def do_GET(self):
+        self.hits.append((self.path, dict(self.headers)))
+        if self.path.startswith("/download/"):
+            port = self.server.server_port
+            self.send_response(302)
+            self.send_header(
+                "Location", f"http://localhost:{port}/items/{self.path[10:]}"
+            )
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        body = self.files.get(self.path)
+        if body is None:
+            self.send_error(404)
+            return
+        required = self.required
+        if required and f"{required[0]}={required[1]}" not in self.headers.get(
+            "Cookie", ""
+        ):
+            self.send_error(403)
+            return
+        status, start, end = 200, 0, len(body) - 1
+        if "Range" in self.headers:
+            first, _, last = self.headers["Range"][len("bytes=") :].partition("-")
+            start, end = int(first), (min(int(last), end) if last else end)
+            status = 206
+        chunk = body[start : end + 1]
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(chunk)))
+        self.send_header("Accept-Ranges", "bytes")
+        if status == 206:
+            self.send_header("Content-Range", f"bytes {start}-{end}/{len(body)}")
+        self.end_headers()
+        if self.command == "GET":
+            self.wfile.write(chunk)
+
+    do_HEAD = do_GET
+
+
+@pytest.fixture
+def ia_server(monkeypatch):
+    handler = type(
+        "Handler", (_CrossOriginHandler,), {"files": {}, "required": None, "hits": []}
+    )
+    httpd = HTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    monkeypatch.setattr(
+        InternetArchiveFileSystem,
+        "download_url",
+        f"http://127.0.0.1:{httpd.server_port}/download/",
+    )
+    monkeypatch.setattr(InternetArchiveFileSystem, "cookie_domain", "localhost")
+    try:
+        yield handler
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
 
 
 def test_uri_maps_to_download_url_and_back():
@@ -178,6 +253,35 @@ def test_refusal_is_a_permission_error(server, monkeypatch):
         fs.open("ia://unauthorized", "rb")
     with pytest.raises(FileNotFoundError):
         fs.cat("ia://index/missing")
+
+
+def test_cookies_survive_the_cross_origin_redirect(ia_server):
+    """The login must reach the data node, which sits behind a cross-origin redirect where
+    aiohttp has already dropped any Cookie/Authorization *header*; the jar re-attaches it."""
+    ia_server.files["/items/restricted/file"] = data
+    ia_server.required = ("logged-in-sig", "sig")
+
+    anonymous = InternetArchiveFileSystem(cookies={})
+    with pytest.raises(PermissionError):
+        anonymous.cat("ia://restricted/file")
+    with pytest.raises(PermissionError):
+        anonymous.open("ia://restricted/file", "rb")
+
+    fs = InternetArchiveFileSystem(
+        access_key="k",
+        secret_key="s",
+        cookies={"logged-in-sig": "sig", "logged-in-user": "u"},
+    )
+    ia_server.hits.clear()
+    assert fs.cat("ia://restricted/file") == data
+    assert fs.cat_file("ia://restricted/file", start=2, end=5) == data[2:5]
+    first_hop = next(h for p, h in ia_server.hits if p.startswith("/download/"))
+    assert first_hop.get("Authorization") == "LOW k:s"
+    assert "logged-in-sig" not in first_hop.get(
+        "Cookie", ""
+    )  # 127.0.0.1 is not `localhost`
+    data_hop = next(h for p, h in ia_server.hits if p.startswith("/items/"))
+    assert "logged-in-sig=sig" in data_hop.get("Cookie", "")
 
 
 @pytest.mark.skipif(not os.environ.get("IA_NETWORK_TESTS"), reason="needs archive.org")

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -161,6 +161,10 @@ known_implementations = {
         "class": "fsspec.implementations.http.HTTPFileSystem",
         "err": 'HTTPFileSystem requires "requests" and "aiohttp" to be installed',
     },
+    "ia": {
+        "class": "fsspec.implementations.ia.InternetArchiveFileSystem",
+        "err": 'InternetArchiveFileSystem requires "requests" and "aiohttp" to be installed',
+    },
     "jlab": {
         "class": "fsspec.implementations.jupyter.JupyterFileSystem",
         "err": "Jupyter FS requires requests to be installed",


### PR DESCRIPTION
Adds `InternetArchiveFileSystem` (`fsspec/implementations/ia.py`, protocol ia): `ia://<identifier>/<filename>` for files in archive.org items, plus registry entry, API docs, changelog and tests.

It remap to HTTP (HTTPFileSystem) with a path mapping and credentials, from https://archive.org/download/<identifier>/<filename>, which redirects to a data node that support HTTP Range queries. That is the same URL the `internetarchive` package downloads from.

**S3-like API** (s3.us.archive.org, which an S3FileSystem + endpoint_url would use): Internet Archive data nodes ignore Range and answer a ranged GET with 200 and the whole file, so every block read would download the entire object. Measured on a 1.6 GB public item (Range: bytes=0-99 on every request):


| Endpoint                               | URL                                                | Status                                       | Bytes sent    |
|--- |--- |--- | ---|
| S3-like front end                      | https://s3.us.archive.org/<item>/<file>            | 307 → http://dnNNN.s3dns.us.archive.org:80/… | 410 (XML)     |
| S3-like data node (following the 307)  | http://dnNNN.s3dns.us.archive.org/<item>/<file>    | 200, Accept-Ranges: bytes, no Content-Range  | 1,689,855,303 |
| Download endpoint                      | https://archive.org/download/<item>/<file>         | 302 → https://dnNNN.ca.archive.org/0/items/… | 0             |
| Download data node (following the 302) | https://dnNNN.ca.archive.org/0/items/<item>/<file> | 206, Content-Range: bytes 0-99/1689855303    | 100           |


IA documents this: "HTTP 1.1 Range headers are ignored" (https://archive.org/developers/ias3.html#how-this-is-different-from-normal-s3). botocore also misreads the 307 as an AWS region redirect and recurses on HeadBucket until RecursionError.

Credentials. Public items need none. For restricted items the class reads the ia.ini written by ia configure, found the way the internetarchive package finds it ($IA_CONFIG_FILE, $XDG_CONFIG_HOME/internetarchive/ia.ini, ~/.config/ia.ini, ~/.ia), with IA_ACCESS_KEY_ID/IA_SECRET_ACCESS_KEY overriding the file. 
Cookies go into the session's cookie jar scoped to .archive.org rather than a Cookie header, because every download is a cross-origin redirect and aiohttp drops Cookie/Authorization headers there; the jar re-attaches them to the data node. 401/403 raise PermissionError (otherwise HTTPFileSystem._info reports a 403 as FileNotFoundError).

Tested with `fsspec/implementations/tests/test_ia.py`. 