### PR TITLE
fix: do not let isfile() swallow BaseException

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -721,7 +721,7 @@ class AsyncFileSystem(AbstractFileSystem):
     async def _isfile(self, path):
         try:
             return (await self._info(path))["type"] == "file"
-        except:  # noqa: E722
+        except Exception:
             return False
 
     async def _isdir(self, path):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -793,7 +793,7 @@ class AbstractFileSystem(metaclass=_Cached):
         """Is this entry file-like?"""
         try:
             return self.info(path)["type"] == "file"
-        except:  # noqa: E722
+        except Exception:
             return False
 
     def read_text(self, path, encoding=None, errors=None, newline=None, **kwargs):

--- a/fsspec/tests/test_async.py
+++ b/fsspec/tests/test_async.py
@@ -478,3 +478,18 @@ async def test_expand_path_with_magic_input_async():
         "bucket/file?.txt",
     ]
     assert sorted(paths) == sorted(expected)
+
+
+@pytest.mark.asyncio
+async def test_isfile_does_not_swallow_cancellation():
+    # `_isdir` catches OSError; `_isfile` must not be broader than that to the point
+    # of swallowing CancelledError, which does not derive from Exception.
+    class CancellingFS(fsspec.asyn.AsyncFileSystem):
+        async def _info(self, path, **kwargs):
+            raise asyncio.CancelledError()
+
+    fs = CancellingFS()
+    with pytest.raises(asyncio.CancelledError):
+        await fs._isdir("path")
+    with pytest.raises(asyncio.CancelledError):
+        await fs._isfile("path")


### PR DESCRIPTION
Two adjacent methods in `AsyncFileSystem` answer the same kind of question and disagree about cancellation:

```python
async def _isfile(self, path):
    try:
        return (await self._info(path))["type"] == "file"
    except:            # noqa: E722
        return False

async def _isdir(self, path):
    try:
        return (await self._info(path))["type"] == "directory"
    except OSError:
        return False
```

`asyncio.CancelledError` derives from `BaseException`, so `_isfile` swallows it and returns `False`. Cancelling a task inside it does not propagate, and the caller continues as though the path merely were not a file. `_isfile` is awaited from batched helpers, so this is a reachable path rather than a theoretical one.

Measured on `master`:

```
_isdir  propagated CancelledError  (correct)
_isfile returned False   <-- swallowed cancellation
```

`AbstractFileSystem.isfile` is the sync twin of the same method with the same bare clause, so it is changed alongside; there the swallowed type is `KeyboardInterrupt`. Its own `isdir` neighbour already uses `except OSError`.

I used `except Exception` rather than copying `_isdir`'s narrower `except OSError`, to confine the change to the `BaseException` case and leave the existing tolerance of other exception types alone. That is the same transformation as #2067.

### Testing

Added a test asserting both `_isdir` and `_isfile` propagate `CancelledError`. It fails on `master` (on the `_isfile` assertion only) and passes with the change; reverting `asyn.py` alone brings the failure back.

`pytest fsspec/tests/test_async.py fsspec/tests/test_spec.py fsspec/tests/test_api.py fsspec/implementations/tests/test_memory.py fsspec/implementations/tests/test_local.py` gives 423 passed. The 52 `test_posix_tests_bash_stat` failures in that run are present identically on a clean checkout of `master` on this machine, so they are unrelated. `ruff format --check` is clean; `ruff check` reports the same three pre-existing FURB110 hits before and after, none on changed lines.

### Not changed

Four other bare `except:` clauses remain (`spec.py` `exists`, `utils.py:507`, `mapping.py:81`, and the `flush()` cleanup in `asyn.py` which re-raises and so swallows nothing). Happy to fold any of them in if you would rather have the class cleared in one go.