### PR TITLE
Forward Arrow file flush and closed state to the stream

### DIFF
--- a/fsspec/implementations/arrow.py
+++ b/fsspec/implementations/arrow.py
@@ -230,6 +230,7 @@ class ArrowFSWrapper(AbstractFileSystem):
         "seek",
         "tell",
         "write",
+        "flush",
         "readable",
         "writable",
         "close",
@@ -249,6 +250,10 @@ class ArrowFile(io.IOBase):
 
     def __enter__(self):
         return self
+
+    @property
+    def closed(self):
+        return self.stream.closed
 
     @property
     def size(self):

--- a/fsspec/implementations/tests/test_arrow.py
+++ b/fsspec/implementations/tests/test_arrow.py
@@ -8,6 +8,41 @@ FileSystem = pyarrow_fs.FileSystem
 from fsspec.implementations.arrow import ArrowFSWrapper, HadoopFileSystem  # noqa: E402
 
 
+@pytest.mark.parametrize("mode", ["rb", "wb"])
+def test_arrow_file_closed_state_follows_stream(tmp_path, mode):
+    path = tmp_path / "data"
+    path.write_bytes(b"data")
+    fs = ArrowFSWrapper(pyarrow_fs.LocalFileSystem())
+    with fs.open(str(path), mode) as file:
+        assert not file.closed
+    assert file.stream.closed
+    assert file.closed
+
+
+def test_arrow_file_flushes_buffered_writes(tmp_path):
+    import pyarrow as pa
+
+    from fsspec.implementations.arrow import ArrowFile
+
+    path = tmp_path / "buffered"
+    fs = ArrowFSWrapper(pyarrow_fs.LocalFileSystem())
+    stream = pa.output_stream(str(path), buffer_size=1024)
+    with ArrowFile(fs, stream, str(path), "wb") as file:
+        file.write(b"checkpoint")
+        assert path.read_bytes() == b""
+        file.flush()
+        assert path.read_bytes() == b"checkpoint"
+
+
+def test_arrow_file_reports_external_stream_close(tmp_path):
+    path = tmp_path / "data"
+    path.write_bytes(b"data")
+    fs = ArrowFSWrapper(pyarrow_fs.LocalFileSystem())
+    with fs.open(str(path), "rb") as file:
+        file.stream.close()
+        assert file.closed
+
+
 @pytest.fixture(scope="function")
 def fs():
     fs, _ = FileSystem.from_uri("mock://")


### PR DESCRIPTION
`ArrowFile` delegates writes and close to its Arrow stream but inherits `IOBase`'s no-op flush and independent closed flag. Buffered writes remain buffered after `flush()`, and closed files report `closed=False`.

Delegate `flush` alongside the other stream methods, and report the stream's closed state. The regression uses a real buffered PyArrow output stream and covers context-managed readers/writers and external stream closure.

On the unchanged base: **4 failed, 43 passed** in the Arrow suite. With the fix, Arrow and core tests give **103 passed, 6 skipped** on Linux/Python 3.12/PyArrow 25.0.1. Ruff lint/format and `git diff --check` passed. No remote Arrow filesystem was used.

AI assistance was used for implementation and local verification.

Fixes #2133.
