### PR TITLE
reference: keep get destinations inside the target

### DIFF
--- a/fsspec/implementations/reference.py
+++ b/fsspec/implementations/reference.py
@@ -23,6 +23,7 @@ from fsspec.callbacks import DEFAULT_CALLBACK
 from fsspec.core import filesystem, open, split_protocol
 from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
 from fsspec.utils import (
+    check_contained,
     isfilelike,
     merge_offset_ranges,
     other_paths,
@@ -882,6 +883,11 @@ class ReferenceFileSystem(AsyncFileSystem):
         rpath = self.expand_path(rpath, recursive=recursive)
         fs = fsspec.filesystem("file", auto_mkdir=True)
         targets = other_paths(rpath, lpath)
+        if isinstance(lpath, str):
+            # The names came from the source listing; ".." in one of them
+            # would otherwise place the copy above the destination. When
+            # lpath is a list the caller named every destination itself.
+            check_contained(lpath, targets)
         if recursive:
             data = self.cat([r for r in rpath if not self.isdir(r)])
         else:

--- a/fsspec/implementations/tests/test_reference.py
+++ b/fsspec/implementations/tests/test_reference.py
@@ -442,6 +442,44 @@ def test_get_sync(tmpdir):
     assert (tmpdir / "c" / "d").read_binary() == b"123456"
 
 
+def test_get_does_not_write_above_destination(tmp_path):
+    # Reference keys come from the spec, so a key holding ".." must not
+    # place the copy above the destination the caller asked for.
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    outside = tmp_path / "escaped.txt"
+    outside.write_bytes(b"ORIGINAL")
+
+    refs = {
+        "version": 1,
+        "refs": {
+            "dataset/../escaped.txt": b"ATTACKER",
+            "dataset/normal.txt": b"ok",
+        },
+    }
+    fs = fsspec.filesystem("reference", fo=refs, skip_instance_cache=True)
+    with pytest.raises(ValueError, match="outside the destination"):
+        fs.get("dataset", str(dest) + "/", recursive=True)
+
+    assert outside.read_bytes() == b"ORIGINAL"
+    assert not (dest / "normal.txt").exists()
+
+
+def test_get_keeps_dotdot_inside_destination(tmp_path):
+    # ".." that resolves within the destination stays a legitimate name.
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    refs = {
+        "plain.txt": b"ok",
+        "a/b/../inner.txt": b"inner",
+    }
+    fs = fsspec.filesystem("reference", fo=refs, skip_instance_cache=True)
+    fs.get("", str(dest) + "/", recursive=True)
+
+    assert (dest / "plain.txt").read_bytes() == b"ok"
+    assert (dest / "a" / "inner.txt").read_bytes() == b"inner"
+
+
 def test_multi_fs_provided(m, tmpdir):
     localfs = LocalFileSystem()
 


### PR DESCRIPTION
## Summary

`ReferenceFileSystem.get()` allows reference keys containing `..` to write outside the caller-provided destination. This can overwrite local files when materializing an untrusted reference specification.

#2103 added containment checks to the standard sync and async `get()` paths, but `ReferenceFileSystem` overrides `get()` and writes its targets directly, so it bypasses those checks.

This change applies the existing `check_contained()` helper before any reference data is fetched or written.

## Tests

- Rejects targets that resolve outside the destination.
- Confirms an existing outside file is not overwritten.
- Preserves `..` paths that still resolve inside the destination.

Full ReferenceFS test module: 24 passed, 13 skipped.
