### PR TITLE
Return relative names from DirFileSystem glob and find

### DIFF
--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -98,6 +98,16 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
             return path[len(prefix) :]
         return [self._relpath(_path) for _path in path]
 
+    def _relpath_detail(self, paths):
+        out = {}
+        for path, info in paths.items():
+            path = self._relpath(path)
+            info = info.copy()
+            if "name" in info:
+                info["name"] = path
+            out[path] = info
+        return out
+
     # Wrappers below
 
     @property
@@ -316,14 +326,14 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
         detail = kwargs.get("detail", False)
         ret = await self.fs._glob(self._join(path), **kwargs)
         if detail:
-            return {self._relpath(path): info for path, info in ret.items()}
+            return self._relpath_detail(ret)
         return self._relpath(ret)
 
     def glob(self, path, **kwargs):
         detail = kwargs.get("detail", False)
         ret = self.fs.glob(self._join(path), **kwargs)
         if detail:
-            return {self._relpath(path): info for path, info in ret.items()}
+            return self._relpath_detail(ret)
         return self._relpath(ret)
 
     async def _du(self, path, *args, **kwargs):
@@ -346,14 +356,14 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
         detail = kwargs.get("detail", False)
         ret = await self.fs._find(self._join(path), *args, **kwargs)
         if detail:
-            return {self._relpath(path): info for path, info in ret.items()}
+            return self._relpath_detail(ret)
         return self._relpath(ret)
 
     def find(self, path, *args, **kwargs):
         detail = kwargs.get("detail", False)
         ret = self.fs.find(self._join(path), *args, **kwargs)
         if detail:
-            return {self._relpath(path): info for path, info in ret.items()}
+            return self._relpath_detail(ret)
         return self._relpath(ret)
 
     async def _expand_path(self, path, *args, **kwargs):

--- a/fsspec/implementations/dirfs.py
+++ b/fsspec/implementations/dirfs.py
@@ -103,8 +103,7 @@ class DirFileSystem(AsyncFileSystem, ChainedFileSystem):
         for path, info in paths.items():
             path = self._relpath(path)
             info = info.copy()
-            if "name" in info:
-                info["name"] = path
+            info["name"] = path
             out[path] = info
         return out
 

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -717,8 +717,10 @@ def test_find_detail_single_tar_file():
         fs = TarFileSystem(fo=data)
         try:
             dirfs = DirFileSystem("root", fs)
-            assert dirfs.find("report.txt", detail=True) == {"report.txt": {}}
-            assert dirfs.cat_file("report.txt") == b"hello"
+            details = dirfs.find("report.txt", detail=True)
+            assert details == {"report.txt": {"name": "report.txt"}}
+            assert dirfs.cat_file(details["report.txt"]["name"]) == b"hello"
+            assert fs.find("root/report.txt", detail=True) == {"root/report.txt": {}}
         finally:
             fs.close()
 
@@ -727,7 +729,7 @@ def test_find_detail_single_tar_file():
 def test_detail_without_name(dirfs, method):
     wrapped = getattr(dirfs.fs, method)
     wrapped.return_value = {f"{PATH}/file": {}}
-    assert getattr(dirfs, method)("file", detail=True) == {"file": {}}
+    assert getattr(dirfs, method)("file", detail=True) == {"file": {"name": "file"}}
     assert wrapped.return_value == {f"{PATH}/file": {}}
 
 
@@ -736,5 +738,7 @@ def test_detail_without_name(dirfs, method):
 async def test_async_detail_without_name(adirfs, method):
     wrapped = getattr(adirfs.fs, method)
     wrapped.return_value = {f"{PATH}/file": {}}
-    assert await getattr(adirfs, method)("file", detail=True) == {"file": {}}
+    assert await getattr(adirfs, method)("file", detail=True) == {
+        "file": {"name": "file"}
+    }
     assert wrapped.return_value == {f"{PATH}/file": {}}

--- a/fsspec/implementations/tests/test_dirfs.py
+++ b/fsspec/implementations/tests/test_dirfs.py
@@ -1,8 +1,13 @@
+import tarfile
+from io import BytesIO
+
 import pytest
 
 from fsspec.asyn import AsyncFileSystem
+from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
 from fsspec.implementations.dirfs import DirFileSystem
 from fsspec.implementations.local import LocalFileSystem
+from fsspec.implementations.tar import TarFileSystem
 from fsspec.spec import AbstractFileSystem
 
 PATH = "path/to/dir"
@@ -454,25 +459,29 @@ def test_glob_with_protocol(dirfs):
 @pytest.mark.asyncio
 async def test_async_glob_detail(adirfs):
     adirfs.fs._glob.return_value = {
-        f"{PATH}/one": {"foo": "bar"},
-        f"{PATH}/two": {"baz": "qux"},
+        f"{PATH}/one": {"name": f"{PATH}/one", "foo": "bar"},
+        f"{PATH}/two": {"name": f"{PATH}/two", "baz": "qux"},
     }
     assert await adirfs._glob("*", detail=True, **KWARGS) == {
-        "one": {"foo": "bar"},
-        "two": {"baz": "qux"},
+        "one": {"name": "one", "foo": "bar"},
+        "two": {"name": "two", "baz": "qux"},
     }
+    for name, info in adirfs.fs._glob.return_value.items():
+        assert info["name"] == name
     adirfs.fs._glob.assert_called_once_with(f"{PATH}/*", detail=True, **KWARGS)
 
 
 def test_glob_detail(dirfs):
     dirfs.fs.glob.return_value = {
-        f"{PATH}/one": {"foo": "bar"},
-        f"{PATH}/two": {"baz": "qux"},
+        f"{PATH}/one": {"name": f"{PATH}/one", "foo": "bar"},
+        f"{PATH}/two": {"name": f"{PATH}/two", "baz": "qux"},
     }
     assert dirfs.glob("*", detail=True, **KWARGS) == {
-        "one": {"foo": "bar"},
-        "two": {"baz": "qux"},
+        "one": {"name": "one", "foo": "bar"},
+        "two": {"name": "two", "baz": "qux"},
     }
+    for name, info in dirfs.fs.glob.return_value.items():
+        assert info["name"] == name
     dirfs.fs.glob.assert_called_once_with(f"{PATH}/*", detail=True, **KWARGS)
 
 
@@ -521,25 +530,29 @@ def test_find(dirfs):
 @pytest.mark.asyncio
 async def test_async_find_detail(adirfs):
     adirfs.fs._find.return_value = {
-        f"{PATH}/dir/one": {"foo": "bar"},
-        f"{PATH}/dir/two": {"baz": "qux"},
+        f"{PATH}/dir/one": {"name": f"{PATH}/dir/one", "foo": "bar"},
+        f"{PATH}/dir/two": {"name": f"{PATH}/dir/two", "baz": "qux"},
     }
     assert await adirfs._find("dir", *ARGS, detail=True, **KWARGS) == {
-        "dir/one": {"foo": "bar"},
-        "dir/two": {"baz": "qux"},
+        "dir/one": {"name": "dir/one", "foo": "bar"},
+        "dir/two": {"name": "dir/two", "baz": "qux"},
     }
+    for name, info in adirfs.fs._find.return_value.items():
+        assert info["name"] == name
     adirfs.fs._find.assert_called_once_with(f"{PATH}/dir", *ARGS, detail=True, **KWARGS)
 
 
 def test_find_detail(dirfs):
     dirfs.fs.find.return_value = {
-        f"{PATH}/dir/one": {"foo": "bar"},
-        f"{PATH}/dir/two": {"baz": "qux"},
+        f"{PATH}/dir/one": {"name": f"{PATH}/dir/one", "foo": "bar"},
+        f"{PATH}/dir/two": {"name": f"{PATH}/dir/two", "baz": "qux"},
     }
     assert dirfs.find("dir", *ARGS, detail=True, **KWARGS) == {
-        "dir/one": {"foo": "bar"},
-        "dir/two": {"baz": "qux"},
+        "dir/one": {"name": "dir/one", "foo": "bar"},
+        "dir/two": {"name": "dir/two", "baz": "qux"},
     }
+    for name, info in dirfs.fs.find.return_value.items():
+        assert info["name"] == name
     dirfs.fs.find.assert_called_once_with(f"{PATH}/dir", *ARGS, detail=True, **KWARGS)
 
 
@@ -650,6 +663,40 @@ def test_open(mocker, dirfs):
     dirfs.fs.open.assert_called_once_with(f"{PATH}/file", *ARGS, **KWARGS)
 
 
+@pytest.mark.parametrize("method, pattern", [("glob", "**/*.txt"), ("find", "")])
+def test_detailed_listing_names_can_be_read(tmp_path, method, pattern):
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "report.txt").write_bytes(b"hello")
+    dirfs = DirFileSystem(str(tmp_path), LocalFileSystem())
+
+    listing = getattr(dirfs, method)
+    details = listing(pattern, detail=True)
+    assert list(details) == listing(pattern) == ["nested/report.txt"]
+    for name, info in details.items():
+        assert dirfs.cat_file(info["name"]) == b"hello"
+        assert info["name"] == dirfs.info(name)["name"] == name
+        assert info["size"] == 5
+        assert info["type"] == "file"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method, pattern", [("_glob", "**/*.txt"), ("_find", "")])
+async def test_async_detailed_listing_names_can_be_read(tmp_path, method, pattern):
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "report.txt").write_bytes(b"hello")
+    fs = AsyncFileSystemWrapper(LocalFileSystem(), asynchronous=True)
+    dirfs = DirFileSystem(tmp_path.as_posix(), fs, asynchronous=True)
+
+    listing = getattr(dirfs, method)
+    details = await listing(pattern, detail=True)
+    assert list(details) == await listing(pattern) == ["nested/report.txt"]
+    for name, info in details.items():
+        assert await dirfs._cat_file(info["name"]) == b"hello"
+        assert info["name"] == (await dirfs._info(name))["name"] == name
+        assert info["size"] == 5
+        assert info["type"] == "file"
+
+
 def test_from_url(m):
     from fsspec.core import url_to_fs
 
@@ -658,3 +705,36 @@ def test_from_url(m):
     assert fs.ls("", False) == ["file"]
     assert fs.ls("", True)[0]["name"] == "file"
     assert fs.cat("file") == b"data"
+
+
+def test_find_detail_single_tar_file():
+    with BytesIO() as data:
+        with tarfile.open(fileobj=data, mode="w") as archive:
+            entry = tarfile.TarInfo("root/report.txt")
+            entry.size = 5
+            archive.addfile(entry, BytesIO(b"hello"))
+        data.seek(0)
+        fs = TarFileSystem(fo=data)
+        try:
+            dirfs = DirFileSystem("root", fs)
+            assert dirfs.find("report.txt", detail=True) == {"report.txt": {}}
+            assert dirfs.cat_file("report.txt") == b"hello"
+        finally:
+            fs.close()
+
+
+@pytest.mark.parametrize("method", ["glob", "find"])
+def test_detail_without_name(dirfs, method):
+    wrapped = getattr(dirfs.fs, method)
+    wrapped.return_value = {f"{PATH}/file": {}}
+    assert getattr(dirfs, method)("file", detail=True) == {"file": {}}
+    assert wrapped.return_value == {f"{PATH}/file": {}}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["_glob", "_find"])
+async def test_async_detail_without_name(adirfs, method):
+    wrapped = getattr(adirfs.fs, method)
+    wrapped.return_value = {f"{PATH}/file": {}}
+    assert await getattr(adirfs, method)("file", detail=True) == {"file": {}}
+    assert wrapped.return_value == {f"{PATH}/file": {}}


### PR DESCRIPTION
## Summary

`DirFileSystem.glob(..., detail=True)` and `find(..., detail=True)` return relative dictionary keys but leave each entry's `name` prefixed with the wrapped directory. Passing that name back to the same filesystem adds the root again, so listing a file and then reading it by its returned name fails.

This change sets each entry's `name` to its relative dictionary key in both synchronous and asynchronous listings, matching the existing `info()` and `ls()` convention. Each metadata dictionary is copied so the wrapped filesystem's results are left unchanged. Entries without a `name`, including the empty metadata returned for a single TAR file, now receive the relative name as well. Non-detailed results are unchanged.

Like the earlier `info()` fix in #1798, this keeps names usable through the wrapper. This PR is limited to `glob()` and `find()`; `walk()`, path joining and root-path conventions are unchanged. Code that used these metadata names directly with the underlying filesystem should instead use the wrapper or explicitly add the root.

## Tests

- Updated the existing detailed-listing tests to include `name` and check that the wrapped metadata is not modified.
- Added synchronous and asynchronous tests that list a real nested file, read it using the returned `name`, and compare with the non-detailed listing and `info()` name.
- The original-name regression checks fail against the unfixed code (10 failures on both Linux and Windows). The 7 missing-name cases fail against the previous guarded implementation and pass after the follow-up change. The real TAR case checks that the added name can be used for reading and that the backend's empty metadata is unchanged.
- Final Windows DirFileSystem, TAR and ZIP selection: 226 passed, 1 skipped.
- Final Linux DirFileSystem, local, memory, async-wrapper, spec, mapping, TAR and ZIP selection: 682 passed, 26 skipped, 1 xfailed.
- Repository pre-commit checks pass.

The full Docker/FUSE/cloud/downstream matrix was not run locally.
