### PR TITLE
fix: preserve existing files when checking FSMap write access

### DIFF
--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -1,6 +1,7 @@
 import array
 import logging
 import posixpath
+import uuid
 import warnings
 from collections.abc import MutableMapping
 from functools import cached_property
@@ -60,8 +61,9 @@ class FSMap(MutableMapping):
                     f"Path {root} does not exist. Create "
                     f" with the ``create=True`` keyword"
                 )
-            self.fs.touch(root + "/a")
-            self.fs.rm(root + "/a")
+            check_path = f"{root}/{uuid.uuid4().hex}"
+            self.fs.touch(check_path)
+            self.fs.rm(check_path)
 
     @cached_property
     def dirfs(self):

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -28,6 +28,19 @@ def test_mapping_prefix(tmpdir):
     assert m == m2 == m3
 
 
+@pytest.mark.parametrize("protocol", ["file", "memory"])
+@pytest.mark.parametrize("key", ["a", "a/nested"])
+def test_check_preserves_contents(tmp_path, protocol, key):
+    url = f"{protocol}://{tmp_path.as_posix()}/mapping"
+    mapper = fsspec.get_mapper(url, create=True)
+    contents = {key: b"existing data", "other": b"more data"}
+    mapper.update(contents)
+
+    checked = fsspec.get_mapper(url, check=True)
+
+    assert dict(checked) == contents
+
+
 def test_getitems_errors(tmpdir):
     tmpdir = str(tmpdir)
     os.makedirs(os.path.join(tmpdir, "afolder"))


### PR DESCRIPTION
## Summary

Opening an `FSMap` with `check=True` can currently overwrite and delete an existing file named `a`; an `a` directory makes the check fail. Use a UUID-named write probe so the check leaves those existing entries intact and removes its own probe afterward.

## Validation

- Four new regression cases fail on upstream and pass with the fix, covering files and directories on local and memory filesystems.
- Mapping, local and memory suites: **211 passed, 5 skipped, 11 xfailed** on Python 3.13.12.
- Core tests excluding downstream: **537 passed, 148 skipped, 2 xfailed**. The run emitted three Windows socket/thread teardown warnings and exited successfully.
- All applicable pre-commit hooks pass. Full Docker/FUSE and downstream integration suites were not run.

## Post-Deploy Monitoring & Validation

For downstream adoption, check a populated mapper root with `check=True` and compare its keys and bytes before and after. Missing entries or leftover probe files are regression signals; callers can temporarily use `check=False` while investigating. The regression tests cover this check for this PR; live cloud validation remains with backend adopters.

Prepared and reviewed with Codex assistance. Review ran in the same agent session; no independent human review is claimed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
