### PR TITLE
Add resumable downloads to get_file

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 Dev
 ---
 
+Enhancements
+
+- Add byte-range and resumable ``get_file`` / ``get`` downloads (#1617),
+  with validated HTTP range responses and progress reporting.
+
 Fixes
 
 - Allow filesystem implementations to assign ``protocol`` per instance

--- a/fsspec/_download.py
+++ b/fsspec/_download.py
@@ -1,0 +1,181 @@
+"""Shared byte-range and destination handling for file downloads."""
+
+import os
+import re
+from contextlib import contextmanager
+from operator import index
+
+from fsspec.callbacks import DEFAULT_CALLBACK
+from fsspec.utils import isfilelike
+
+
+class _Download:
+    def __init__(
+        self,
+        lpath,
+        *,
+        outfile=None,
+        start=None,
+        end=None,
+        resume=False,
+        callback=DEFAULT_CALLBACK,
+    ):
+        self.outfile = (
+            outfile if outfile is not None else (lpath if isfilelike(lpath) else None)
+        )
+        self.lpath = lpath
+        self.resume = resume
+        self.ranged = start is not None or end is not None or resume
+        self.callback = callback
+        if resume and start is not None:
+            raise ValueError("resume and start cannot be used together")
+        if resume and self.outfile is not None:
+            raise ValueError("resume requires a local filename, not a file-like object")
+        if self.outfile is None and lpath is None:
+            raise ValueError("A local filename or outfile is required")
+
+        self._start = 0 if start is None else index(start)
+        self._end = None if end is None else index(end)
+        if resume:
+            try:
+                self._start = os.path.getsize(lpath)
+            except FileNotFoundError:
+                self._start = 0
+        self.offset = self._start if resume else 0
+        self.start = self._start
+        self.end = self._end
+        self.length = None
+        self.count = 0
+        if not self.needs_size:
+            self.set_size(None)
+
+    @property
+    def needs_size(self):
+        return self._start < 0 or (self._end is not None and self._end < 0)
+
+    def set_size(self, size):
+        """Resolve Python-style, half-open bounds without opening the destination."""
+        start, end = self._start, self._end
+        if size is not None:
+            if self.resume and self.offset > size:
+                raise ValueError("Local file is larger than the remote file")
+            start, end, _ = slice(start, end).indices(size)
+        elif self.needs_size:
+            raise ValueError("The remote size is required for negative byte offsets")
+        if self.resume and end is not None and self.offset > end:
+            raise ValueError("Local file is larger than the requested end offset")
+        self.start = start
+        self.end = None if end is None else max(start, end)
+        self.length = None if self.end is None else self.end - self.start
+
+    def request_headers(self, kwargs):
+        """Add a single HTTP range without modifying caller-owned headers."""
+        headers = dict(kwargs.get("headers") or {})
+        if any(key.lower() == "range" for key in headers):
+            raise ValueError("Do not combine a Range header with start, end, or resume")
+        headers = {
+            key: value
+            for key, value in headers.items()
+            if key.lower() != "accept-encoding"
+        }
+        last = "" if self.end is None else self.end - 1
+        headers["Range"] = f"bytes={self.start}-{last}"
+        headers["Accept-Encoding"] = "identity"
+        kwargs["headers"] = headers
+
+    def response(self, status, headers):
+        """Validate an HTTP range before any existing local bytes can be changed.
+
+        Return False for a valid, empty response (including an already complete
+        resumed download). The caller handles other HTTP errors normally.
+        """
+        headers = {key.lower(): value for key, value in headers.items()}
+        try:
+            size = int(headers["content-length"])
+            if size < 0:
+                size = None
+        except (KeyError, TypeError, ValueError):
+            size = None
+        if not self.ranged:
+            self.set_size(size)
+            return True
+        if headers.get("content-encoding", "identity").lower() != "identity":
+            raise ValueError("A byte-range download requires identity content encoding")
+
+        requested_start = self.start
+        if status == 416:
+            match = re.fullmatch(r"bytes \*/(\d+)", headers.get("content-range", ""))
+            if match is None:
+                raise ValueError("Missing or invalid Content-Range for HTTP 416")
+            total = int(match[1])
+            if requested_start < total:
+                raise ValueError("Server rejected a satisfiable byte range")
+            self.set_size(total)
+            return False
+        if status == 200:
+            if self.start != 0 or self.end is not None:
+                raise ValueError("Server does not support the requested byte range")
+            self.set_size(size)
+            return True
+        if status != 206:
+            raise ValueError(f"Unexpected HTTP status for a byte range: {status}")
+
+        match = re.fullmatch(
+            r"bytes (\d+)-(\d+)/(\d+|\*)", headers.get("content-range", "")
+        )
+        if match is None:
+            raise ValueError("Missing or invalid Content-Range for HTTP 206")
+        first, last = int(match[1]), int(match[2])
+        total = None if match[3] == "*" else int(match[3])
+        if first > last or (total is not None and last >= total):
+            raise ValueError("Invalid Content-Range bounds")
+        if total is not None:
+            self.set_size(total)
+        if first != requested_start or first != self.start:
+            raise ValueError("Content-Range does not match the requested start offset")
+        if self.end is not None and last != self.end - 1:
+            raise ValueError("Content-Range does not match the requested end offset")
+        self.length = last - first + 1
+        if size is not None and size != self.length:
+            raise ValueError("Content-Length does not match Content-Range")
+        return True
+
+    @contextmanager
+    def open(self):
+        """Own filename destinations, but never close caller-provided streams."""
+        outfile = self.outfile
+        owned = outfile is None
+        if owned:
+            outfile = open(self.lpath, "ab" if self.resume else "wb")
+        try:
+            if self.resume and os.fstat(outfile.fileno()).st_size != self.offset:
+                raise ValueError("Local file changed while preparing the download")
+            self.callback.set_size(
+                None if self.length is None else self.offset + self.length
+            )
+            if self.resume:
+                self.callback.absolute_update(self.offset)
+            yield outfile
+            if self.ranged and self.length is not None and self.count != self.length:
+                raise OSError(
+                    f"Incomplete download: expected {self.length} bytes, "
+                    f"received {self.count}; the partial file has been retained"
+                )
+        finally:
+            if owned:
+                outfile.close()
+
+    def write(self, outfile, data):
+        if self.ranged and self.length is not None:
+            if self.count + len(data) > self.length:
+                raise OSError("Response contains more bytes than the requested range")
+        remaining = memoryview(data)
+        while remaining:
+            written = outfile.write(remaining)
+            if written is None:
+                written = len(remaining)
+            if written <= 0 or written > len(remaining):
+                raise OSError("Destination did not write the requested bytes")
+            self.count += written
+            self.callback.relative_update(written)
+            remaining = remaining[written:]

--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -219,7 +219,12 @@ class ArrowFSWrapper(AbstractFileSystem):
         return super().cat_file(path, start, end, **kwargs)
 
     def get_file(self, rpath, lpath, **kwargs):
-        kwargs.setdefault("seekable", False)
+        kwargs.setdefault(
+            "seekable",
+            kwargs.get("start") is not None
+            or kwargs.get("end") is not None
+            or kwargs.get("resume", False),
+        )
         super().get_file(rpath, lpath, **kwargs)
 
 

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -195,6 +195,12 @@ class FTPFileSystem(AbstractFileSystem):
         return out
 
     def get_file(self, rpath, lpath, **kwargs):
+        if (
+            kwargs.get("start") is not None
+            or kwargs.get("end") is not None
+            or kwargs.get("resume", False)
+        ):
+            return super().get_file(rpath, lpath, **kwargs)
         if self.isdir(rpath):
             if not os.path.exists(lpath):
                 os.mkdir(lpath)

--- a/fsspec/implementations/http.py
+++ b/fsspec/implementations/http.py
@@ -4,11 +4,13 @@ import logging
 import re
 import weakref
 from copy import copy
+from operator import index
 from urllib.parse import urlparse
 
 import aiohttp
 import yarl
 
+from fsspec._download import _Download
 from fsspec.asyn import AbstractAsyncStreamedFile, AsyncFileSystem, sync, sync_wrapper
 from fsspec.callbacks import DEFAULT_CALLBACK
 from fsspec.exceptions import FSTimeoutError
@@ -16,7 +18,6 @@ from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import (
     DEFAULT_BLOCK_SIZE,
     glob_translate,
-    isfilelike,
     nullcontext,
     tokenize,
 )
@@ -251,34 +252,47 @@ class HTTPFileSystem(AsyncFileSystem):
         return out
 
     async def _get_file(
-        self, rpath, lpath, chunk_size=5 * 2**20, callback=DEFAULT_CALLBACK, **kwargs
+        self,
+        rpath,
+        lpath,
+        chunk_size=5 * 2**20,
+        callback=DEFAULT_CALLBACK,
+        *,
+        start=None,
+        end=None,
+        resume=False,
+        **kwargs,
     ):
+        chunk_size = index(chunk_size)
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        download = _Download(
+            lpath, start=start, end=end, resume=resume, callback=callback
+        )
         kw = self.kwargs.copy()
         kw.update(kwargs)
+        if download.needs_size or download.length == 0:
+            info = await self._info(rpath, **kwargs)
+            download.set_size(info.get("size"))
+            if download.length == 0:
+                with download.open():
+                    return
+        if download.ranged:
+            download.request_headers(kw)
+            kw["auto_decompress"] = False
         logger.debug(rpath)
         session = await self.set_session()
-        async with session.get(self.encode_url(rpath), **kw) as r:
-            try:
-                size = int(r.headers["content-length"])
-            except (ValueError, KeyError):
-                size = None
-
-            callback.set_size(size)
-            self._raise_not_found_for_status(r, rpath)
-            if isfilelike(lpath):
-                outfile = lpath
-            else:
-                outfile = open(lpath, "wb")  # noqa: ASYNC230
-
-            try:
-                chunk = True
-                while chunk:
-                    chunk = await r.content.read(chunk_size)
-                    outfile.write(chunk)
-                    callback.relative_update(len(chunk))
-            finally:
-                if not isfilelike(lpath):
-                    outfile.close()
+        async with session.get(self.encode_url(rpath), **kw) as response:
+            if response.status != 416 or not download.ranged:
+                self._raise_not_found_for_status(response, rpath)
+            read_body = download.response(response.status, response.headers)
+            with download.open() as outfile:
+                if read_body:
+                    while True:
+                        chunk = await response.content.read(chunk_size)
+                        if not chunk:
+                            break
+                        download.write(outfile, chunk)
 
     async def _put_file(
         self,

--- a/fsspec/implementations/http_sync.py
+++ b/fsspec/implementations/http_sync.py
@@ -7,6 +7,7 @@ import urllib.error
 import urllib.parse
 from copy import copy
 from json import dumps, loads
+from operator import index
 from urllib.parse import urlparse
 
 try:
@@ -14,10 +15,11 @@ try:
 except (ImportError, ModuleNotFoundError, OSError):
     yarl = False
 
+from fsspec._download import _Download
 from fsspec.callbacks import _DEFAULT_CALLBACK
 from fsspec.registry import register_implementation
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
-from fsspec.utils import DEFAULT_BLOCK_SIZE, isfilelike, nullcontext, tokenize
+from fsspec.utils import DEFAULT_BLOCK_SIZE, nullcontext, tokenize
 
 from ..caching import AllBytes
 
@@ -370,27 +372,48 @@ class HTTPFileSystem(AbstractFileSystem):
         return r.content
 
     def get_file(
-        self, rpath, lpath, chunk_size=5 * 2**20, callback=_DEFAULT_CALLBACK, **kwargs
+        self,
+        rpath,
+        lpath,
+        chunk_size=5 * 2**20,
+        callback=_DEFAULT_CALLBACK,
+        *,
+        start=None,
+        end=None,
+        resume=False,
+        **kwargs,
     ):
+        chunk_size = index(chunk_size)
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        download = _Download(
+            lpath, start=start, end=end, resume=resume, callback=callback
+        )
         kw = self.kwargs.copy()
         kw.update(kwargs)
+        if download.needs_size or download.length == 0:
+            info = self.info(rpath, **kwargs)
+            download.set_size(info.get("size"))
+            if download.length == 0:
+                with download.open():
+                    return
+        if download.ranged:
+            download.request_headers(kw)
+            kw.setdefault("stream", True)
         logger.debug(rpath)
-        r = self.session.get(self.encode_url(rpath), **kw)
+        response = self.session.get(self.encode_url(rpath), **kw)
         try:
-            size = int(
-                r.headers.get("content-length", None)
-                or r.headers.get("Content-Length", None)
-            )
-        except (ValueError, KeyError, TypeError):
-            size = None
-
-        callback.set_size(size)
-        self._raise_not_found_for_status(r, rpath)
-        if not isfilelike(lpath):
-            lpath = open(lpath, "wb")
-        for chunk in r.iter_content(chunk_size, decode_unicode=False):
-            lpath.write(chunk)
-            callback.relative_update(len(chunk))
+            if response.status_code != 416 or not download.ranged:
+                self._raise_not_found_for_status(response, rpath)
+            read_body = download.response(response.status_code, response.headers)
+            with download.open() as outfile:
+                if read_body:
+                    for chunk in response.iter_content(
+                        chunk_size, decode_unicode=False
+                    ):
+                        download.write(outfile, chunk)
+        finally:
+            response.close()
 
     def put_file(
         self,

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -150,6 +150,28 @@ class LocalFileSystem(AbstractFileSystem):
         return os.path.isdir(path)
 
     def get_file(self, path1, path2, callback=None, **kwargs):
+        if (
+            kwargs.get("start") is not None
+            or kwargs.get("end") is not None
+            or kwargs.get("resume", False)
+        ):
+            from fsspec.callbacks import DEFAULT_CALLBACK
+
+            path1 = self._strip_protocol(path1)
+            if not isfilelike(path2):
+                path2 = self._strip_protocol(path2)
+                try:
+                    same_file = os.path.samefile(path1, path2)
+                except FileNotFoundError:
+                    same_file = False
+                if same_file:
+                    raise shutil.SameFileError(path1, path2)
+            return super().get_file(
+                path1,
+                path2,
+                callback=DEFAULT_CALLBACK if callback is None else callback,
+                **kwargs,
+            )
         if isfilelike(path2):
             with open(path1, "rb") as f:
                 shutil.copyfileobj(f, path2)

--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -10,6 +10,7 @@ from itertools import chain
 from typing import TYPE_CHECKING, Literal
 
 import fsspec.core
+from fsspec._download import _Download
 from fsspec.spec import AbstractBufferedFile
 
 try:
@@ -18,7 +19,7 @@ except ImportError:
     if not TYPE_CHECKING:
         import json
 
-from fsspec.asyn import AsyncFileSystem
+from fsspec.asyn import AsyncFileSystem, sync
 from fsspec.callbacks import DEFAULT_CALLBACK
 from fsspec.core import filesystem, open, split_protocol
 from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
@@ -856,14 +857,48 @@ class ReferenceFileSystem(AsyncFileSystem):
         """Temporarily add binary data or reference as a file"""
         self.references[path] = value
 
-    async def _get_file(self, rpath, lpath, **kwargs):
+    async def _get_file(
+        self,
+        rpath,
+        lpath,
+        callback=DEFAULT_CALLBACK,
+        *,
+        start=None,
+        end=None,
+        resume=False,
+        **kwargs,
+    ):
         if self.isdir(rpath):
             return os.makedirs(lpath, exist_ok=True)
-        data = await self._cat_file(rpath)
-        with open(lpath, "wb") as f:
-            f.write(data)
+        if start is None and end is None and not resume:
+            data = await self._cat_file(rpath)
+            with open(lpath, "wb") as f:
+                f.write(data)
+            return
+        download = _Download(
+            lpath, start=start, end=end, resume=resume, callback=callback
+        )
+        part_or_url, _, _ = self._cat_common(rpath)
+        if isinstance(part_or_url, bytes):
+            size = len(part_or_url)
+        else:
+            size = (await self._info(rpath)).get("size")
+        download.set_size(size)
+        data = b""
+        if download.length != 0:
+            data = await self._cat_file(
+                rpath, start=download.start, end=download.end, **kwargs
+            )
+        with download.open() as outfile:
+            download.write(outfile, data)
 
     def get_file(self, rpath, lpath, callback=DEFAULT_CALLBACK, **kwargs):
+        if (
+            kwargs.get("start") is not None
+            or kwargs.get("end") is not None
+            or kwargs.get("resume", False)
+        ):
+            return super().get_file(rpath, lpath, callback=callback, **kwargs)
         if self.isdir(rpath):
             return os.makedirs(lpath, exist_ok=True)
         data = self.cat_file(rpath, **kwargs)
@@ -876,6 +911,14 @@ class ReferenceFileSystem(AsyncFileSystem):
         callback.absolute_update(len(data))
 
     def get(self, rpath, lpath, recursive=False, **kwargs):
+        if (
+            kwargs.get("start") is not None
+            or kwargs.get("end") is not None
+            or kwargs.get("resume", False)
+        ):
+            return sync(
+                self.loop, self._get, rpath, lpath, recursive=recursive, **kwargs
+            )
         if recursive:
             # trigger directory build
             self.ls("")

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -158,6 +158,12 @@ class SFTPFileSystem(AbstractFileSystem):
         self.ftp.put(lpath, rpath)
 
     def get_file(self, rpath, lpath, **kwargs):
+        if (
+            kwargs.get("start") is not None
+            or kwargs.get("end") is not None
+            or kwargs.get("resume", False)
+        ):
+            return super().get_file(rpath, lpath, **kwargs)
         if self.isdir(rpath):
             os.makedirs(lpath, exist_ok=True)
         else:

--- a/fsspec/implementations/tests/test_http_download.py
+++ b/fsspec/implementations/tests/test_http_download.py
@@ -1,0 +1,348 @@
+import gzip
+import io
+import re
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from fsspec.asyn import sync
+from fsspec.callbacks import Callback
+from fsspec.implementations.http import HTTPFileSystem
+from fsspec.implementations.http_sync import HTTPFileSystem as SyncHTTPFileSystem
+from fsspec.implementations.http_sync import unregister as unregister_sync_http
+
+# Importing the synchronous implementation registers it as the default HTTP
+# backend. Restore the normal async registration so this module is isolated.
+unregister_sync_http()
+
+DATA = bytes(range(64))
+
+
+@pytest.fixture(scope="module")
+def range_server():
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_HEAD(self):
+            self.respond(head=True)
+
+        def do_GET(self):
+            self.respond(head=False)
+
+        def respond(self, head):
+            requests.append((self.command, self.path, dict(self.headers)))
+            data = b"" if self.path == "/empty" else DATA
+            if self.path == "/missing":
+                self.send_response(404)
+                self.end_headers()
+                return
+            if self.path == "/redirect":
+                self.send_response(302)
+                self.send_header("Location", "/data")
+                self.end_headers()
+                return
+            if head:
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(data)))
+                self.send_header("Accept-Ranges", "bytes")
+                self.end_headers()
+                return
+            value = self.headers.get("Range")
+            if value is None or self.path == "/ignore":
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+                return
+            match = re.fullmatch(r"bytes=(\d+)-(\d*)", value)
+            if match is None:
+                self.send_response(400)
+                self.end_headers()
+                return
+            first = int(match[1])
+            last = min(int(match[2]) if match[2] else len(data) - 1, len(data) - 1)
+            if first >= len(data):
+                self.send_response(416)
+                self.send_header("Content-Range", f"bytes */{len(data)}")
+                self.end_headers()
+                return
+            body = data[first : last + 1]
+            if self.path == "/shift":
+                first += 1
+                body = data[first : last + 1]
+            self.send_response(206)
+            if self.path != "/missing-range":
+                total = "*" if self.path == "/unknown" else str(len(data))
+                self.send_header("Content-Range", f"bytes {first}-{last}/{total}")
+            short = self.path == "/short" or (self.path == "/flaky" and first == 0)
+            if short:
+                body = body[:3]
+            elif self.path == "/long":
+                body += b"extra"
+            elif self.path == "/encoded":
+                self.send_header("Content-Encoding", "gzip")
+                body = gzip.compress(body)
+            else:
+                length = len(body) + 1 if self.path == "/bad-length" else len(body)
+                self.send_header("Content-Length", str(length))
+            self.end_headers()
+            try:
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.fixture(params=["aiohttp", "requests"])
+def http_fs(request):
+    fs = HTTPFileSystem() if request.param == "aiohttp" else SyncHTTPFileSystem()
+    try:
+        yield fs
+    finally:
+        if isinstance(fs, HTTPFileSystem):
+            if fs._session is not None:
+                sync(fs.loop, fs._session.close)
+        else:
+            fs.session.close()
+
+
+@pytest.mark.parametrize(
+    "start,end",
+    [
+        (None, None),
+        (0, None),
+        (3, 19),
+        (None, 8),
+        (11, None),
+        (-8, None),
+        (None, -4),
+        (-20, -3),
+        (-100, 100),
+        (100, None),
+        (0, 0),
+        (7, 7),
+        (9, 2),
+    ],
+)
+def test_http_byte_ranges(http_fs, range_server, tmp_path, start, end):
+    url, _ = range_server
+    target = tmp_path / "download"
+    target.write_bytes(b"previous")
+    callback = Callback()
+    http_fs.get_file(
+        url + "/data", target, start=start, end=end, chunk_size=7, callback=callback
+    )
+    assert target.read_bytes() == DATA[start:end]
+    assert callback.size == callback.value == len(DATA[start:end])
+
+
+@pytest.mark.parametrize("prefix", [None, 0, 5, len(DATA)])
+def test_http_resume_requests_only_remaining_bytes(
+    http_fs, range_server, tmp_path, prefix
+):
+    url, requests = range_server
+    target = tmp_path / "download"
+    if prefix is not None:
+        target.write_bytes(DATA[:prefix])
+    callback = Callback()
+    http_fs.get_file(url + "/data", target, resume=True, callback=callback)
+    assert target.read_bytes() == DATA
+    assert callback.value == callback.size == len(DATA)
+    assert requests[-1][2]["Range"] == f"bytes={prefix or 0}-"
+
+
+@pytest.mark.parametrize("end", [24, -4, 100])
+def test_http_resume_with_end(http_fs, range_server, tmp_path, end):
+    url, _ = range_server
+    target = tmp_path / "download"
+    target.write_bytes(DATA[:5])
+    callback = Callback()
+    http_fs.get_file(url + "/data", target, resume=True, end=end, callback=callback)
+    assert target.read_bytes() == DATA[:end]
+    assert callback.size == callback.value == len(DATA[:end])
+
+
+@pytest.mark.parametrize(
+    "endpoint,match",
+    [
+        ("ignore", "does not support"),
+        ("shift", "start offset"),
+        ("missing-range", "Content-Range"),
+        ("bad-length", "Content-Length"),
+        ("encoded", "identity"),
+    ],
+)
+def test_bad_http_ranges_preserve_partial_file(
+    http_fs, range_server, tmp_path, endpoint, match
+):
+    url, _ = range_server
+    target = tmp_path / "download"
+    target.write_bytes(DATA[:5])
+    with pytest.raises(ValueError, match=match):
+        http_fs.get_file(url + "/" + endpoint, target, resume=True)
+    assert target.read_bytes() == DATA[:5]
+
+
+def test_ignored_range_does_not_truncate_existing_file(http_fs, range_server, tmp_path):
+    url, _ = range_server
+    target = tmp_path / "download"
+    target.write_bytes(b"keep")
+    with pytest.raises(ValueError, match="does not support"):
+        http_fs.get_file(url + "/ignore", target, start=5, end=12)
+    assert target.read_bytes() == b"keep"
+
+
+@pytest.mark.parametrize("endpoint", ["data", "ignore"])
+def test_new_resume_can_start_with_a_full_response(
+    http_fs, range_server, tmp_path, endpoint
+):
+    url, _ = range_server
+    target = tmp_path / "download"
+    http_fs.get_file(url + "/" + endpoint, target, resume=True)
+    assert target.read_bytes() == DATA
+
+
+def test_interrupted_http_download_is_resumable(http_fs, range_server, tmp_path):
+    url, requests = range_server
+    target = tmp_path / "download"
+    with pytest.raises(OSError, match="Incomplete download"):
+        http_fs.get_file(url + "/flaky", target, resume=True)
+    assert target.read_bytes() == DATA[:3]
+    http_fs.get_file(url + "/flaky", target, resume=True)
+    assert requests[-1][2]["Range"] == "bytes=3-"
+    assert target.read_bytes() == DATA
+
+
+def test_oversized_http_response_does_not_append_invalid_bytes(
+    http_fs, range_server, tmp_path
+):
+    url, _ = range_server
+    target = tmp_path / "download"
+    target.write_bytes(DATA[:5])
+    with pytest.raises(OSError, match="more bytes"):
+        http_fs.get_file(url + "/long", target, resume=True, chunk_size=7)
+    assert DATA.startswith(target.read_bytes())
+
+
+def test_local_file_larger_than_remote_is_preserved(http_fs, range_server, tmp_path):
+    url, _ = range_server
+    target = tmp_path / "download"
+    original = DATA + b"extra"
+    target.write_bytes(original)
+    with pytest.raises(ValueError, match="larger than the remote"):
+        http_fs.get_file(url + "/data", target, resume=True)
+    assert target.read_bytes() == original
+
+
+@pytest.mark.parametrize("resume", [False, True])
+def test_empty_http_file(http_fs, range_server, tmp_path, resume):
+    url, _ = range_server
+    target = tmp_path / "download"
+    http_fs.get_file(url + "/empty", target, resume=resume)
+    assert target.read_bytes() == b""
+
+
+def test_http_headers_are_preserved_without_mutation(http_fs, range_server, tmp_path):
+    url, requests = range_server
+    target = tmp_path / "download"
+    headers = {"X-Download-Test": "yes", "accept-encoding": "gzip"}
+    http_fs.get_file(url + "/data", target, start=3, headers=headers)
+    assert headers == {"X-Download-Test": "yes", "accept-encoding": "gzip"}
+    assert requests[-1][2]["X-Download-Test"] == "yes"
+    assert requests[-1][2]["Accept-Encoding"] == "identity"
+    assert target.read_bytes() == DATA[3:]
+    with pytest.raises(ValueError, match="Range header"):
+        http_fs.get_file(url + "/data", target, start=3, headers={"range": "bytes=4-"})
+    assert target.read_bytes() == DATA[3:]
+
+
+def test_http_filelike_destination_is_not_closed(http_fs, range_server):
+    url, _ = range_server
+    target = io.BytesIO(b"prefix:")
+    target.seek(0, 2)
+    http_fs.get_file(url + "/data", target, start=3, end=8)
+    assert target.getvalue() == b"prefix:" + DATA[3:8]
+    assert not target.closed
+    with pytest.raises(ValueError, match="filename"):
+        http_fs.get_file(url + "/data", target, resume=True)
+
+
+@pytest.mark.parametrize("endpoint", ["unknown", "redirect"])
+def test_http_unknown_total_and_redirects(http_fs, range_server, tmp_path, endpoint):
+    url, _ = range_server
+    target = tmp_path / "download"
+    target.write_bytes(DATA[:5])
+    http_fs.get_file(url + "/" + endpoint, target, resume=True)
+    assert target.read_bytes() == DATA
+
+
+def test_http_missing_source_preserves_destination(http_fs, range_server, tmp_path):
+    url, _ = range_server
+    target = tmp_path / "download"
+    target.write_bytes(b"keep")
+    with pytest.raises(FileNotFoundError):
+        http_fs.get_file(url + "/missing", target, resume=True)
+    assert target.read_bytes() == b"keep"
+
+
+@pytest.mark.parametrize("chunk_size", [0, -1])
+def test_http_invalid_chunk_size_is_rejected(
+    http_fs, range_server, tmp_path, chunk_size
+):
+    url, _ = range_server
+    target = tmp_path / "download"
+    target.write_bytes(b"keep")
+    with pytest.raises(ValueError, match="chunk_size"):
+        http_fs.get_file(url + "/data", target, start=0, chunk_size=chunk_size)
+    assert target.read_bytes() == b"keep"
+
+
+@pytest.mark.asyncio
+async def test_native_async_http_and_batched_downloads(range_server, tmp_path):
+    url, requests = range_server
+    fs = HTTPFileSystem(asynchronous=True)
+    first, second = tmp_path / "first", tmp_path / "second"
+    first.write_bytes(DATA[:5])
+    second.write_bytes(DATA[:9])
+    try:
+        await fs._get(
+            [url + "/data", url + "/data"],
+            [str(first), str(second)],
+            resume=True,
+        )
+        assert first.read_bytes() == second.read_bytes() == DATA
+        assert {entry[2]["Range"] for entry in requests[-2:]} == {
+            "bytes=5-", "bytes=9-"
+        }
+        target = io.BytesIO()
+        await fs._get_file(url + "/data", target, start=-8, end=-2)
+        assert target.getvalue() == DATA[-8:-2]
+        assert not target.closed
+    finally:
+        if fs._session is not None:
+            await fs._session.close()
+
+
+@pytest.mark.parametrize("chunk_size", [1.5, "3"])
+def test_http_noninteger_chunk_size_preserves_destination(
+    http_fs, range_server, tmp_path, chunk_size
+):
+    url, _ = range_server
+    target = tmp_path / "download"
+    target.write_bytes(b"keep")
+    with pytest.raises(TypeError):
+        http_fs.get_file(url + "/data", target, start=0, chunk_size=chunk_size)
+    assert target.read_bytes() == b"keep"

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -973,9 +973,39 @@ class AbstractFileSystem(metaclass=_Cached):
             return self.cat_file(paths[0], **kwargs)
 
     def get_file(
-        self, rpath, lpath=None, callback=DEFAULT_CALLBACK, outfile=None, **kwargs
+        self,
+        rpath,
+        lpath=None,
+        callback=DEFAULT_CALLBACK,
+        outfile=None,
+        *,
+        start=None,
+        end=None,
+        resume=False,
+        **kwargs,
     ):
-        """Copy single remote file to local"""
+        """Copy a remote file, optionally selecting a range or resuming a download.
+
+        Parameters
+        ----------
+        start, end : int, optional
+            Half-open byte offsets, as for ``cat_file``. Negative offsets are
+            relative to the remote file's end. Without ``resume``, a filename
+            destination is overwritten with only the selected bytes.
+        resume : bool, default False
+            Append bytes starting at the current local file size. A missing
+            local file starts at zero. Requires a filename destination and
+            cannot be combined with ``start``. ``end`` remains an absolute
+            remote offset. The remote file must not have changed since the
+            partial download; its existing prefix is not compared.
+        outfile : file-like, optional
+            Caller-owned binary output stream. It is not closed by this method.
+            File-like destinations cannot be used with ``resume``.
+
+        Other keyword arguments are passed to ``open``. Backends overriding
+        this method must implement or delegate the range/resume options.
+        """
+        from ._download import _Download
         from .implementations.local import LocalFileSystem
 
         if outfile is None and isfilelike(lpath):
@@ -984,27 +1014,45 @@ class AbstractFileSystem(metaclass=_Cached):
             os.makedirs(lpath, exist_ok=True)
             return None
 
-        if outfile is None:
-            fs = LocalFileSystem(auto_mkdir=True)
-            fs.makedirs(fs._parent(lpath), exist_ok=True)
-
-        with self.open(rpath, "rb", **kwargs) as f1:
-            close_outfile = outfile is None
-            if close_outfile:
-                outfile = open(lpath, "wb")
-
-            try:
-                callback.set_size(getattr(f1, "size", None))
-                data = True
-                while data:
-                    data = f1.read(self.blocksize)
-                    segment_len = outfile.write(data)
-                    if segment_len is None:
-                        segment_len = len(data)
-                    callback.relative_update(segment_len)
-            finally:
-                if close_outfile:
-                    outfile.close()
+        download = _Download(
+            lpath,
+            outfile=outfile,
+            start=start,
+            end=end,
+            resume=resume,
+            callback=callback,
+        )
+        with self.open(rpath, "rb", **kwargs) as source:
+            size = getattr(source, "size", None)
+            if size is None and (
+                download.needs_size
+                or resume
+                or (download.ranged and getattr(source, "seekable", lambda: False)())
+            ):
+                source.seek(0, 2)
+                size = source.tell()
+                source.seek(0)
+            download.set_size(size)
+            if download.start:
+                source.seek(download.start)
+            if outfile is None:
+                fs = LocalFileSystem(auto_mkdir=True)
+                fs.makedirs(fs._parent(lpath), exist_ok=True)
+            with download.open() as target:
+                while (
+                    not download.ranged
+                    or download.length is None
+                    or (download.count < download.length)
+                ):
+                    count = self.blocksize
+                    if download.ranged and download.length is not None:
+                        count = min(count, download.length - download.count)
+                    data = source.read(count)
+                    if not data:
+                        break
+                    download.write(target, data)
+                if not download.ranged:
+                    callback.relative_update(0)
 
     def get(
         self,

--- a/fsspec/tests/test_download.py
+++ b/fsspec/tests/test_download.py
@@ -1,0 +1,403 @@
+import base64
+import io
+import os
+import shutil
+
+import pytest
+
+from fsspec.callbacks import Callback
+from fsspec.implementations.dirfs import DirFileSystem
+from fsspec.implementations.local import LocalFileSystem
+from fsspec.implementations.reference import ReferenceFileSystem
+
+DATA = bytes(range(64))
+
+
+class RecordingCallback(Callback):
+    def __init__(self):
+        super().__init__()
+        self.increments = []
+
+    def relative_update(self, inc=1):
+        self.increments.append(inc)
+        super().relative_update(inc)
+
+
+@pytest.fixture(params=["memory", "local", "reference", "dirfs"])
+def source(request, m, tmp_path):
+    if request.param == "memory":
+        m.pipe_file("/source", DATA)
+        return m, "/source"
+    if request.param == "local":
+        path = tmp_path / "source"
+        path.write_bytes(DATA)
+        return LocalFileSystem(), str(path)
+    if request.param == "reference":
+        return ReferenceFileSystem({"source": DATA}), "source"
+    m.pipe_file("/root/source", DATA)
+    return DirFileSystem(path="/root", fs=m), "source"
+
+
+@pytest.mark.parametrize(
+    "start,end",
+    [
+        (None, None),
+        (0, None),
+        (3, 19),
+        (None, 8),
+        (11, None),
+        (-8, None),
+        (None, -4),
+        (-20, -3),
+        (-100, 100),
+        (100, None),
+        (0, 0),
+        (7, 7),
+        (9, 2),
+    ],
+)
+def test_byte_ranges(source, tmp_path, start, end):
+    fs, path = source
+    target = tmp_path / "download"
+    target.write_bytes(b"old contents")
+    callback = RecordingCallback()
+    fs.get_file(path, target, start=start, end=end, callback=callback)
+    assert target.read_bytes() == DATA[start:end]
+    # LocalFileSystem's pre-existing whole-file fast path does not use callbacks.
+    if start is not None or end is not None:
+        assert callback.size == callback.value == len(DATA[start:end])
+
+
+@pytest.mark.parametrize("prefix", [None, 0, 5, len(DATA)])
+def test_resume_download(source, tmp_path, prefix):
+    fs, path = source
+    target = tmp_path / "download"
+    if prefix is not None:
+        target.write_bytes(DATA[:prefix])
+    callback = RecordingCallback()
+    fs.get_file(path, target, resume=True, callback=callback)
+    assert target.read_bytes() == DATA
+    assert callback.size == callback.value == len(DATA)
+    assert sum(callback.increments) == len(DATA) - (prefix or 0)
+
+
+@pytest.mark.parametrize("end", [24, -4, 100])
+def test_resume_to_end(source, tmp_path, end):
+    fs, path = source
+    target = tmp_path / "download"
+    target.write_bytes(DATA[:5])
+    callback = RecordingCallback()
+    fs.get_file(path, target, resume=True, end=end, callback=callback)
+    expected = DATA[:end]
+    assert target.read_bytes() == expected
+    assert callback.value == callback.size == len(expected)
+    assert sum(callback.increments) == len(expected) - 5
+
+
+@pytest.mark.parametrize("options", [{"start": 2}, {"end": 3}])
+def test_invalid_resume_preserves_destination(source, tmp_path, options):
+    fs, path = source
+    target = tmp_path / "download"
+    target.write_bytes(DATA[:5])
+    with pytest.raises(ValueError):
+        fs.get_file(path, target, resume=True, **options)
+    assert target.read_bytes() == DATA[:5]
+
+
+def test_oversized_local_file_is_not_truncated(source, tmp_path):
+    fs, path = source
+    target = tmp_path / "download"
+    original = DATA + b"extra"
+    target.write_bytes(original)
+    with pytest.raises(ValueError, match="larger than the remote"):
+        fs.get_file(path, target, resume=True)
+    assert target.read_bytes() == original
+
+
+def test_filelike_range_stays_open(source):
+    fs, path = source
+    target = io.BytesIO(b"prefix:")
+    target.seek(0, 2)
+    fs.get_file(path, target, start=3, end=12)
+    assert not target.closed
+    assert target.getvalue() == b"prefix:" + DATA[3:12]
+    with pytest.raises(ValueError, match="filename"):
+        fs.get_file(path, target, resume=True)
+    assert target.getvalue() == b"prefix:" + DATA[3:12]
+
+
+@pytest.mark.parametrize("options", [{"start": 2.5}, {"end": "3"}])
+def test_invalid_offsets_do_not_touch_destination(source, tmp_path, options):
+    fs, path = source
+    target = tmp_path / "download"
+    target.write_bytes(b"keep")
+    with pytest.raises(TypeError):
+        fs.get_file(path, target, **options)
+    assert target.read_bytes() == b"keep"
+
+
+def test_outfile_takes_precedence_and_is_not_closed(m, tmp_path):
+    m.pipe_file("source", DATA)
+    ignored = tmp_path / "ignored"
+    target = io.BytesIO()
+    m.get_file("source", ignored, outfile=target, start=5, end=15)
+    assert not ignored.exists()
+    assert target.getvalue() == DATA[5:15]
+    assert not target.closed
+    with pytest.raises(ValueError, match="filename"):
+        m.get_file("source", outfile=target, resume=True)
+
+
+def test_missing_remote_preserves_destination(m, tmp_path):
+    target = tmp_path / "download"
+    target.write_bytes(b"keep")
+    with pytest.raises(FileNotFoundError):
+        m.get_file("missing", target, resume=True)
+    assert target.read_bytes() == b"keep"
+
+
+def test_failed_transfer_can_resume_without_reading_the_prefix(
+    m, tmp_path, monkeypatch
+):
+    m.pipe_file("source", DATA)
+    m.blocksize = 3
+    target = tmp_path / "download"
+    reads = []
+
+    class Reader(io.BytesIO):
+        size = len(DATA)
+
+        def __init__(self, fail):
+            super().__init__(DATA)
+            self.fail = fail
+
+        def read(self, count=-1):
+            reads.append((self.tell(), count))
+            if self.fail and self.tell() >= 3:
+                raise OSError("interrupted")
+            return super().read(count)
+
+    monkeypatch.setattr(m, "open", lambda *args, **kwargs: Reader(fail=True))
+    with pytest.raises(OSError, match="interrupted"):
+        m.get_file("source", target, resume=True)
+    assert target.read_bytes() == DATA[:3]
+    reads.clear()
+    monkeypatch.setattr(m, "open", lambda *args, **kwargs: Reader(fail=False))
+    m.get_file("source", target, resume=True)
+    assert reads[0][0] == 3
+    assert target.read_bytes() == DATA
+
+
+def test_recursive_get_resumes_each_file_independently(m, tmp_path):
+    m.pipe_file("/source/a", DATA)
+    m.pipe_file("/source/nested/b", DATA[::-1])
+    m.makedirs("/source/empty")
+    target = tmp_path / "result"
+    target.mkdir()
+    (target / "a").write_bytes(DATA[:5])
+    m.get("/source/", str(target), recursive=True, resume=True)
+    assert (target / "a").read_bytes() == DATA
+    assert (target / "nested/b").read_bytes() == DATA[::-1]
+    assert (target / "empty").is_dir()
+
+
+@pytest.mark.parametrize("hardlink", [False, True])
+def test_local_source_and_destination_cannot_be_the_same(tmp_path, hardlink):
+    source = tmp_path / "source"
+    source.write_bytes(DATA)
+    target = tmp_path / "target" if hardlink else source
+    if hardlink:
+        os.link(source, target)
+    with pytest.raises(shutil.SameFileError):
+        LocalFileSystem().get_file(source, target, start=3, end=9)
+    assert source.read_bytes() == DATA
+
+
+@pytest.mark.parametrize("encoded", [False, True])
+@pytest.mark.parametrize("resume", [False, True])
+@pytest.mark.asyncio
+async def test_native_async_reference_download(tmp_path, encoded, resume):
+    value = b"base64:" + base64.b64encode(DATA) if encoded else DATA
+    fs = ReferenceFileSystem({"source": value})
+    target = tmp_path / "download"
+    callback = RecordingCallback()
+    if resume:
+        target.write_bytes(DATA[:5])
+        await fs._get_file("source", target, resume=True, end=-4, callback=callback)
+        expected = DATA[:-4]
+    else:
+        await fs._get_file("source", target, start=-20, end=-4, callback=callback)
+        expected = DATA[-20:-4]
+    assert target.read_bytes() == expected
+    assert callback.size == callback.value == len(expected)
+
+
+@pytest.mark.asyncio
+async def test_native_async_reference_filelike_target():
+    fs = ReferenceFileSystem({"source": DATA})
+    target = io.BytesIO()
+    await fs._get_file("source", target, start=3, end=8)
+    assert target.getvalue() == DATA[3:8]
+    assert not target.closed
+
+
+def test_destination_change_while_preparing_resume_is_rejected(tmp_path):
+    from fsspec._download import _Download
+
+    target = tmp_path / "download"
+    target.write_bytes(DATA[:3])
+    download = _Download(target, resume=True)
+    download.set_size(len(DATA))
+    target.write_bytes(DATA[:5])
+    with pytest.raises(ValueError, match="changed"):
+        with download.open():
+            pytest.fail("A concurrently changed destination was accepted")
+    assert target.read_bytes() == DATA[:5]
+
+
+@pytest.mark.parametrize("return_none", [False, True])
+def test_short_writes_and_none_returning_writes(m, return_none):
+    class Writer(io.BytesIO):
+        def write(self, data):
+            if return_none:
+                super().write(data)
+                return None
+            return super().write(data[:2])
+
+    m.pipe_file("source", DATA)
+    target = Writer()
+    callback = RecordingCallback()
+    m.get_file("source", target, start=3, end=15, callback=callback)
+    assert target.getvalue() == DATA[3:15]
+    assert callback.value == callback.size == 12
+    assert not target.closed
+
+
+@pytest.mark.parametrize("written", [0, -1, 100])
+def test_invalid_write_result_raises_instead_of_looping(m, written):
+    class Writer(io.BytesIO):
+        def write(self, data):
+            return written
+
+    m.pipe_file("source", DATA)
+    target = Writer()
+    with pytest.raises(OSError, match="Destination"):
+        m.get_file("source", target, start=0, end=3)
+    assert not target.closed
+
+
+def test_unknown_size_negative_offsets_fail_clearly():
+    from fsspec._download import _Download
+
+    download = _Download(io.BytesIO(), start=-3)
+    with pytest.raises(ValueError, match="remote size"):
+        download.set_size(None)
+
+
+def test_reference_bulk_get_uses_range_and_resume_options(tmp_path):
+    fs = ReferenceFileSystem({"source/a": DATA, "source/b": DATA[::-1]})
+    target = tmp_path / "output"
+    target.mkdir()
+    (target / "a").write_bytes(DATA[:5])
+    fs.get("source/", str(target), recursive=True, resume=True)
+    assert (target / "a").read_bytes() == DATA
+    assert (target / "b").read_bytes() == DATA[::-1]
+    fs.get("source/a", str(target / "slice"), start=3, end=12)
+    assert (target / "slice").read_bytes() == DATA[3:12]
+
+
+@pytest.mark.parametrize("backend", ["ftp", "sftp"])
+def test_transfer_backends_delegate_ranges(backend, monkeypatch, tmp_path):
+    if backend == "ftp":
+        from fsspec.implementations.ftp import FTPFileSystem
+
+        cls = FTPFileSystem
+    else:
+        pytest.importorskip("paramiko")
+        from fsspec.implementations.sftp import SFTPFileSystem
+
+        cls = SFTPFileSystem
+    # Exercise the adapter's dispatch, without making a network connection.
+    fs = object.__new__(cls)
+    fs.ftp = io.BytesIO()
+    monkeypatch.setattr(fs, "isdir", lambda path: False)
+    monkeypatch.setattr(fs, "open", lambda *args, **kwargs: io.BytesIO(DATA))
+    target = tmp_path / "download"
+    fs.get_file("source", target, start=3, end=12)
+    assert target.read_bytes() == DATA[3:12]
+    target.write_bytes(DATA[:5])
+    fs.get_file("source", target, resume=True)
+    assert target.read_bytes() == DATA
+
+
+@pytest.mark.parametrize(
+    "options,seekable",
+    [
+        ({}, False),
+        ({"start": 0}, True),
+        ({"end": 8}, True),
+        ({"resume": True}, True),
+        ({"start": 3, "seekable": False}, False),
+    ],
+)
+def test_arrow_download_selects_seekable_streams(monkeypatch, options, seekable):
+    from fsspec.implementations.arrow import ArrowFSWrapper
+    from fsspec.spec import AbstractFileSystem
+
+    calls = []
+    monkeypatch.setattr(
+        AbstractFileSystem,
+        "get_file",
+        lambda self, rpath, lpath, **kwargs: calls.append(kwargs),
+    )
+    fs = object.__new__(ArrowFSWrapper)
+    fs.get_file("source", "target", **options)
+    assert calls == [{**options, "seekable": seekable}]
+
+
+@pytest.mark.parametrize(
+    "status,headers,match",
+    [
+        (416, {}, "Content-Range"),
+        (416, {"Content-Range": "bytes */64"}, "satisfiable"),
+        (206, {"Content-Range": "nonsense"}, "Content-Range"),
+        (206, {"Content-Range": "bytes 8-4/64"}, "bounds"),
+        (206, {"Content-Range": "bytes 3-64/64"}, "bounds"),
+        (206, {"Content-Range": "bytes 3-7/64"}, "end offset"),
+        (204, {}, "status"),
+    ],
+)
+def test_invalid_http_range_metadata(status, headers, match):
+    from fsspec._download import _Download
+
+    download = _Download(io.BytesIO(), start=3, end=12)
+    with pytest.raises(ValueError, match=match):
+        download.response(status, headers)
+
+
+def test_generic_nonseekable_stream_can_download_a_bounded_prefix(m, monkeypatch):
+    class Reader(io.BytesIO):
+        def seekable(self):
+            return False
+
+        def seek(self, *args):
+            raise io.UnsupportedOperation("seek")
+
+    m.pipe_file("source", DATA)
+    monkeypatch.setattr(m, "open", lambda *args, **kwargs: Reader(DATA))
+    target = io.BytesIO()
+    m.get_file("source", target, end=8)
+    assert target.getvalue() == DATA[:8]
+
+
+@pytest.mark.asyncio
+async def test_empty_async_reference_range_does_not_fetch_data(tmp_path, monkeypatch):
+    fs = ReferenceFileSystem({"source": DATA})
+
+    async def unexpected_fetch(*args, **kwargs):
+        pytest.fail("An empty range should not fetch any bytes")
+
+    monkeypatch.setattr(fs, "_cat_file", unexpected_fetch)
+    target = tmp_path / "download"
+    await fs._get_file("source", target, start=8, end=8)
+    assert target.read_bytes() == b""


### PR DESCRIPTION
Closes #1617.

Adds `resume=True` to `get_file` and `get` for local path destinations. The generic path opens an existing destination in append mode and seeks the remote file to the same offset. HTTP resumes with an internal range request, restarts safely if the server ignores it, and checks the remote size before accepting a completed local file. There is no public byte-range API.

Tests:
- 8 focused resume/get-file tests passed
- full suite: 1,917 passed, 70 skipped, 2 xfailed
- 52 existing GNU `stat -c` comparison cases fail on macOS with BSD `stat`
- Ruff check/format passed on all changed files
