### PR TITLE
Close cached readers when exiting an open_files context

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,8 @@ Dev
 
 Fixes
 
+- Close cached readers when exiting an ``open_files`` context
+
 - Allow filesystem implementations to assign ``protocol`` per instance
 
 - Avoid mutating live ``BlockCache`` and ``BackgroundBlockCache`` instances

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -192,7 +192,11 @@ class OpenFiles(list):
     def __exit__(self, *args):
         fs = self.fs
         [s.__exit__(*args) for s in self]
-        if "r" not in self.mode:
+        if "r" in self.mode:
+            # open_many() returns files without populating the OpenFile objects.
+            for f in self.files:
+                f.close()
+        else:
             while True:
                 if hasattr(fs, "open_many"):
                     # check for concurrent cache upload

--- a/fsspec/implementations/tests/test_cached.py
+++ b/fsspec/implementations/tests/test_cached.py
@@ -955,6 +955,36 @@ def test_again(protocol):
 
 
 @pytest.mark.parametrize("protocol", ["simplecache", "filecache"])
+@pytest.mark.parametrize("raise_in_context", [False, True])
+def test_multi_cache_closes_readers(tmp_path, m, protocol, raise_in_context):
+    m.pipe({"/first": b"first", "/second": b"second"})
+    open_files = fsspec.open_files(
+        [f"{protocol}::memory:///{name}" for name in ["first", "second"]],
+        cache_storage=str(tmp_path),
+    )
+
+    # Re-entering the context should close both cold- and warm-cache readers.
+    for _ in range(2):
+        try:
+            with open_files as files:
+                assert [f.read() for f in files] == [b"first", b"second"]
+                assert all(not f.closed for f in files)
+                if raise_in_context:
+                    raise RuntimeError("consumer failed")
+        except RuntimeError as exc:
+            assert raise_in_context
+            assert str(exc) == "consumer failed"
+        else:
+            assert not raise_in_context
+        try:
+            assert all(f.closed for f in files)
+        finally:
+            # Also release the descriptors when this regression fails.
+            for f in files:
+                f.close()
+
+
+@pytest.mark.parametrize("protocol", ["simplecache", "filecache"])
 def test_multi_cache(protocol):
     with fsspec.open_files("memory://file*", "wb", num=2) as files:
         for f in files:


### PR DESCRIPTION
Exiting an `open_files` context leaves `simplecache` and `filecache` readers open because `open_many()` returns handles without populating the `OpenFile` wrappers. Close those handles on exit, including when the consumer raises an exception.

Regression coverage exercises both cache implementations, normal and exceptional exits, and cold and warm cache reads. The four regressions fail on the unchanged base and pass with the fix. Local validation: cached-filesystem and core suites **137 passed, 37 skipped**; Ruff lint/format and `git diff --check` passed. Remote backends and downstream suites were not run.

AI assistance was used for implementation and local verification.

Fixes #2130.
