### PR TITLE
Distinguish omitted and None defaults in FSMap.pop

### DIFF
--- a/fsspec/mapping.py
+++ b/fsspec/mapping.py
@@ -9,6 +9,7 @@ from functools import cached_property
 from fsspec.core import url_to_fs
 
 logger = logging.getLogger("fsspec.mapping")
+_MISSING = object()
 
 
 class FSMap(MutableMapping):
@@ -161,9 +162,14 @@ class FSMap(MutableMapping):
             raise KeyError(key) from exc
         return result
 
-    def pop(self, key, default=None):
+    def pop(self, key, default=_MISSING):
         """Pop data"""
-        result = self.__getitem__(key, default)
+        try:
+            result = self[key]
+        except KeyError:
+            if default is _MISSING:
+                raise
+            return default
         try:
             del self[key]
         except KeyError:

--- a/fsspec/tests/test_mapping.py
+++ b/fsspec/tests/test_mapping.py
@@ -239,3 +239,34 @@ def test_fsmap_dirfs():
     fs = m.dirfs
     assert isinstance(fs, fsspec.implementations.dirfs.DirFileSystem)
     assert fs.path == m.root
+
+
+@pytest.mark.parametrize("protocol", ["memory", "file"])
+@pytest.mark.parametrize("default", [None, False, 0, b"", []])
+def test_pop_missing_key_returns_explicit_default(tmp_path, protocol, default):
+    mapper = fsspec.get_mapper(
+        f"{protocol}://{tmp_path.as_posix()}/mapping", create=True
+    )
+
+    assert mapper.pop("missing", default) is default
+
+
+@pytest.mark.parametrize("protocol", ["memory", "file"])
+def test_pop_without_default_raises_for_missing_key(tmp_path, protocol):
+    mapper = fsspec.get_mapper(
+        f"{protocol}://{tmp_path.as_posix()}/mapping", create=True
+    )
+
+    with pytest.raises(KeyError, match="missing"):
+        mapper.pop("missing")
+
+
+@pytest.mark.parametrize("protocol", ["memory", "file"])
+def test_pop_existing_key_returns_and_removes_value(tmp_path, protocol):
+    mapper = fsspec.get_mapper(
+        f"{protocol}://{tmp_path.as_posix()}/mapping", create=True
+    )
+    mapper["key"] = b"value"
+
+    assert mapper.pop("key", None) == b"value"
+    assert "key" not in mapper


### PR DESCRIPTION
`FSMap.pop(key, None)` currently raises for missing keys because the implementation conflates an explicit `None` default with an omitted default. Use a sentinel and handle lookup failure in `pop`, matching `MutableMapping` semantics.

Tests exercise memory and local mappings, explicit `None` and other falsy defaults, missing keys without a default, and retrieval/removal of existing values. The two `None` cases fail on the unchanged base. With the fix, mapping and adjacent local/memory/DirFS suites give **379 passed, 16 skipped**. Ruff lint/format and `git diff --check` passed.

AI assistance was used for implementation and local verification.

Fixes #2135.
