### PR TITLE
fix: normalize ZIP paths in pipe_file and find

### DIFF
--- a/fsspec/implementations/tests/test_zip.py
+++ b/fsspec/implementations/tests/test_zip.py
@@ -66,6 +66,18 @@ def test_write_seek(m):
         assert fs.cat("another") == b"hi"
 
 
+@pytest.mark.parametrize("prefix", ["", "/", "zip://", "zip:///"])
+def test_pipe_file_normalizes_path(m, prefix):
+    fs = fsspec.filesystem("zip", fo="memory://out.zip", mode="w")
+    fs.pipe_file(f"{prefix}reports/result.csv", b"total\n12\n")
+    fs.close()
+
+    fs = fsspec.filesystem("zip", fo="memory://out.zip")
+    assert fs.find("") == ["reports/result.csv"]
+    assert fs.cat("reports/result.csv") == b"total\n12\n"
+    fs.close()
+
+
 def test_rw(m):
     # extra arg to zip means "create archive"
     with fsspec.open(
@@ -457,13 +469,15 @@ def test_find_returns_expected_result_detail_false_include_dirs(zip_file):
     assert result == expected_result
 
 
-def test_find_returns_expected_result_path_set(zip_file):
+@pytest.mark.parametrize("prefix", ["/", "zip://", "zip:///"])
+@pytest.mark.parametrize("detail", [False, True])
+def test_find_returns_expected_result_path_set(zip_file, prefix, detail):
     zip_file_system = ZipFileSystem(zip_file)
 
-    result = zip_file_system.find("/dir2")
+    result = zip_file_system.find(f"{prefix}dir2", detail=detail)
     expected_result = ["dir2/file3.txt"]
 
-    assert result == expected_result
+    assert list(result) == expected_result
 
 
 def test_find_with_and_without_slash_should_return_same_result(zip_file):
@@ -472,10 +486,11 @@ def test_find_with_and_without_slash_should_return_same_result(zip_file):
     assert zip_file_system.find("/dir2/") == zip_file_system.find("/dir2")
 
 
-def test_find_should_return_file_if_exact_match(zip_file):
+@pytest.mark.parametrize("prefix", ["/", "zip://", "zip:///"])
+def test_find_should_return_file_if_exact_match(zip_file, prefix):
     zip_file_system = ZipFileSystem(zip_file)
 
-    result = zip_file_system.find("/dir2startwithsamename.txt", detail=False)
+    result = zip_file_system.find(f"{prefix}dir2startwithsamename.txt", detail=False)
     expected_result = ["dir2startwithsamename.txt"]
 
     assert result == expected_result

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -111,6 +111,7 @@ class ZipFileSystem(AbstractArchiveFileSystem):
 
     def pipe_file(self, path, value, **kwargs):
         # override upstream, because we know the exact file size in this case
+        path = self._strip_protocol(path)
         self.zip.writestr(path, value, **kwargs)
 
     def _open(
@@ -146,9 +147,7 @@ class ZipFileSystem(AbstractArchiveFileSystem):
         if not isinstance(path, str):
             path = str(path)
 
-        # Remove the leading slash, as the zip file paths are always
-        # given without a leading slash
-        path = path.lstrip("/")
+        path = self._strip_protocol(path)
         path_parts = to_parts(path)
         path_depth = len(path_parts)
 


### PR DESCRIPTION
## Summary

ZIP writes and searches should interpret archive URLs consistently with `open()`. Currently, `pipe_file("zip://reports/result.csv", data)` stores the protocol prefix in the member name, while `find("zip://reports")` returns no files for an ordinary `reports/` directory. Reuse the backend's path normalization in both methods so stored names are archive-relative and prefixed searches find their files.

## Validation

- Nine regression cases fail on upstream and pass with the fix.
- ZIP, archive, tar and mapping suites: **165 passed, 17 skipped** on Python 3.13.12 / Windows.
- Tests reopen real ZIP archives to verify member names and bytes, and cover prefixed directory/exact-file searches with and without detailed output.
- All applicable pre-commit hooks pass. Full Docker/FUSE and remote backend integration suites were not run.

## Post-Deploy Monitoring & Validation

During downstream adoption, verify ZIP member names and compare prefixed searches with archive-relative searches. Unexpected empty results or member names containing `zip://` are regression signals; callers can pass archive-relative paths as a workaround. This PR validates those cases locally; remote archive storage checks remain with backend adopters.

Prepared and reviewed with Codex assistance. Review ran in the same agent session; no independent human review is claimed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
