### PR TITLE
Make the SFTP host key policy configurable

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,11 @@ Fixes
 - End the transaction even when a commit or discard raises, so the filesystem
   is not left in transaction mode and deferred temporary files are cleaned up
 
+- The SFTP host key policy is configurable with the new ``host_key_policy``
+  argument of ``SFTPFileSystem``, which accepts ``"auto_add"`` (default,
+  unchanged behaviour), ``"warning"`` or ``"reject"``, or any
+  ``paramiko.MissingHostKeyPolicy`` (#2119)
+
 2026.7.0
 --------
 

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -12,6 +12,37 @@ from ..utils import infer_storage_options
 
 logger = logging.getLogger("fsspec.sftp")
 
+#: Short names for the missing host key policies built into paramiko, accepted
+#: as the ``host_key_policy`` argument of ``SFTPFileSystem``.
+HOST_KEY_POLICIES = {
+    "auto_add": paramiko.AutoAddPolicy,
+    "reject": paramiko.RejectPolicy,
+    "warning": paramiko.WarningPolicy,
+}
+
+
+def _resolve_host_key_policy(policy):
+    """Turn a ``host_key_policy`` argument into a paramiko policy instance."""
+    if policy is None:
+        return paramiko.AutoAddPolicy()
+    if isinstance(policy, str):
+        try:
+            return HOST_KEY_POLICIES[policy]()
+        except KeyError:
+            raise ValueError(
+                f"Unknown host_key_policy {policy!r}; expected one of "
+                f"{sorted(HOST_KEY_POLICIES)} or a paramiko.MissingHostKeyPolicy"
+            ) from None
+    if isinstance(policy, type) and issubclass(policy, paramiko.MissingHostKeyPolicy):
+        return policy()
+    if isinstance(policy, paramiko.MissingHostKeyPolicy):
+        return policy
+    raise TypeError(
+        "host_key_policy must be one of "
+        f"{sorted(HOST_KEY_POLICIES)}, a paramiko.MissingHostKeyPolicy subclass "
+        f"or instance, not {type(policy).__name__}"
+    )
+
 
 class SFTPFileSystem(AbstractFileSystem):
     """Files over SFTP/SSH
@@ -34,6 +65,20 @@ class SFTPFileSystem(AbstractFileSystem):
             Hostname or IP as a string
         temppath: str
             Location on the server to put files, when within a transaction
+        host_key_policy: str or paramiko.MissingHostKeyPolicy, optional
+            Policy applied when the server presents a host key that is not
+            known yet, passed to
+            ``paramiko.SSHClient.set_missing_host_key_policy``. Either one of
+            the strings ``"auto_add"`` (default, ``paramiko.AutoAddPolicy``:
+            accept and remember any unknown key), ``"warning"``
+            (``paramiko.WarningPolicy``: log a warning and accept) or
+            ``"reject"`` (``paramiko.RejectPolicy``: refuse to connect), or a
+            ``paramiko.MissingHostKeyPolicy`` subclass or instance.
+
+            The default, ``"auto_add"``, trusts any host key presented on the
+            first connection to a host, so a man-in-the-middle attacker can
+            impersonate the server. Pass ``"reject"`` to only connect to hosts
+            whose keys are already in the known hosts of the process.
         ssh_kwargs: dict
             Parameters passed on to connection. See details in
             https://docs.paramiko.org/en/3.3/api/client.html#paramiko.client.SSHClient.connect
@@ -43,6 +88,9 @@ class SFTPFileSystem(AbstractFileSystem):
             return
         super().__init__(**ssh_kwargs)
         self.temppath = ssh_kwargs.pop("temppath", "/tmp")  # remote temp directory
+        self.host_key_policy = _resolve_host_key_policy(
+            ssh_kwargs.pop("host_key_policy", None)
+        )
         self.host = host
         self.ssh_kwargs = ssh_kwargs
         self._connect()
@@ -50,7 +98,7 @@ class SFTPFileSystem(AbstractFileSystem):
     def _connect(self):
         logger.debug("Connecting to SFTP server %s", self.host)
         self.client = paramiko.SSHClient()
-        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.client.set_missing_host_key_policy(self.host_key_policy)
         self.client.connect(self.host, **self.ssh_kwargs)
         self.ftp = self.client.open_sftp()
 

--- a/fsspec/implementations/tests/test_sftp.py
+++ b/fsspec/implementations/tests/test_sftp.py
@@ -9,7 +9,7 @@ import pytest
 
 import fsspec
 
-pytest.importorskip("paramiko")
+paramiko = pytest.importorskip("paramiko")
 
 
 def stop_docker(name):
@@ -314,3 +314,92 @@ def test_created_time(ssh, root_path):
     created_file_date: datetime = f.created(file_path)
     assert created_file_date >= created_dir_date
     assert created_file_date <= datetime.now(timezone.utc)
+
+
+# The tests below do not need a server: they check how the client is set up
+# before connecting, using a stand-in for ``paramiko.SSHClient``.
+
+
+class _FakeSSHClient:
+    """Record what is requested from ``paramiko.SSHClient``."""
+
+    def __init__(self):
+        self.policy = None
+        self.host = None
+        self.connect_kwargs = None
+
+    def set_missing_host_key_policy(self, policy):
+        self.policy = policy
+
+    def connect(self, host, **kwargs):
+        self.host = host
+        self.connect_kwargs = kwargs
+
+    def open_sftp(self):
+        return object()
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    monkeypatch.setattr(paramiko, "SSHClient", _FakeSSHClient)
+    return _FakeSSHClient
+
+
+def test_host_key_policy_default(fake_client):
+    fs = fsspec.filesystem("sftp", host="host", skip_instance_cache=True)
+
+    assert isinstance(fs.client.policy, paramiko.AutoAddPolicy)
+
+
+@pytest.mark.parametrize(
+    ("name", "cls"),
+    [
+        ("auto_add", paramiko.AutoAddPolicy),
+        ("reject", paramiko.RejectPolicy),
+        ("warning", paramiko.WarningPolicy),
+    ],
+)
+def test_host_key_policy_by_name(fake_client, name, cls):
+    fs = fsspec.filesystem(
+        "sftp", host="host", host_key_policy=name, skip_instance_cache=True
+    )
+
+    assert isinstance(fs.client.policy, cls)
+
+
+@pytest.mark.parametrize("as_instance", [False, True])
+def test_host_key_policy_passed_through(fake_client, as_instance):
+    policy = paramiko.RejectPolicy() if as_instance else paramiko.RejectPolicy
+    fs = fsspec.filesystem(
+        "sftp", host="host", host_key_policy=policy, skip_instance_cache=True
+    )
+
+    assert isinstance(fs.client.policy, paramiko.RejectPolicy)
+
+
+def test_host_key_policy_not_passed_to_connect(fake_client):
+    fs = fsspec.filesystem(
+        "sftp",
+        host="host",
+        host_key_policy="reject",
+        username="user",
+        port=2222,
+        skip_instance_cache=True,
+    )
+
+    assert fs.client.host == "host"
+    assert fs.client.connect_kwargs == {"username": "user", "port": 2222}
+
+
+def test_host_key_policy_unknown_name(fake_client):
+    with pytest.raises(ValueError, match="Unknown host_key_policy 'letmein'"):
+        fsspec.filesystem(
+            "sftp", host="host", host_key_policy="letmein", skip_instance_cache=True
+        )
+
+
+def test_host_key_policy_wrong_type(fake_client):
+    with pytest.raises(TypeError, match="host_key_policy must be one of"):
+        fsspec.filesystem(
+            "sftp", host="host", host_key_policy=42, skip_instance_cache=True
+        )


### PR DESCRIPTION
`SFTPFileSystem._connect()` hardcoded `paramiko.AutoAddPolicy()` as the missing host key
policy, so a caller had no way to ask for a stricter one. As reported in #2119, that
policy accepts and remembers any key presented on a first connection to a host, which
allows a man-in-the-middle to impersonate the server.

This adds a `host_key_policy` argument to `SFTPFileSystem`:

```python
fs = fsspec.filesystem("sftp", host="example.com", host_key_policy="reject")
```

It accepts either one of the strings `"auto_add"` (default), `"warning"` or `"reject"`,
or a `paramiko.MissingHostKeyPolicy` subclass or instance:

| value | policy |
| --- | --- |
| `"auto_add"` (default) | `paramiko.AutoAddPolicy` — accept and remember unknown keys, as before |
| `"warning"` | `paramiko.WarningPolicy` — log a warning and accept |
| `"reject"` | `paramiko.RejectPolicy` — refuse to connect to unknown hosts |

The value is popped from the ssh kwargs, so it is not forwarded to
`SSHClient.connect()`, and it is applied with
`set_missing_host_key_policy()` before connecting, as before. Unknown strings raise
`ValueError` and anything else that is not a policy raises `TypeError`, at construction
time rather than at connect time.

**The default is deliberately unchanged** (`"auto_add"`), since switching it to
`"reject"` would break every existing user whose known hosts file does not already
contain the server key; the docstring and changelog entry document that the default
trusts any key and that `"reject"` is available for verification. If you would rather
change the default in a future release, that is a one-line change and I am happy to
send it separately — the parameter has to exist first either way.

### Tests

The docker-based SFTP tests exercise a live server, so the new tests use a stand-in for
`paramiko.SSHClient` and check how the client is configured before connecting:

- the default is `AutoAddPolicy`
- each of the three names selects the matching paramiko policy
- a policy class and a policy instance are both used as given
- `host_key_policy` is not passed to `connect()`, while the other ssh kwargs still are
- an unknown name raises `ValueError`, a non-policy raises `TypeError`

```
$ pytest fsspec/implementations/tests/test_sftp.py -q
9 passed, 17 skipped
```

Without the change to `sftp.py`, 7 of the 9 new tests fail. Running the whole suite
(`pytest fsspec/ -q`) gives the same set of failures and errors before and after this
change (170 in this environment, all from optional dependencies that are not installed);
`ruff check` and `ruff format --check` are clean on the changed files.

Closes #2119
